### PR TITLE
Add SizeParamIndex or CountConst as required to extern methods

### DIFF
--- a/src/Microsoft.Windows.CsWin32/ArrayTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/ArrayTypeHandleInfo.cs
@@ -19,6 +19,6 @@ internal record ArrayTypeHandleInfo(TypeHandleInfo ElementType, ArrayShape Shape
         TypeSyntaxAndMarshaling element = this.ElementType.ToTypeSyntax(inputs, customAttributes);
         ArrayTypeSyntax arrayType = ArrayType(element.Type, SingletonList(ArrayRankSpecifier().AddSizes(this.Shape.Sizes.Select(size => LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(size))).ToArray<ExpressionSyntax>())));
         MarshalAsAttribute? marshalAs = element.MarshalAsAttribute is object ? new MarshalAsAttribute(UnmanagedType.LPArray) { ArraySubType = element.MarshalAsAttribute.Value } : null;
-        return new TypeSyntaxAndMarshaling(arrayType, marshalAs);
+        return new TypeSyntaxAndMarshaling(arrayType, marshalAs, element.NativeArrayInfo);
     }
 }

--- a/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
@@ -89,7 +89,7 @@ internal record HandleTypeHandleInfo : TypeHandleInfo
         }
         else if (TryMarshalAsObject(inputs, simpleName, out MarshalAsAttribute? marshalAs))
         {
-            return new TypeSyntaxAndMarshaling(PredefinedType(Token(SyntaxKind.ObjectKeyword)), marshalAs);
+            return new TypeSyntaxAndMarshaling(PredefinedType(Token(SyntaxKind.ObjectKeyword)), marshalAs, null);
         }
         else if (!inputs.AllowMarshaling && this.IsDelegate(inputs, out TypeDefinition delegateDefinition) && inputs.Generator is object && !Generator.IsUntypedDelegate(this.reader, delegateDefinition))
         {
@@ -125,7 +125,7 @@ internal record HandleTypeHandleInfo : TypeHandleInfo
                         marshalCookie = marshalCookie.Substring(Generator.GlobalNamespacePrefix.Length);
                     }
 
-                    return new TypeSyntaxAndMarshaling(syntax, new MarshalAsAttribute(UnmanagedType.CustomMarshaler) { MarshalCookie = marshalCookie, MarshalType = Generator.WinRTCustomMarshalerFullName });
+                    return new TypeSyntaxAndMarshaling(syntax, new MarshalAsAttribute(UnmanagedType.CustomMarshaler) { MarshalCookie = marshalCookie, MarshalType = Generator.WinRTCustomMarshalerFullName }, null);
                 }
             }
         }

--- a/src/Microsoft.Windows.CsWin32/TypeSyntaxAndMarshaling.cs
+++ b/src/Microsoft.Windows.CsWin32/TypeSyntaxAndMarshaling.cs
@@ -11,10 +11,19 @@ namespace Microsoft.Windows.CsWin32;
 
 internal struct TypeSyntaxAndMarshaling
 {
-    internal TypeSyntaxAndMarshaling(TypeSyntax type, MarshalAsAttribute? marshalAs = null)
+    internal TypeSyntaxAndMarshaling(TypeSyntax type)
+    {
+        this.Type = type;
+        this.MarshalAsAttribute = null;
+        this.NativeArrayInfo = null;
+        this.ParameterModifier = null;
+    }
+
+    internal TypeSyntaxAndMarshaling(TypeSyntax type, MarshalAsAttribute? marshalAs, Generator.NativeArrayInfo? nativeArrayInfo)
     {
         this.Type = type;
         this.MarshalAsAttribute = marshalAs;
+        this.NativeArrayInfo = nativeArrayInfo;
         this.ParameterModifier = null;
     }
 
@@ -22,39 +31,35 @@ internal struct TypeSyntaxAndMarshaling
 
     internal MarshalAsAttribute? MarshalAsAttribute { get; init; }
 
-    internal SyntaxToken? ParameterModifier { get; init; }
+    internal Generator.NativeArrayInfo? NativeArrayInfo { get; }
 
-    internal void Deconstruct(out TypeSyntax type, out MarshalAsAttribute? marshalAs)
-    {
-        type = this.Type;
-        marshalAs = this.MarshalAsAttribute;
-    }
+    internal SyntaxToken? ParameterModifier { get; init; }
 
     internal FieldDeclarationSyntax AddMarshalAs(FieldDeclarationSyntax fieldDeclaration)
     {
         return this.MarshalAsAttribute is object
-            ? fieldDeclaration.AddAttributeLists(AttributeList().AddAttributes(Generator.MarshalAs(this.MarshalAsAttribute)))
+            ? fieldDeclaration.AddAttributeLists(AttributeList().AddAttributes(Generator.MarshalAs(this.MarshalAsAttribute, this.NativeArrayInfo)))
             : fieldDeclaration;
     }
 
     internal ParameterSyntax AddMarshalAs(ParameterSyntax parameter)
     {
         return this.MarshalAsAttribute is object
-            ? parameter.AddAttributeLists(AttributeList().AddAttributes(Generator.MarshalAs(this.MarshalAsAttribute)))
+            ? parameter.AddAttributeLists(AttributeList().AddAttributes(Generator.MarshalAs(this.MarshalAsAttribute, this.NativeArrayInfo)))
             : parameter;
     }
 
     internal MethodDeclarationSyntax AddReturnMarshalAs(MethodDeclarationSyntax methodDeclaration)
     {
         return this.MarshalAsAttribute is object
-            ? methodDeclaration.AddAttributeLists(AttributeList().WithTarget(AttributeTargetSpecifier(Token(SyntaxKind.ReturnKeyword))).AddAttributes(Generator.MarshalAs(this.MarshalAsAttribute)))
+            ? methodDeclaration.AddAttributeLists(AttributeList().WithTarget(AttributeTargetSpecifier(Token(SyntaxKind.ReturnKeyword))).AddAttributes(Generator.MarshalAs(this.MarshalAsAttribute, this.NativeArrayInfo)))
             : methodDeclaration;
     }
 
     internal DelegateDeclarationSyntax AddReturnMarshalAs(DelegateDeclarationSyntax methodDeclaration)
     {
         return this.MarshalAsAttribute is object
-            ? methodDeclaration.AddAttributeLists(AttributeList().WithTarget(AttributeTargetSpecifier(Token(SyntaxKind.ReturnKeyword))).AddAttributes(Generator.MarshalAs(this.MarshalAsAttribute)))
+            ? methodDeclaration.AddAttributeLists(AttributeList().WithTarget(AttributeTargetSpecifier(Token(SyntaxKind.ReturnKeyword))).AddAttributes(Generator.MarshalAs(this.MarshalAsAttribute, this.NativeArrayInfo)))
             : methodDeclaration;
     }
 

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -2608,6 +2608,21 @@ namespace Windows.Win32
         }
     }
 
+    [Fact]
+    public void ParametersIncludeSizeParamIndex()
+    {
+        this.generator = this.CreateGenerator();
+        Assert.True(this.generator.TryGenerate("IEnumSearchScopeRules", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+
+        MethodDeclarationSyntax nextMethod = this.FindGeneratedMethod("Next").Single(m => !m.Modifiers.Any(SyntaxKind.StaticKeyword));
+        AttributeSyntax marshalAsAttribute = nextMethod.ParameterList.Parameters[1].AttributeLists.SelectMany(al => al.Attributes).Single(a => a.Name.ToString() == "MarshalAs");
+        AttributeArgumentSyntax? sizeParamIndex = marshalAsAttribute.ArgumentList?.Arguments.Single(a => a.NameEquals?.Name.ToString() == nameof(MarshalAsAttribute.SizeParamIndex));
+        Assert.NotNull(sizeParamIndex);
+        Assert.Equal("0", ((LiteralExpressionSyntax)sizeParamIndex!.Expression).Token.ValueText);
+    }
+
     private static string ConstructGlobalConfigString(bool omitDocs = false)
     {
         StringBuilder globalConfigBuilder = new();


### PR DESCRIPTION
The `MarshalAsAttribute` doesn't let us discern between 0 and unset. The C# compiler can tell and sets metadata based on the syntax. We have to lug around `NativeArrayInfo` in order to track a 0 vs. an unset value though till we're ready to emit syntax.

Fixes #372