### PR TITLE
Make docs links locale agnostic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ You should install the version specified in `global.json` or a later version wit
 the same major.minor.Bxx "hundreds" band.
 For example if 2.2.300 is specified, you may install 2.2.300, 2.2.301, or 2.2.310
 while the 2.2.400 version would not be considered compatible by .NET SDK.
-See [.NET Core Versioning](https://docs.microsoft.com/en-us/dotnet/core/versions/) for more information.
+See [.NET Core Versioning](https://docs.microsoft.com/dotnet/core/versions/) for more information.
 
 ## Package restore
 
@@ -39,4 +39,4 @@ This repository can be built on Windows, Linux, and OSX.
 
 Building, testing, and packing this repository can be done by using the standard dotnet CLI commands (e.g. `dotnet build`, `dotnet test`, `dotnet pack`, etc.).
 
-[pwsh]: https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-6
+[pwsh]: https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-6

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
 
 ## Reporting Security Issues
 
@@ -14,7 +14,7 @@ Instead, please report them to the Microsoft Security Response Center (MSRC) at 
 
 If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Windows.CsWin32
 
         internal static readonly Dictionary<string, string> BannedAPIs = new Dictionary<string, string>
         {
-            { "GetLastError", "Do not generate GetLastError. Call Marshal.GetLastWin32Error() instead. Learn more from https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.getlastwin32error" },
+            { "GetLastError", "Do not generate GetLastError. Call Marshal.GetLastWin32Error() instead. Learn more from https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getlastwin32error" },
         };
 
         private const string SystemRuntimeCompilerServices = "System.Runtime.CompilerServices";

--- a/src/ScrapeDocs/Program.cs
+++ b/src/ScrapeDocs/Program.cs
@@ -110,9 +110,6 @@ namespace ScrapeDocs
 
         private (string ApiName, YamlNode YamlNode)? ParseDocFile(string filePath)
         {
-            string presumedMethodName = FileNamePattern.Match(Path.GetFileNameWithoutExtension(filePath)).Groups[1].Value;
-            Uri helpLink = new Uri("https://docs.microsoft.com/en-us/windows/win32/api/" + filePath.Substring(this.contentBasePath.Length, filePath.Length - 3 - this.contentBasePath.Length).Replace('\\', '/'));
-
             var yaml = new YamlStream();
             using StreamReader mdFileReader = File.OpenText(filePath);
             using var markdownToYamlReader = new YamlSectionReader(mdFileReader);
@@ -159,6 +156,8 @@ namespace ScrapeDocs
                 return match is object;
             }
 
+            string presumedMethodName = FileNamePattern.Match(Path.GetFileNameWithoutExtension(filePath)).Groups[1].Value;
+
             // Some structures have filenames that include the W or A suffix when the content doesn't. So try some fuzzy matching.
             if (!TryGetProperName(presumedMethodName, null, out string? properName) &&
                 !TryGetProperName(presumedMethodName, 'a', out properName) &&
@@ -169,6 +168,7 @@ namespace ScrapeDocs
             }
 
             var methodNode = new YamlMappingNode();
+            Uri helpLink = new Uri("https://docs.microsoft.com/windows/win32/api/" + filePath.Substring(this.contentBasePath.Length, filePath.Length - 3 - this.contentBasePath.Length).Replace('\\', '/'));
             methodNode.Add("HelpLink", helpLink.AbsoluteUri);
 
             var description = ((YamlMappingNode)yaml.Documents[0].RootNode).Children.FirstOrDefault(n => n.Key is YamlScalarNode { Value: "description" }).Value as YamlScalarNode;


### PR DESCRIPTION
I know we have a docs guideline to not use locale-specific hyperlinks, but I can't find it. @gewarren would have a link to that guideline somewhere handy?