### PR TITLE
Re-apply System.Text.Encodings.Web update

### DIFF
--- a/src/Microsoft.Windows.CsWin32/BindingRedirects.cs
+++ b/src/Microsoft.Windows.CsWin32/BindingRedirects.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Windows.CsWin32
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
+    using System.Runtime.InteropServices;
+
+    internal static class BindingRedirects
+    {
+        private static readonly string SourceGeneratorAssemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        private static readonly Lazy<Dictionary<string, string>> LocalAssemblies;
+
+        static BindingRedirects()
+        {
+            LocalAssemblies = new Lazy<Dictionary<string, string>>(
+                () => Directory.GetFiles(SourceGeneratorAssemblyDirectory, "*.dll").ToDictionary(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase));
+        }
+
+        private static bool IsNetFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+
+#pragma warning disable CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
+        [ModuleInitializer]
+#pragma warning restore CA2255 // The 'ModuleInitializer' attribute should not be used in libraries
+        internal static void ApplyBindingRedirects()
+        {
+            if (IsNetFramework)
+            {
+                AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+            }
+        }
+
+        private static Assembly? CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            AssemblyName expected = new(args.Name);
+            if (LocalAssemblies.Value.TryGetValue(expected.Name, out string? path))
+            {
+                AssemblyName actual = AssemblyName.GetAssemblyName(path);
+                if (actual.Version >= expected.Version)
+                {
+                    return Assembly.LoadFile(path);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
@@ -50,6 +50,7 @@
     <PackageReference Include="Nullable" Version="1.3.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" PrivateAssets="none" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 

--- a/src/Microsoft.Windows.CsWin32/ModuleInitializerAttribute.cs
+++ b/src/Microsoft.Windows.CsWin32/ModuleInitializerAttribute.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    internal sealed class ModuleInitializerAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
This reverts #405 and applies an assembly resolver to .NET Framework processes to workaround the fact that we cannot supply binding redirects for the compiler to honor.