### PR TITLE
Prefer `bool` over `BOOL` in method signatures

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Windows.CsWin32
         {
             { nameof(System.Runtime.InteropServices.ComTypes.FILETIME), ParseTypeName("System.Runtime.InteropServices.ComTypes.FILETIME") },
             { nameof(Guid), ParseTypeName("System.Guid") },
+            { "BOOL", PredefinedType(Token(SyntaxKind.BoolKeyword)) },
             { "OLD_LARGE_INTEGER", PredefinedType(Token(SyntaxKind.LongKeyword)) },
             { "LARGE_INTEGER", PredefinedType(Token(SyntaxKind.LongKeyword)) },
             { "ULARGE_INTEGER", PredefinedType(Token(SyntaxKind.ULongKeyword)) },

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -167,6 +167,18 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
     }
 
     [Fact]
+    public void BOOL_ReturnTypeBecomes_Boolean()
+    {
+        this.generator = new Generator(this.metadataStream, compilation: this.compilation, parseOptions: this.parseOptions);
+        Assert.True(this.generator.TryGenerate("WinUsb_FlushPipe", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+        MethodDeclarationSyntax? createFileMethod = this.FindGeneratedMethod("WinUsb_FlushPipe");
+        Assert.NotNull(createFileMethod);
+        Assert.Equal(SyntaxKind.BoolKeyword, Assert.IsType<PredefinedTypeSyntax>(createFileMethod!.ReturnType).Keyword.Kind());
+    }
+
+    [Fact]
     public void BSTR_FieldsDoNotBecomeSafeHandles()
     {
         this.generator = new Generator(this.metadataStream, compilation: this.compilation, parseOptions: this.parseOptions);


### PR DESCRIPTION
Closes #63