### PR TITLE
Suppress SafeHandle generation when a referencing project already declares it

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -844,6 +844,11 @@ namespace Microsoft.Windows.CsWin32
                 return safeHandleType;
             }
 
+            if (this.FindSymbolIfAlreadyAvailable($"{this.Namespace}.{safeHandleType}") is object)
+            {
+                return safeHandleType;
+            }
+
             this.GenerateExternMethod(releaseMethodHandle);
 
             TypeSyntax releaseMethodReturnType = this.GetReturnTypeCustomAttributes(releaseMethodDef) is { } atts


### PR DESCRIPTION
Fixes #93