### PR TITLE
Downgrade System.Text.Json version

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="Nullable" Version="1.3.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
     <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="$(MetadataVersion)" GeneratePathProperty="true" PrivateAssets="none" />
-    <PackageReference Include="System.Text.Json" Version="5.0.1" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="YamlDotNet" Version="11.1.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" PrivateAssets="none" />
   </ItemGroup>


### PR DESCRIPTION
This version ships with .NET Core 3.1 and therefore resolves one possible bug that shows up in [this condition][1].

[1]: https://github.com/dotnet/roslyn/issues/53672#issuecomment-860126237
