### PR TITLE
Add `[SupportedOSPlatform]` to friendly overloads

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -3683,7 +3683,6 @@ namespace Microsoft.Windows.CsWin32
                     .WithModifiers(modifiers)
                     .WithAttributeLists(List<AttributeListSyntax>())
                     .WithParameterList(ParameterList().AddParameters(parameters.ToArray()))
-                    .WithLeadingTrivia(leadingTrivia)
                     .WithBody(body)
                     .WithSemicolonToken(default);
 
@@ -3691,6 +3690,14 @@ namespace Microsoft.Windows.CsWin32
                 {
                     friendlyDeclaration = friendlyDeclaration.WithReturnType(returnSafeHandleType);
                 }
+
+                if (this.GetSupportedOSPlatformAttribute(methodDefinition.GetCustomAttributes()) is AttributeSyntax supportedOSPlatformAttribute)
+                {
+                    friendlyDeclaration = friendlyDeclaration.AddAttributeLists(AttributeList().AddAttributes(supportedOSPlatformAttribute));
+                }
+
+                friendlyDeclaration = friendlyDeclaration
+                    .WithLeadingTrivia(leadingTrivia);
 
                 yield return friendlyDeclaration;
             }

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -108,6 +108,18 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
         }
     }
 
+    [Fact]
+    public void SupportedOSPlatform_AppearsOnFriendlyOverloads()
+    {
+        const string methodName = "GetStagedPackagePathByFullName2";
+        this.compilation = this.starterCompilations["net5.0"];
+        this.generator = new Generator(this.metadataStream, DefaultTestGeneratorOptions, this.compilation, this.parseOptions);
+        Assert.True(this.generator.TryGenerate(methodName, CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+        Assert.All(this.FindGeneratedMethod(methodName), method => Assert.Contains(method.AttributeLists, al => IsAttributePresent(al, "SupportedOSPlatform")));
+    }
+
     [Theory, PairwiseData]
     public void COMInterfaceWithSupportedOSPlatform(bool net50, bool allowMarshaling)
     {


### PR DESCRIPTION
Fixes #229
