### PR TITLE
Make SafeHandle parameters accept null

### DIFF
--- a/src/Microsoft.Windows.CsWin32/SignatureTypeProvider.cs
+++ b/src/Microsoft.Windows.CsWin32/SignatureTypeProvider.cs
@@ -103,12 +103,6 @@ namespace Microsoft.Windows.CsWin32
             TypeDefinitionHandle? typeDefHandle = this.owner.GenerateInteropType(handle);
             if (typeDefHandle.HasValue)
             {
-                if (this.preferMarshaledTypes && this.owner.TryGetHandleReleaseMethod(name, out string? releaseMethod) && this.owner.GenerateSafeHandle(releaseMethod) is TypeSyntax safeHandleType)
-                {
-                    // Return the safe handle instead.
-                    return safeHandleType;
-                }
-
                 TypeSyntax identifier = IdentifierName(name);
                 TypeDefinition td = reader.GetTypeDefinition(typeDefHandle.Value);
                 if ((td.Attributes & TypeAttributes.Interface) == TypeAttributes.Interface)

--- a/test/GenerationSandbox.Tests/BasicTests.cs
+++ b/test/GenerationSandbox.Tests/BasicTests.cs
@@ -128,7 +128,7 @@ public class BasicTests
             lpSecurityAttributes: null,
             FILE_CREATE_FLAGS.CREATE_NEW,
             FILE_FLAGS_AND_ATTRIBUTES.FILE_ATTRIBUTE_TEMPORARY | (FILE_FLAGS_AND_ATTRIBUTES)FILE_FLAG_DELETE_ON_CLOSE,
-            hTemplateFile: NullSafeHandle.NullHandle);
+            hTemplateFile: null);
         Assert.True(File.Exists(path));
         fileHandle.Dispose();
         Assert.False(File.Exists(path));


### PR DESCRIPTION
This also:
* adds support for SafeHandles that are 32-bits long even in 64-bit processes (e.g. `MSIHANDLE`).
* removes `SafeHandle` from all `extern` methods. They only appear on helper methods now.
* removes the `NullSafeHandle` static class.

Closes #129