### PR TITLE
Generated files now have a '.g.cs' extension

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -579,7 +579,8 @@ namespace Microsoft.Windows.CsWin32
         {
             var starterNamespace = NamespaceDeclaration(ParseName(this.Namespace));
 
-            const string FilenamePattern = "{0}.cs";
+            // .g.cs because the resulting files are not user-created.
+            const string FilenamePattern = "{0}.g.cs";
             var results = new Dictionary<string, NamespaceDeclarationSyntax>(StringComparer.OrdinalIgnoreCase);
 
             if (this.options.EmitSingleFile)


### PR DESCRIPTION
A 2-character long PR: I simply modified the filename pattern so that generated files end in `.g.cs` and not simply in `.cs`. This is useful when integrating with 3rd-party code analysis tools. This way, one can easily exclude generated files from such analyses.