### PR TITLE
Allow customizing the name of the `Constants` class

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -116,7 +116,6 @@ namespace Microsoft.Windows.CsWin32
         private static readonly XmlTextSyntax DocCommentEnd = XmlText(XmlTextNewLine("\n", continueXmlDocumentationComment: false));
 
         private static readonly SyntaxToken SemicolonWithLineFeed = TokenWithLineFeed(SyntaxKind.SemicolonToken);
-        private static readonly IdentifierNameSyntax ConstantsClassName = IdentifierName("Constants");
         private static readonly IdentifierNameSyntax InlineArrayIndexerExtensionsClassName = IdentifierName("InlineArrayIndexerExtensions");
         private static readonly IdentifierNameSyntax ComInterfaceFriendlyExtensionsClassName = IdentifierName("FriendlyOverloadExtensions");
         private static readonly TypeSyntax SafeHandleTypeSyntax = IdentifierName("SafeHandle");
@@ -296,6 +295,7 @@ namespace Microsoft.Windows.CsWin32
         private readonly bool generateDefaultDllImportSearchPathsAttribute;
         private readonly GeneratedCode committedCode = new();
         private readonly GeneratedCode volatileCode;
+        private readonly IdentifierNameSyntax constantsClassName;
         private bool needsWinRTCustomMarshaler;
 
         /// <summary>
@@ -347,6 +347,8 @@ namespace Microsoft.Windows.CsWin32
             this.extensionMethodSignatureTypeSettings = this.generalTypeSettings with { QualifyNames = true };
             this.functionPointerTypeSettings = this.generalTypeSettings with { QualifyNames = true };
             this.errorMessageTypeSettings = this.generalTypeSettings with { QualifyNames = true };
+
+            this.constantsClassName = IdentifierName(options.ConstantsClassName);
         }
 
         private enum FriendlyOverloadOf
@@ -1506,12 +1508,12 @@ namespace Microsoft.Windows.CsWin32
                                 break;
                             case "NTSTATUS":
                                 this.TryGenerateConstantOrThrow("STATUS_SUCCESS");
-                                ExpressionSyntax statusSuccess = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, ConstantsClassName, IdentifierName("STATUS_SUCCESS"));
+                                ExpressionSyntax statusSuccess = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, this.constantsClassName, IdentifierName("STATUS_SUCCESS"));
                                 releaseInvocation = BinaryExpression(SyntaxKind.EqualsExpression, releaseInvocation, statusSuccess);
                                 break;
                             case "HRESULT":
                                 this.TryGenerateConstantOrThrow("S_OK");
-                                ExpressionSyntax ok = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, ConstantsClassName, IdentifierName("S_OK"));
+                                ExpressionSyntax ok = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, this.constantsClassName, IdentifierName("S_OK"));
                                 releaseInvocation = BinaryExpression(SyntaxKind.EqualsExpression, releaseInvocation, ok);
                                 break;
                             default:
@@ -2797,7 +2799,7 @@ namespace Microsoft.Windows.CsWin32
 
         private ClassDeclarationSyntax DeclareConstantDefiningClass()
         {
-            return ClassDeclaration(ConstantsClassName.Identifier)
+            return ClassDeclaration(this.constantsClassName.Identifier)
                 .AddMembers(this.committedCode.Fields.ToArray())
                 .WithModifiers(TokenList(TokenWithSpace(this.Visibility), TokenWithSpace(SyntaxKind.StaticKeyword), TokenWithSpace(SyntaxKind.PartialKeyword)));
         }

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -385,11 +385,11 @@ namespace Microsoft.Windows.CsWin32
 
         private bool WideCharOnly => this.options.WideCharOnly;
 
-        private bool GroupByModule => string.IsNullOrEmpty(this.options.ClassName);
+        private bool GroupByModule => string.IsNullOrEmpty(this.options.MethodsClassName);
 
         private string Namespace => this.InputAssemblyName;
 
-        private string SingleClassName => this.options.ClassName ?? throw new InvalidOperationException("Not in one-class mode.");
+        private string SingleClassName => this.options.MethodsClassName ?? throw new InvalidOperationException("Not in one-class mode.");
 
         private SyntaxKind Visibility => this.options.Public ? SyntaxKind.PublicKeyword : SyntaxKind.InternalKeyword;
 

--- a/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
+++ b/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Windows.CsWin32
         public bool WideCharOnly { get; init; } = true;
 
         /// <summary>
-        /// Gets the name of a single class under which all p/invoke methods should be added, regardless of imported module. Use null for one class per imported module.
+        /// Gets the name of a single class under which all p/invoke methods are generated, regardless of imported module. Use <see langword="null"/> for one class per imported module.
         /// </summary>
         /// <value>The default value is "PInvoke".</value>
-        public string? ClassName { get; init; } = "PInvoke";
+        public string? MethodsClassName { get; init; } = "PInvoke";
 
         /// <summary>
         /// Gets the name of the single class under which all constants are generated.

--- a/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
+++ b/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Windows.CsWin32
         public string? ClassName { get; init; } = "PInvoke";
 
         /// <summary>
+        /// Gets the name of the single class under which all constants are generated.
+        /// </summary>
+        public string ConstantsClassName { get; init; } = "Constants";
+
+        /// <summary>
         /// Gets a value indicating whether to emit a single source file as opposed to types spread across many files.
         /// </summary>
         /// <value>The default value is <see langword="false" />.</value>

--- a/src/Microsoft.Windows.CsWin32/settings.schema.json
+++ b/src/Microsoft.Windows.CsWin32/settings.schema.json
@@ -58,6 +58,12 @@
       "default": "PInvoke",
       "pattern": "^\\w+$"
     },
+    "constantsClassName": {
+      "title": "The name of the single class under which all constants are generated.",
+      "type": "string",
+      "default": "Constants",
+      "pattern": "^\\w+$"
+    },
     "public": {
       "title": "A value indicating whether to expose the generated APIs publicly (as opposed to internally).",
       "type": "boolean",

--- a/src/Microsoft.Windows.CsWin32/settings.schema.json
+++ b/src/Microsoft.Windows.CsWin32/settings.schema.json
@@ -52,8 +52,8 @@
       "type": "boolean",
       "default": false
     },
-    "className": {
-      "title": "The name of a single class under which all p/invoke methods should be added, regardless of imported module. Use null for one class per imported module.",
+    "methodsClassName": {
+      "title": "The name of a single class under which all p/invoke methods are generated, regardless of imported module. Use null for one class per imported module.",
       "type": [ "string", "null" ],
       "default": "PInvoke",
       "pattern": "^\\w+$"

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -977,6 +977,27 @@ i++)						if (p0[i] != default(uint))							return false;
     }
 
     [Fact]
+    public void NullMethodsClass()
+    {
+        this.generator = this.CreateGenerator(new GeneratorOptions { MethodsClassName = null });
+        Assert.True(this.generator.TryGenerate("GetTickCount", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+        Assert.Single(this.FindGeneratedType("Kernel32"));
+        Assert.Empty(this.FindGeneratedType("PInvoke"));
+    }
+
+    [Fact]
+    public void RenamedMethodsClass()
+    {
+        this.generator = this.CreateGenerator(new GeneratorOptions { MethodsClassName = "MyPInvoke" });
+        Assert.True(this.generator.TryGenerate("GetTickCount", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        Assert.Single(this.FindGeneratedType("MyPInvoke"));
+        Assert.Empty(this.FindGeneratedType("PInvoke"));
+    }
+
+    [Fact]
     public void RenamedConstantsClass()
     {
         this.generator = this.CreateGenerator(new GeneratorOptions { ConstantsClassName = "MyConstants" });
@@ -1009,7 +1030,7 @@ i++)						if (p0[i] != default(uint))							return false;
                 CSharpSyntaxTree.ParseText($@"[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(""{this.compilation.AssemblyName}"")]", this.parseOptions));
         }
 
-        using var referencedGenerator = this.CreateGenerator(new GeneratorOptions { ClassName = "P1" }, referencedProject);
+        using var referencedGenerator = this.CreateGenerator(new GeneratorOptions { MethodsClassName = "P1" }, referencedProject);
         Assert.True(referencedGenerator.TryGenerate("LockWorkStation", CancellationToken.None));
         Assert.True(referencedGenerator.TryGenerate("CreateFile", CancellationToken.None));
         referencedProject = this.AddGeneratedCode(referencedProject, referencedGenerator);
@@ -1017,7 +1038,7 @@ i++)						if (p0[i] != default(uint))							return false;
 
         // Now produce more code in a referencing project that includes at least one of the same types as generated in the referenced project.
         this.compilation = this.compilation.AddReferences(referencedProject.ToMetadataReference());
-        this.generator = this.CreateGenerator(new GeneratorOptions { ClassName = "P2" });
+        this.generator = this.CreateGenerator(new GeneratorOptions { MethodsClassName = "P2" });
         Assert.True(this.generator.TryGenerate("HidD_GetAttributes", CancellationToken.None));
         this.CollectGeneratedCode(this.generator);
         this.AssertNoDiagnostics();

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -976,6 +976,17 @@ i++)						if (p0[i] != default(uint))							return false;
         this.AssertGeneratedType("MainAVIHeader", expected, expectedIndexer);
     }
 
+    [Fact]
+    public void RenamedConstantsClass()
+    {
+        this.generator = this.CreateGenerator(new GeneratorOptions { ConstantsClassName = "MyConstants" });
+        Assert.True(this.generator.TryGenerate("CDB_REPORT_BITS", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+        Assert.Single(this.FindGeneratedType("MyConstants"));
+        Assert.Empty(this.FindGeneratedType("Constants"));
+    }
+
     [Theory, PairwiseData]
     public void FullGeneration(bool allowMarshaling, [CombinatorialValues(Platform.AnyCpu, Platform.X86, Platform.X64, Platform.Arm64)] Platform platform)
     {


### PR DESCRIPTION
Fixes #419

### Breaking change

The `version.json` property `className` has been renamed to `methodsClassName`.