### PR TITLE
Fix thread-safety bug in MetadataIndex

### DIFF
--- a/src/Microsoft.Windows.CsWin32/MetadataIndex.cs
+++ b/src/Microsoft.Windows.CsWin32/MetadataIndex.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO.MemoryMappedFiles;
@@ -43,7 +44,7 @@ internal class MetadataIndex
 
     private readonly HashSet<string> releaseMethods = new HashSet<string>(StringComparer.Ordinal);
 
-    private readonly Dictionary<TypeReferenceHandle, TypeDefinitionHandle> refToDefCache = new();
+    private readonly ConcurrentDictionary<TypeReferenceHandle, TypeDefinitionHandle> refToDefCache = new();
 
     /// <summary>
     /// The set of names of typedef structs that represent handles where the handle has length of <see cref="IntPtr"/>
@@ -305,7 +306,7 @@ internal class MetadataIndex
             }
         }
 
-        this.refToDefCache.Add(typeRefHandle, typeDefHandle);
+        this.refToDefCache.TryAdd(typeRefHandle, typeDefHandle);
         return !typeDefHandle.IsNil;
     }
 

--- a/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
+++ b/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
@@ -352,6 +352,9 @@ public class SourceGenerator : ISourceGenerator
             inner = inner.InnerException;
         }
 
+        sb.AppendLine();
+        sb.AppendLine(ex.ToString());
+
         return sb.ToString();
     }
 


### PR DESCRIPTION
Now that the type ref to type def cache is shared across generators, it should have been using thread-safe patterns to access and update its cache dictionary.