### PR TITLE
Tolerate leading/trailing whitespace in NativeMethods.txt

### DIFF
--- a/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
+++ b/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
@@ -122,6 +122,7 @@ namespace Microsoft.Windows.CsWin32
                     continue;
                 }
 
+                name = name.Trim();
                 var location = Location.Create(nativeMethodsTxtFile.Path, line.Span, nativeMethodsTxt.Lines.GetLinePositionSpan(line.Span));
                 if (Generator.BannedAPIs.TryGetValue(name, out string? reason))
                 {

--- a/test/GenerationSandbox.Tests/NativeMethods.txt
+++ b/test/GenerationSandbox.Tests/NativeMethods.txt
@@ -1,4 +1,4 @@
-﻿GetTickCount
+﻿GetTickCount 
 IEnumDebugPropertyInfo
 CreateFile
 DISPLAYCONFIG_VIDEO_SIGNAL_INFO


### PR DESCRIPTION
Prior to this, a trailing space on a line in `NativeMethods.txt` would block generation of that API.