### PR TITLE
Arrange for msbuild import to apply to pre-net40 projects

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
@@ -4,14 +4,13 @@
     <IsPackable>true</IsPackable>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <Description>Microsoft Windows SDK Win32 API Source Generator</Description>
 
     <!-- Special properties for analyzer packages. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <NoWarn>$(NoWarn);NU5128</NoWarn>
-    <DevelopmentDependency>true</DevelopmentDependency>
+    <NoWarn>$(NoWarn);NU5128;NU5127</NoWarn>
+    <NuSpecFile>Microsoft.Windows.CsWin32.nuspec</NuSpecFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.nuspec
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.nuspec
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Windows.CsWin32</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <developmentDependency>true</developmentDependency>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/Microsoft/CsWin32</projectUrl>
+    <description>Microsoft Windows SDK Win32 API Source Generator</description>
+    <releaseNotes>$PackageReleaseNotes$</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <repository type="git" url="https://github.com/microsoft/CsWin32.git" commit="$commit$" />
+    <dependencies>
+      <group targetFramework="net20">
+        <dependency id="Microsoft.Windows.SDK.Win32Metadata" version="$MetadataVersion$" include="All" />
+      </group>
+      <group targetFramework="net45">
+        <dependency id="Microsoft.Windows.SDK.Win32Metadata" version="$MetadataVersion$" include="All" />
+        <dependency id="System.Memory" version="4.5.4" include="All" />
+      </group>
+      <group targetFramework=".NETStandard1.1">
+        <dependency id="Microsoft.Windows.SDK.Win32Metadata" version="$MetadataVersion$" include="All" />
+        <dependency id="System.Memory" version="4.5.4" include="All" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="$BaseOutputPath$Microsoft.Windows.CsWin32.dll" target="analyzers\cs\Microsoft.Windows.CsWin32.dll" />
+    <file src="$BaseOutputPath$YamlDotNet.dll" target="analyzers\cs\YamlDotNet.dll" />
+    <file src="$BaseOutputPath$Microsoft.Bcl.AsyncInterfaces.dll" target="analyzers\cs\Microsoft.Bcl.AsyncInterfaces.dll" />
+    <file src="$BaseOutputPath$System.Text.Json.dll" target="analyzers\cs\System.Text.Json.dll" />
+    <file src="$BaseOutputPath$System.Text.Encodings.Web.dll" target="analyzers\cs\System.Text.Encodings.Web.dll" />
+    <file src="readme.txt" target="readme.txt" />
+    <file src="build\**" target="build\" />
+  </files>
+</package>

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.targets
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.targets
@@ -14,6 +14,12 @@
           StandardOutputImportance="high"/>
   </Target>
 
+  <Target Name="SetNuSpecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
+    <PropertyGroup>
+      <NuspecProperties>$(NuspecProperties);Version=$(Version);BaseOutputPath=$(OutputPath);MetadataVersion=$(MetadataVersion);PackageReleaseNotes=$(PackageReleaseNotes);commit=$(GitCommitId);</NuspecProperties>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="PackBuildOutputs" DependsOnTargets="ResolveProjectReferences;SatelliteDllsProjectOutputGroup;SatelliteDllsProjectOutputGroupDependencies">
     <ItemGroup>
       <!-- Analysis of C# projects -->

--- a/src/Microsoft.Windows.CsWin32/build/net20/Microsoft.Windows.CsWin32.props
+++ b/src/Microsoft.Windows.CsWin32/build/net20/Microsoft.Windows.CsWin32.props
@@ -1,0 +1,3 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\$(MSBuildThisFileName)$(MSBuildThisFileExtension)" />
+</Project>

--- a/src/Microsoft.Windows.CsWin32/build/netstandard1.0/Microsoft.Windows.CsWin32.props
+++ b/src/Microsoft.Windows.CsWin32/build/netstandard1.0/Microsoft.Windows.CsWin32.props
@@ -1,0 +1,3 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\$(MSBuildThisFileName)$(MSBuildThisFileExtension)" />
+</Project>


### PR DESCRIPTION
Fixes #68, when combined with https://github.com/microsoft/win32metadata/pull/194