### PR TITLE
Rollback MessagePack upgrade back to 2.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
   directory: /
   schedule:
     interval: monthly
+  ignore:
+  - dependency-name: MessagePack # We have to use the MessagePack version used by win32metadata (https://github.com/microsoft/CsWin32/issues/371)

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
@@ -42,7 +42,7 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.3.75" />
+    <PackageReference Include="MessagePack" Version="2.2.85" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="$(MetadataVersion)" GeneratePathProperty="true" PrivateAssets="none" />

--- a/test/Microsoft.Windows.CsWin32.Tests/Microsoft.Windows.CsWin32.Tests.csproj
+++ b/test/Microsoft.Windows.CsWin32.Tests/Microsoft.Windows.CsWin32.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="3.1.0" />
+    <PackageReference Include="MessagePack" Version="2.2.85" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1-beta1.21413.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />


### PR DESCRIPTION
Rolls back #348, and fixes a test failure due to messagepack.annotations.dll not deploying to the test directory. 

Fixes #371