### PR TITLE
Fix marshaling of NativeArrayInfo parameters

### DIFF
--- a/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Windows.CsWin32
                     // But this pointer represents an array, so type as an array.
                     return new TypeSyntaxAndMarshaling(
                         ArrayType(elementSyntax).AddRankSpecifiers(ArrayRankSpecifier()),
-                        marshalAs is object ? new MarshalAsAttribute(UnmanagedType.LPArray) { ArraySubType = marshalAs.Value } : null);
+                        marshalAs is object ? new MarshalAsAttribute(UnmanagedType.LPArray) { ArraySubType = marshalAs.Value } : new MarshalAsAttribute(UnmanagedType.LPArray));
                 }
                 else if (xIn || xOut)
                 {

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -342,6 +342,28 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
     }
 
     [Theory, PairwiseData]
+    public void NativeArray_OfManagedTypes_MarshaledAsLPArray(bool allowMarshaling)
+    {
+        const string ifaceName = "ID3D11DeviceContext";
+        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions with { AllowMarshaling = allowMarshaling });
+        Assert.True(this.generator.TryGenerate(ifaceName, CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+
+        var generatedMethod = this.FindGeneratedMethod("OMSetRenderTargets").Where(m => m.ParameterList.Parameters.Count == 3 && m.ParameterList.Parameters[0].Identifier.ValueText == "NumViews").FirstOrDefault();
+        Assert.NotNull(generatedMethod);
+
+        if (allowMarshaling)
+        {
+            Assert.Contains(generatedMethod!.ParameterList.Parameters[1].AttributeLists, al => IsAttributePresent(al, "MarshalAs"));
+        }
+        else
+        {
+            Assert.DoesNotContain(generatedMethod!.ParameterList.Parameters[1].AttributeLists, al => IsAttributePresent(al, "MarshalAs"));
+        }
+    }
+
+    [Theory, PairwiseData]
     public void NativeArray_SizeParamIndex_ProducesSimplerFriendlyOverload(bool allowMarshaling)
     {
         var options = DefaultTestGeneratorOptions with { AllowMarshaling = allowMarshaling };


### PR DESCRIPTION
Fixes #269 and many other problems with DirectX2D/11/12 etc.

When parameters with `NativeArrayInfo` are marshaled `MarshalAsAttribute` is sometimes missing.

https://github.com/microsoft/CsWin32/blob/main/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs#L32
In this case `marshalAs` variable corresponds to element type of the array.
When there is no need for setting specific `ArraySubType` the `MarshalAsAttribute` is dropped altogether.
It should be set to just `MarshalAs(UnmanagedType.LPArray)` without specifying `ArraySubType`.

https://github.com/microsoft/CsWin32/blob/main/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs#L57
There is exactly the same code in case of marshaling structs as array. Maybe that caused some confusion.
But in that case dropping `MarshalAs` is correct.


