### PR TITLE
 Update metadata to 10.0.19041.5-preview.101

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <MetadataVersion>10.0.19041.5-preview.75</MetadataVersion>
+    <MetadataVersion>10.0.19041.5-preview.90</MetadataVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <MetadataVersion>10.0.19041.5-preview.90</MetadataVersion>
+    <MetadataVersion>10.0.19041.5-preview.101</MetadataVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the metadata package.

There may be more changes needed however.

See https://github.com/microsoft/win32metadata/releases/tag/v10.0.19041.5-preview.101 for the release notes to the update.