### PR TITLE
Remove AsSpan from inline array struct

### DIFF
--- a/test/GenerationSandbox.Tests/BasicTests.cs
+++ b/test/GenerationSandbox.Tests/BasicTests.cs
@@ -171,12 +171,6 @@ public class BasicTests
     {
         MainAVIHeader header = default;
 
-#if NETCOREAPP
-        header.dwReserved.AsSpan()[1] = 3;
-        Assert.Equal(3u, header.dwReserved.AsSpan()[1]);
-        Assert.Equal(3u, header.dwReserved._1);
-#endif
-
         header.dwReserved.ItemRef(2) = 4;
         Assert.Equal(4u, header.dwReserved.ReadOnlyItemRef(2));
         Assert.Equal(4u, header.dwReserved._2);

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -446,8 +446,6 @@ namespace Microsoft.Windows.Sdk
         internal struct __dwReserved_4
         {
             internal uint _0, _1, _2, _3;
-            internal ref uint this[int index] => ref AsSpan()[index];
-            internal Span<uint> AsSpan() => MemoryMarshal.CreateSpan(ref _0, 4);
         }
     }
 ";


### PR DESCRIPTION
This was vulnerable to accessing memory after the stack it belonged to was destroyed:

```cs
var x = new __dwReserved_4();
return ref x[0];
```

If C# 10 gets https://github.com/dotnet/csharplang/blob/master/proposals/low-level-struct-improvements.md, then we can annotate it as ThisRefEscapes and it becomes safe.
