### PR TITLE
Include the period in the full-sentence link in XML docs

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -1891,7 +1891,7 @@ namespace Microsoft.Windows.CsWin32
                     else if (docs.HelpLink is object)
                     {
                         docCommentsBuilder.AppendLine();
-                        docCommentsBuilder.AppendLine($@"/// <para><see href=""{docs.HelpLink}"">Learn more about this API from docs.microsoft.com</see>.</para>");
+                        docCommentsBuilder.AppendLine($@"/// <para><see href=""{docs.HelpLink}"">Learn more about this API from docs.microsoft.com.</see></para>");
                         docCommentsBuilder.Append("/// ");
                     }
 


### PR DESCRIPTION
Fixes #279. This was a tough one.