### PR TITLE
Make `[In, Optional]` managed struct parameters actually optional in friendly overloads

### DIFF
--- a/src/Microsoft.Windows.CsWin32/ArrayTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/ArrayTypeHandleInfo.cs
@@ -28,4 +28,6 @@ internal record ArrayTypeHandleInfo(TypeHandleInfo ElementType, ArrayShape Shape
             return new TypeSyntaxAndMarshaling(PointerType(element.Type));
         }
     }
+
+    internal override bool? IsValueType(TypeSyntaxSettings inputs) => false;
 }

--- a/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
@@ -76,6 +76,8 @@ internal record PointerTypeHandleInfo(TypeHandleInfo ElementType) : TypeHandleIn
         return new TypeSyntaxAndMarshaling(PointerType(elementTypeDetails.Type));
     }
 
+    internal override bool? IsValueType(TypeSyntaxSettings inputs) => false;
+
     private bool TryGetElementTypeDefinition(Generator generator, out TypeDefinition typeDef)
     {
         if (this.ElementType is HandleTypeHandleInfo handleElement)

--- a/src/Microsoft.Windows.CsWin32/PrimitiveTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PrimitiveTypeHandleInfo.cs
@@ -16,6 +16,11 @@ internal record PrimitiveTypeHandleInfo(PrimitiveTypeCode PrimitiveTypeCode) : T
     internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes)
         => new TypeSyntaxAndMarshaling(ToTypeSyntax(this.PrimitiveTypeCode, inputs.PreferNativeInt));
 
+    internal override bool? IsValueType(TypeSyntaxSettings inputs)
+    {
+        return this.PrimitiveTypeCode is not PrimitiveTypeCode.Object or PrimitiveTypeCode.Void;
+    }
+
     internal static TypeSyntax ToTypeSyntax(PrimitiveTypeCode typeCode, bool preferNativeInt)
     {
         return typeCode switch

--- a/src/Microsoft.Windows.CsWin32/TypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/TypeHandleInfo.cs
@@ -16,6 +16,8 @@ internal abstract record TypeHandleInfo
 
     internal abstract TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes = default);
 
+    internal abstract bool? IsValueType(TypeSyntaxSettings inputs);
+
     protected static bool TryGetSimpleName(TypeSyntax nameSyntax, [NotNullWhen(true)] out string? simpleName)
     {
         if (nameSyntax is QualifiedNameSyntax qname)

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -67,6 +67,14 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
             new object[] { "net6.0" },
         };
 
+    public static IEnumerable<object[]> TFMDataNoNetFx35 =>
+        new object[][]
+        {
+            new object[] { "net472" },
+            new object[] { "netstandard2.0" },
+            new object[] { "net6.0" },
+        };
+
     public static Platform[] SpecificCpuArchitectures =>
         new Platform[]
         {
@@ -2724,10 +2732,12 @@ namespace Windows.Win32
         Assert.True(this.generator.TryGenerate("CreateFile", CancellationToken.None));
     }
 
-    [Fact]
-    public void MiniDumpWriteDump_AllOptionalPointerParametersAreOptional()
+    [Theory]
+    [MemberData(nameof(TFMDataNoNetFx35))]
+    public void MiniDumpWriteDump_AllOptionalPointerParametersAreOptional(string tfm)
     {
-        this.compilation = this.compilation.WithOptions(this.compilation.Options.WithPlatform(Platform.X64));
+        // We split on TFMs because the generated code is slightly different depending on TFM.
+        this.compilation = this.starterCompilations[tfm].WithOptions(this.compilation.Options.WithPlatform(Platform.X64));
         this.generator = this.CreateGenerator();
         Assert.True(this.generator.TryGenerate("MiniDumpWriteDump", CancellationToken.None));
         this.CollectGeneratedCode(this.generator);
@@ -3043,6 +3053,7 @@ namespace Windows.Win32
 #pragma warning disable SA1202 // Elements should be ordered by access
         private static readonly ImmutableArray<PackageIdentity> AdditionalPackages = ImmutableArray.Create(
             new PackageIdentity("Microsoft.Windows.SDK.Contracts", "10.0.19041.1"),
+            new PackageIdentity("System.Memory", "4.5.4"),
             new PackageIdentity("Microsoft.Win32.Registry", "5.0.0"));
 
         internal static readonly ReferenceAssemblies NetStandard20 = ReferenceAssemblies.NetStandard.NetStandard20.AddPackages(AdditionalPackages.Add(new PackageIdentity("System.Memory", "4.5.4")));


### PR DESCRIPTION
Fixes #578
