### PR TITLE
Avoid mapping the metadata file more than once

### DIFF
--- a/src/Microsoft.Windows.CsWin32/MetadataIndex.cs
+++ b/src/Microsoft.Windows.CsWin32/MetadataIndex.cs
@@ -20,6 +20,12 @@ namespace Microsoft.Windows.CsWin32
     {
         private static readonly Dictionary<CacheKey, Stack<MetadataIndex>> Cache = new();
 
+        /// <summary>
+        /// A cache of metadata files read.
+        /// All access to this should be within a <see cref="Cache"/> lock.
+        /// </summary>
+        private static readonly Dictionary<string, byte[]> MetadataFileContent = new(StringComparer.OrdinalIgnoreCase);
+
         private readonly string metadataPath;
 
         private readonly Platform? platform;
@@ -45,14 +51,14 @@ namespace Microsoft.Windows.CsWin32
         /// </summary>
         private readonly Dictionary<TypeDefinitionHandle, string> handleTypeReleaseMethod = new();
 
-        private MetadataIndex(string metadataPath, Platform? platform)
+        private MetadataIndex(string metadataPath, byte[] metadataBytes, Platform? platform)
         {
             this.metadataPath = metadataPath;
             this.platform = platform;
 
             try
             {
-                this.metadataStream = File.OpenRead(metadataPath);
+                this.metadataStream = new MemoryStream(metadataBytes, writable: false);
                 this.peReader = new PEReader(this.metadataStream);
                 this.mr = this.peReader.GetMetadataReader();
 
@@ -230,16 +236,25 @@ namespace Microsoft.Windows.CsWin32
 
         internal static MetadataIndex Get(string metadataPath, Platform? platform)
         {
+            metadataPath = Path.GetFullPath(metadataPath);
             CacheKey key = new CacheKey(metadataPath, platform);
+            byte[]? metadataBytes;
             lock (Cache)
             {
                 if (Cache.TryGetValue(key, out Stack<MetadataIndex> stack) && stack.Count > 0)
                 {
                     return stack.Pop();
                 }
+
+                // Read the entire metadata file exactly once so that many MemoryStreams can share the memory.
+                if (!MetadataFileContent.TryGetValue(metadataPath, out metadataBytes))
+                {
+                    metadataBytes = File.ReadAllBytes(metadataPath);
+                    MetadataFileContent.Add(metadataPath, metadataBytes);
+                }
             }
 
-            return new MetadataIndex(metadataPath, platform);
+            return new MetadataIndex(metadataPath, metadataBytes, platform);
         }
 
         internal static void Return(MetadataIndex index)

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
@@ -47,7 +47,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="$(MetadataVersion)" GeneratePathProperty="true" PrivateAssets="none" />
     <PackageReference Include="Microsoft.Windows.SDK.Win32Docs" Version="$(ApiDocsVersion)" GeneratePathProperty="true" PrivateAssets="none" />
-    <PackageReference Include="Nullable" Version="1.3.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" PrivateAssets="none" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />


### PR DESCRIPTION
When the source generator is invoked concurrently, it would call `File.OpenRead` for each concurrent use. This maps the file content into memory. Each call gets its own mapped area, and the file will be read once per concurrent use. This ends up taking up *lots* of memory in some sessions.

In this change, we map the file *once* and create many streams based on it.

This fixes devdiv-1520804