### PR TITLE
Added comment parsing check for  NativeMethods.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Create a `NativeMethods.txt` file in your project directory that lists the APIs 
 Each line may consist of *one* of the following:
 
 * Exported method name (e.g. `CreateFile`). This *may* include the `A` or `W` suffix, where applicable.
-* Module name followed by `.*` to generate all methods exported from that module (e.g. `Kernel32.*`)
+* Module name followed by `.*` to generate all methods exported from that module (e.g. `Kernel32.*`).
 * The name of a struct, enum, constant or interface to generate.
+* A comment (i.e. any line starting with `//`) or white space line, which will be ignored.
 
 When generating any type or member, all supporting types will also be generated.
 

--- a/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
+++ b/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Windows.CsWin32
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
                 string name = line.ToString();
-                if (string.IsNullOrWhiteSpace(name))
+                if (string.IsNullOrWhiteSpace(name) || name.StartsWith("//", StringComparison.InvariantCulture))
                 {
                     continue;
                 }


### PR DESCRIPTION
Lines starting with "//" will be ignored when parsing NativeMethods.txt
to allow more expressive configuration files.

I've also documented the option for comments in the readme file.

This is a potential (simplistic) solution to #65.