### PR TITLE
Share MetadataIndex instances across multiple generators

### DIFF
--- a/src/Microsoft.Windows.CsWin32/NamespaceMetadata.cs
+++ b/src/Microsoft.Windows.CsWin32/NamespaceMetadata.cs
@@ -6,6 +6,12 @@ using System.Reflection.Metadata;
 
 namespace Microsoft.Windows.CsWin32;
 
+/// <summary>
+/// An immutable index into metadata.
+/// </summary>
+/// <devremarks>
+/// This class must not contain definitions. It may contain handles. See <see cref="MetadataIndex"/> devremarks for details.
+/// </devremarks>
 [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
 internal class NamespaceMetadata
 {


### PR DESCRIPTION
This should drastically cut down on memory demands (from 1.2GB to store 128 copies of MetadataIndex to just 1 of them). It should presumably improve warmup perf as well, since we only create one index instead of 128.