### PR TITLE
Fix some bad handling of handles

### DIFF
--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -41,3 +41,6 @@ dotnet_diagnostic.CA1816.severity = silent
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = none
+
+# SA1310: Field names should not contain underscore
+dotnet_diagnostic.SA1310.severity = silent


### PR DESCRIPTION
This (sadly) disables `SafeHandle`-derived type generation till we have a better story.

Closes #27
