### PR TITLE
Metadata update to 10.0.19041.202-preview

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <MetadataVersion>10.0.19041.5-preview.122</MetadataVersion>
+    <MetadataVersion>10.0.19041.202-preview</MetadataVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -1165,7 +1165,7 @@ namespace Microsoft.Windows.CsWin32
                 return;
             }
 
-            FieldDeclarationSyntax constantDeclaration = this.DeclareField(fieldDefHandle);
+            FieldDeclarationSyntax constantDeclaration = this.DeclareConstant(fieldDefHandle);
             constantDeclaration = AddApiDocumentation(constantDeclaration.Declaration.Variables[0].Identifier.ValueText, constantDeclaration);
             this.fieldsToSyntax.Add(fieldDefHandle, constantDeclaration);
         }
@@ -2516,13 +2516,14 @@ namespace Microsoft.Windows.CsWin32
             }
         }
 
-        private FieldDeclarationSyntax DeclareField(FieldDefinitionHandle fieldDefHandle)
+        private FieldDeclarationSyntax DeclareConstant(FieldDefinitionHandle fieldDefHandle)
         {
             FieldDefinition fieldDef = this.mr.GetFieldDefinition(fieldDefHandle);
             string name = this.mr.GetString(fieldDef.Name);
             try
             {
-                TypeHandleInfo fieldTypeInfo = fieldDef.DecodeSignature(SignatureHandleProvider.Instance, null);
+                bool isConst = (fieldDef.Attributes & FieldAttributes.HasDefault) == FieldAttributes.HasDefault;
+                TypeHandleInfo fieldTypeInfo = fieldDef.DecodeSignature(SignatureHandleProvider.Instance, null) with { IsConstantField = true };
                 var customAttributes = fieldDef.GetCustomAttributes();
                 var fieldType = fieldTypeInfo.ToTypeSyntax(this.fieldTypeSettings, customAttributes);
                 ExpressionSyntax value =

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -1091,8 +1091,18 @@ namespace Microsoft.Windows.CsWin32
 
         internal bool IsInterface(HandleTypeHandleInfo typeInfo)
         {
-            return typeInfo.Handle.Kind == HandleKind.TypeDefinition
-                && (this.mr.GetTypeDefinition((TypeDefinitionHandle)typeInfo.Handle).Attributes & TypeAttributes.Interface) == TypeAttributes.Interface;
+            TypeDefinitionHandle tdh = default;
+            if (typeInfo.Handle.Kind == HandleKind.TypeReference)
+            {
+                var trh = (TypeReferenceHandle)typeInfo.Handle;
+                this.TryGetTypeDefHandle(trh, out tdh);
+            }
+            else if (typeInfo.Handle.Kind == HandleKind.TypeDefinition)
+            {
+                tdh = (TypeDefinitionHandle)typeInfo.Handle;
+            }
+
+            return !tdh.IsNil && (this.mr.GetTypeDefinition(tdh).Attributes & TypeAttributes.Interface) == TypeAttributes.Interface;
         }
 
         internal bool IsInterface(TypeHandleInfo handleInfo)

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -3657,8 +3657,8 @@ namespace Microsoft.Windows.CsWin32
                         {
                             var args = att.DecodeValue(CustomAttributeTypeProvider.Instance);
                             isArray = true;
-                            sizeParamIndex = (short?)args.NamedArguments.FirstOrDefault(a => a.Name == "SizeParamIndex").Value;
-                            sizeConst = (int?)args.NamedArguments.FirstOrDefault(a => a.Name == "SizeConst").Value;
+                            sizeParamIndex = (short?)args.NamedArguments.FirstOrDefault(a => a.Name == "CountParamIndex").Value;
+                            sizeConst = (int?)args.NamedArguments.FirstOrDefault(a => a.Name == "CountConst").Value;
 
                             break;
                         }

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -3028,6 +3028,7 @@ namespace Microsoft.Windows.CsWin32
                 throw new NotSupportedException("No COM interface base type found."));
 
             var members = new List<MemberDeclarationSyntax>();
+            var friendlyOverloads = new List<MethodDeclarationSyntax>();
 
             foreach (MethodDefinitionHandle methodDefHandle in allMethods)
             {
@@ -3094,7 +3095,7 @@ namespace Microsoft.Windows.CsWin32
                     members.Add(methodDeclaration);
 
                     NameSyntax declaringTypeName = HandleTypeHandleInfo.GetNestingQualifiedName(this.mr, typeDef);
-                    this.comInterfaceFriendlyExtensionsMembers.AddRange(
+                    friendlyOverloads.AddRange(
                         this.DeclareFriendlyOverloads(methodDefinition, methodDeclaration, declaringTypeName, FriendlyOverloadOf.InterfaceMethod));
                 }
                 catch (Exception ex)
@@ -3122,6 +3123,10 @@ namespace Microsoft.Windows.CsWin32
             {
                 ifaceDeclaration = ifaceDeclaration.AddAttributeLists(AttributeList().AddAttributes(supportedOSPlatformAttribute));
             }
+
+            // Only add overloads to instance collections after everything else is done,
+            // so we don't leave extension methods behind if we fail to generate the target interface.
+            this.comInterfaceFriendlyExtensionsMembers.AddRange(friendlyOverloads);
 
             return ifaceDeclaration;
         }

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -2410,7 +2410,7 @@ namespace Microsoft.Windows.CsWin32
                     var requiredPlatform = (InteropArchitecture)(int)att.DecodeValue(CustomAttributeTypeProvider.Instance).FixedArguments[0].Value!;
                     return this.compilation.Options.Platform switch
                     {
-                        Platform.AnyCpu => requiredPlatform == InteropArchitecture.All,
+                        Platform.AnyCpu or Platform.AnyCpu32BitPreferred => requiredPlatform == InteropArchitecture.All,
                         Platform.Arm64 => (requiredPlatform & InteropArchitecture.Arm64) == InteropArchitecture.Arm64,
                         Platform.X86 => (requiredPlatform & InteropArchitecture.X86) == InteropArchitecture.X86,
                         Platform.X64 => (requiredPlatform & InteropArchitecture.X64) == InteropArchitecture.X64,

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -3012,7 +3012,7 @@ namespace Microsoft.Windows.CsWin32
                     else
                     {
                         this.RequestInteropType(baseTypeHandle);
-                        baseTypeSyntaxList.Add(SimpleBaseType(new HandleTypeHandleInfo(this.mr, baseTypeHandle).ToTypeSyntax(this.generalTypeSettings, null).Type));
+                        baseTypeSyntaxList.Add(SimpleBaseType(new HandleTypeHandleInfo(this.mr, baseTypeHandle).ToTypeSyntax(this.comSignatureTypeSettings, null).Type));
                         allMethods.AddRange(baseType.GetMethods());
                     }
                 }

--- a/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
+++ b/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Windows.CsWin32
         /// <summary>
         /// Gets the namespace for generated code.
         /// </summary>
-        /// <value>The default value is "Microsoft.Windows.Sdk". Must be non-empty.</value>
-        public string Namespace { get; init; } = "Microsoft.Windows.Sdk";
+        /// <value>The default value is "Windows.Win32". Must be non-empty.</value>
+        public string Namespace { get; init; } = "Windows.Win32";
 
         /// <summary>
         /// Gets a value indicating whether to emit a single source file as opposed to types spread across many files.

--- a/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Windows.CsWin32
                 return new TypeSyntaxAndMarshaling(bclType);
             }
 
-            if (simpleName is "PWSTR" or "PSTR" && customAttributes?.Any(ah => Generator.IsAttribute(this.reader, this.reader.GetCustomAttribute(ah), Generator.InteropDecorationNamespace, "ConstAttribute")) is true)
+            if (simpleName is "PWSTR" or "PSTR" && (this.IsConstantField || customAttributes?.Any(ah => Generator.IsAttribute(this.reader, this.reader.GetCustomAttribute(ah), Generator.InteropDecorationNamespace, "ConstAttribute")) is true))
             {
                 IdentifierNameSyntax constantTypeIdentifierName = IdentifierName("PC" + simpleName.Substring(1));
 

--- a/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
@@ -73,10 +73,16 @@ namespace Microsoft.Windows.CsWin32
 
             if (simpleName is "PWSTR" or "PSTR" && (this.IsConstantField || customAttributes?.Any(ah => Generator.IsAttribute(this.reader, this.reader.GetCustomAttribute(ah), Generator.InteropDecorationNamespace, "ConstAttribute")) is true))
             {
-                IdentifierNameSyntax constantTypeIdentifierName = IdentifierName("PC" + simpleName.Substring(1));
-
-                inputs.Generator?.RequestTypeDefStruct(constantTypeIdentifierName.Identifier.ValueText);
-                return new TypeSyntaxAndMarshaling(constantTypeIdentifierName);
+                string specialName = "PC" + simpleName.Substring(1);
+                if (inputs.Generator is object)
+                {
+                    inputs.Generator.RequestSpecialTypeDefStruct(specialName, out string fullyQualifiedName);
+                    return new TypeSyntaxAndMarshaling(ParseName(Generator.ReplaceCommonNamespaceWithAlias(fullyQualifiedName)));
+                }
+                else
+                {
+                    return new TypeSyntaxAndMarshaling(IdentifierName(specialName));
+                }
             }
             else if (TryMarshalAsObject(inputs, simpleName, out MarshalAsAttribute? marshalAs))
             {
@@ -125,12 +131,12 @@ namespace Microsoft.Windows.CsWin32
 
         private static NameSyntax GetNestingQualifiedName(MetadataReader reader, TypeDefinitionHandle handle) => GetNestingQualifiedName(reader, reader.GetTypeDefinition(handle));
 
-        private static NameSyntax GetNestingQualifiedName(MetadataReader reader, TypeDefinition td)
+        internal static NameSyntax GetNestingQualifiedName(MetadataReader reader, TypeDefinition td)
         {
             IdentifierNameSyntax name = IdentifierName(reader.GetString(td.Name));
             return td.GetDeclaringType() is { IsNil: false } nestingType
                 ? QualifiedName(GetNestingQualifiedName(reader, nestingType), name)
-                : name;
+                : QualifiedName(ParseName(Generator.ReplaceCommonNamespaceWithAlias(reader.GetString(td.Namespace))), name);
         }
 
         private static NameSyntax GetNestingQualifiedName(MetadataReader reader, TypeReferenceHandle handle) => GetNestingQualifiedName(reader, reader.GetTypeReference(handle));
@@ -140,7 +146,7 @@ namespace Microsoft.Windows.CsWin32
             SimpleNameSyntax typeName = IdentifierName(reader.GetString(tr.Name));
             return tr.ResolutionScope.Kind == HandleKind.TypeReference
                 ? QualifiedName(GetNestingQualifiedName(reader, (TypeReferenceHandle)tr.ResolutionScope), typeName)
-                : tr.ResolutionScope.Kind == HandleKind.ModuleDefinition ? typeName : QualifiedName(ParseName(Generator.GlobalNamespacePrefix + reader.GetString(tr.Namespace)), typeName);
+                : QualifiedName(ParseName(Generator.ReplaceCommonNamespaceWithAlias(reader.GetString(tr.Namespace))), typeName);
         }
 
         private bool IsDelegate(TypeSyntaxSettings inputs, out TypeDefinition delegateTypeDef)

--- a/src/Microsoft.Windows.CsWin32/PlatformIncompatibleException.cs
+++ b/src/Microsoft.Windows.CsWin32/PlatformIncompatibleException.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Windows.CsWin32
+{
+    using System;
+
+    /// <summary>
+    /// An exception thrown when code generation fails because the requested type or member is not available given the target CPU architecture.
+    /// </summary>
+    [Serializable]
+    public class PlatformIncompatibleException : GenerationFailedException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlatformIncompatibleException"/> class.
+        /// </summary>
+        public PlatformIncompatibleException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlatformIncompatibleException"/> class.
+        /// </summary>
+        /// <inheritdoc cref="Exception(string)" />
+        public PlatformIncompatibleException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlatformIncompatibleException"/> class.
+        /// </summary>
+        /// <inheritdoc cref="Exception(string, Exception)" />
+        public PlatformIncompatibleException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlatformIncompatibleException"/> class.
+        /// </summary>
+        /// <inheritdoc cref="Exception(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)" />
+        protected PlatformIncompatibleException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Windows.CsWin32/TypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/TypeHandleInfo.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Windows.CsWin32
     {
         private static readonly TypeSyntaxSettings DebuggerDisplaySettings = new TypeSyntaxSettings(null, PreferNativeInt: false, PreferMarshaledTypes: false, AllowMarshaling: false, QualifyNames: true);
 
+        internal bool IsConstantField { get; init; }
+
         internal abstract TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes = default);
 
         protected static bool TryGetSimpleName(TypeSyntax nameSyntax, [NotNullWhen(true)] out string? simpleName)

--- a/src/Microsoft.Windows.CsWin32/templates/marshaling/CoCreateInstance.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/marshaling/CoCreateInstance.cs
@@ -1,8 +1,8 @@
-﻿/// <inheritdoc cref="CoCreateInstance(Guid*, object, CLSCTX, Guid*, out object)"/>
-internal static unsafe HRESULT CoCreateInstance<T>(in Guid rclsid, object pUnkOuter, CLSCTX dwClsContext, out T ppv)
+﻿/// <inheritdoc cref="CoCreateInstance(Guid*, object, win32.System.Com.CLSCTX, Guid*, out object)"/>
+internal static unsafe win32.System.Com.HRESULT CoCreateInstance<T>(in Guid rclsid, object pUnkOuter, win32.System.Com.CLSCTX dwClsContext, out T ppv)
     where T : class
 {
-    HRESULT hr = CoCreateInstance(rclsid, pUnkOuter, dwClsContext, typeof(T).GUID, out object o);
+    win32.System.Com.HRESULT hr = CoCreateInstance(rclsid, pUnkOuter, dwClsContext, typeof(T).GUID, out object o);
     ppv = (T)o;
     return hr;
 }

--- a/src/Microsoft.Windows.CsWin32/templates/no_marshaling/CoCreateInstance.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/no_marshaling/CoCreateInstance.cs
@@ -1,8 +1,8 @@
-﻿/// <inheritdoc cref="CoCreateInstance(Guid*, IUnknown*, CLSCTX, Guid*, void**)"/>
-internal static unsafe HRESULT CoCreateInstance<T>(in Guid rclsid, IUnknown* pUnkOuter, CLSCTX dwClsContext, out T* ppv)
+﻿/// <inheritdoc cref="CoCreateInstance(Guid*, win32.System.Com.IUnknown*, win32.System.Com.CLSCTX, Guid*, void**)"/>
+internal static unsafe win32.System.Com.HRESULT CoCreateInstance<T>(in Guid rclsid, win32.System.Com.IUnknown* pUnkOuter, win32.System.Com.CLSCTX dwClsContext, out T* ppv)
     where T : unmanaged
 {
-    HRESULT hr = CoCreateInstance(rclsid, pUnkOuter, dwClsContext, typeof(T).GUID, out void* o);
+    win32.System.Com.HRESULT hr = CoCreateInstance(rclsid, pUnkOuter, dwClsContext, typeof(T).GUID, out void* o);
     ppv = (T*)o;
     return hr;
 }

--- a/test/GenerationSandbox.Tests/BasicTests.cs
+++ b/test/GenerationSandbox.Tests/BasicTests.cs
@@ -6,6 +6,13 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
 using Windows.Win32;
+using Windows.Win32.Graphics.DirectShow;
+using Windows.Win32.Storage.FileSystem;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.OleAutomation;
+using Windows.Win32.System.SystemServices;
+using Windows.Win32.UI.DisplayDevices;
+using Windows.Win32.UI.WindowsAndMessaging;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/GenerationSandbox.Tests/BasicTests.cs
+++ b/test/GenerationSandbox.Tests/BasicTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
-using Microsoft.Windows.Sdk;
+using Windows.Win32;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/GenerationSandbox.Tests/GeneratedForm.cs
+++ b/test/GenerationSandbox.Tests/GeneratedForm.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.Windows.Sdk;
+using Windows.Win32;
 
 #pragma warning disable CA1812 // dead code
 

--- a/test/GenerationSandbox.Tests/GeneratedForm.cs
+++ b/test/GenerationSandbox.Tests/GeneratedForm.cs
@@ -3,6 +3,9 @@
 
 using System;
 using Windows.Win32;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.Diagnostics.Debug;
+using Windows.Win32.UI.WindowsAndMessaging;
 
 #pragma warning disable CA1812 // dead code
 

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -677,9 +677,10 @@ namespace Microsoft.Windows.Sdk
     }
 
     [Theory, PairwiseData]
-    public void FullGeneration(bool allowMarshaling)
+    public void FullGeneration(bool allowMarshaling, [CombinatorialValues(Platform.AnyCpu, Platform.X86, Platform.X64, Platform.Arm64)] Platform platform)
     {
         var generatorOptions = new GeneratorOptions { AllowMarshaling = allowMarshaling };
+        this.compilation = this.compilation.WithOptions(this.compilation.Options.WithPlatform(platform));
         this.generator = new Generator(this.metadataStream, generatorOptions, this.compilation, this.parseOptions);
         this.generator.GenerateAll(CancellationToken.None);
         this.CollectGeneratedCode(this.generator);

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -492,11 +492,12 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
 
     [Theory, CombinatorialData]
     public void ArchitectureSpecificAPIsTreatment(
-        [CombinatorialValues("MEMORY_BASIC_INFORMATION", "SP_PROPCHANGE_PARAMS", "JsCreateContext")] string apiName,
-        [CombinatorialValues(Platform.AnyCpu, Platform.X64, Platform.X86)] Platform platform)
+        [CombinatorialValues("MEMORY_BASIC_INFORMATION", "SP_PROPCHANGE_PARAMS", "JsCreateContext", "IShellBrowser")] string apiName,
+        [CombinatorialValues(Platform.AnyCpu, Platform.X64, Platform.X86)] Platform platform,
+        bool allowMarshaling)
     {
         this.compilation = this.compilation.WithOptions(this.compilation.Options.WithPlatform(platform));
-        this.generator = new Generator(this.metadataStream, DefaultTestGeneratorOptions, this.compilation, this.parseOptions);
+        this.generator = new Generator(this.metadataStream, DefaultTestGeneratorOptions with { AllowMarshaling = allowMarshaling }, this.compilation, this.parseOptions);
         if (platform == Platform.AnyCpu)
         {
             // AnyCPU targets should throw an exception with a helpful error message when asked for arch-specific APIs

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -278,6 +278,14 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
     }
 
     [Fact]
+    public void AmbiguousApiName()
+    {
+        this.generator = new Generator(this.metadataStream, DefaultTestGeneratorOptions, this.compilation, this.parseOptions);
+        var ex = Assert.Throws<ArgumentException>(() => this.generator.TryGenerate("IDENTITY_TYPE", CancellationToken.None));
+        this.logger.WriteLine(ex.Message);
+    }
+
+    [Fact]
     public void ReleaseMethodGeneratedWithHandleStruct()
     {
         this.generator = new Generator(this.metadataStream, DefaultTestGeneratorOptions, this.compilation, this.parseOptions);

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -159,7 +159,6 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
             "MFVideoAlphaBitmap", // field named params
             "DDRAWI_DDVIDEOPORT_INT", // field that is never used
             "MainAVIHeader", // dwReserved field is a fixed length array
-            "JsRuntimeVersionEdge", // Constant typed as an enum
             "POSITIVE_INFINITY", // Special float imaginary number
             "NEGATIVE_INFINITY", // Special float imaginary number
             "NaN", // Special float imaginary number

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -200,6 +200,7 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
             "DS_SELECTION_LIST", // A struct with a fixed-length inline array of potentially managed structs
             "ISpellCheckerFactory", // COM interface that includes `ref` parameters
             "LocalSystemTimeToLocalFileTime", // small step
+            "WSAHtons", // A method that references SOCKET (which is typed as UIntPtr) so that a SafeHandle will be generated.
             "ID3D12Resource", // COM interface with base types
             "ID2D1RectangleGeometry")] // COM interface with base types
         string api,

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -201,6 +201,7 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
             "ISpellCheckerFactory", // COM interface that includes `ref` parameters
             "LocalSystemTimeToLocalFileTime", // small step
             "WSAHtons", // A method that references SOCKET (which is typed as UIntPtr) so that a SafeHandle will be generated.
+            "IDelayedPropertyStoreFactory", // interface inheritance across namespaces
             "ID3D12Resource", // COM interface with base types
             "ID2D1RectangleGeometry")] // COM interface with base types
         string api,

--- a/test/SpellChecker/Program.cs
+++ b/test/SpellChecker/Program.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Windows.Sdk;
-using static Microsoft.Windows.Sdk.Constants;
-using static Microsoft.Windows.Sdk.PInvoke;
+using Windows.Win32;
+using static Windows.Win32.Constants;
+using static Windows.Win32.PInvoke;
 
 unsafe
 {

--- a/test/SpellChecker/Program.cs
+++ b/test/SpellChecker/Program.cs
@@ -4,6 +4,9 @@
 using System;
 using System.Collections.Generic;
 using Windows.Win32;
+using Windows.Win32.Globalization;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.SystemServices;
 using static Windows.Win32.Constants;
 using static Windows.Win32.PInvoke;
 


### PR DESCRIPTION
* Update the metadata to 10.0.19041.202-preview
* Generate interop types into sub-namespaces. This avoids type name collisions from the metadata across namespaces and allows us to finally generate *all* APIs. Closes #31
* Discriminate code generation based on the compilation platform (i.e. CPU architecture). This gets the generation accurate for x64, x86, ARM64 where it would be different. It also _omits_ generation of anything that requires a specific platform when the platform is AnyCPU. Closes #264