### PR TITLE
Apply `[StructLayout(CharSet.Unicode)]` to structs that contain the `char` type

### DIFF
--- a/src/Microsoft.Windows.CsWin32/FastSyntaxFactory.cs
+++ b/src/Microsoft.Windows.CsWin32/FastSyntaxFactory.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Windows.CsWin32
 
         internal static AttributeArgumentListSyntax AttributeArgumentList(SeparatedSyntaxList<AttributeArgumentSyntax> arguments = default) => SyntaxFactory.AttributeArgumentList(Token(SyntaxKind.OpenParenToken), arguments, Token(SyntaxKind.CloseParenToken));
 
-        internal static AttributeListSyntax AttributeList() => SyntaxFactory.AttributeList(Token(SyntaxKind.OpenBracketToken), null, SeparatedList<AttributeSyntax>(), Token(SyntaxKind.CloseBracketToken));
+        internal static AttributeListSyntax AttributeList() => SyntaxFactory.AttributeList(Token(SyntaxKind.OpenBracketToken), null, SeparatedList<AttributeSyntax>(), TokenWithLineFeed(SyntaxKind.CloseBracketToken));
 
         internal static SyntaxList<TNode> List<TNode>()
             where TNode : SyntaxNode => SyntaxFactory.List<TNode>();

--- a/test/GenerationSandbox.Tests/BasicTests.cs
+++ b/test/GenerationSandbox.Tests/BasicTests.cs
@@ -10,6 +10,9 @@ using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.DirectShow;
 using Windows.Win32.Storage.FileSystem;
+using Windows.Win32.System.Console;
+using Windows.Win32.System.ErrorReporting;
+using Windows.Win32.System.SystemServices;
 using Windows.Win32.UI.DisplayDevices;
 using Xunit;
 using Xunit.Abstractions;
@@ -412,5 +415,18 @@ public class BasicTests
         var getTickCountPtr = (delegate*<uint>)pGetTickCount.Value;
         ticks = getTickCountPtr();
         Assert.NotEqual(0u, ticks);
+    }
+
+    [Fact]
+    public void StructCharFieldsMarshaledAsUtf16()
+    {
+        Assert.Equal(128 * sizeof(char), Marshal.SizeOf<WER_REPORT_INFORMATION.__char_128>());
+        Assert.Equal(sizeof(char), Marshal.SizeOf<KEY_EVENT_RECORD._uChar_e__Union>());
+    }
+
+    [Fact]
+    public void CHAR_MarshaledAsUtf8()
+    {
+        Assert.Equal(1, Marshal.SizeOf<CHAR>());
     }
 }

--- a/test/GenerationSandbox.Tests/NativeMethods.txt
+++ b/test/GenerationSandbox.Tests/NativeMethods.txt
@@ -1,4 +1,5 @@
 ﻿BOOL
+CHAR
 CreateFile
 DISPLAYCONFIG_VIDEO_SIGNAL_INFO
 EnumWindows
@@ -8,9 +9,11 @@ GetWindowText
 GetWindowTextLength
 HDC_UserSize
 IEnumDebugPropertyInfo
+KEY_EVENT_RECORD
 LoadLibrary
 MainAVIHeader
 NTSTATUS
 RM_PROCESS_INFO
+WER_REPORT_INFORMATION
 wglGetProcAddress
 WPARAM


### PR DESCRIPTION
Without this, the .NET marshaler will assume Ansi, which is the C# default.

Fixes #389