### PR TITLE
Perf improvements to repeated generations

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -661,67 +661,8 @@ public class Generator : IDisposable
         return false;
     }
 
-    /// <summary>
-    /// Gets the name of the declaring enum if a supplied value matches the name of an enum's value.
-    /// </summary>
-    /// <param name="enumValueName">A string that may match an enum value name.</param>
-    /// <param name="declaringEnum">Receives the name of the declaring enum if a match is found.</param>
-    /// <returns><see langword="true"/> if a match was found; otherwise <see langword="false"/>.</returns>
-    public bool TryGetEnumName(string enumValueName, [NotNullWhen(true)] out string? declaringEnum)
-    {
-        // First find the type reference for System.Enum
-        TypeReferenceHandle? enumTypeRefHandle = null;
-        foreach (TypeReferenceHandle typeRefHandle in this.Reader.TypeReferences)
-        {
-            TypeReference typeRef = this.Reader.GetTypeReference(typeRefHandle);
-            if (this.Reader.StringComparer.Equals(typeRef.Name, nameof(Enum)) && this.Reader.StringComparer.Equals(typeRef.Namespace, nameof(System)))
-            {
-                enumTypeRefHandle = typeRefHandle;
-                break;
-            }
-        }
-
-        Debug.Assert(enumTypeRefHandle.HasValue, "We always expect at least one enum.");
-        if (enumTypeRefHandle is null)
-        {
-            // No enums -> it couldn't be what the caller is looking for.
-            declaringEnum = null;
-            return false;
-        }
-
-        foreach (TypeDefinitionHandle typeDefHandle in this.Reader.TypeDefinitions)
-        {
-            TypeDefinition typeDef = this.Reader.GetTypeDefinition(typeDefHandle);
-            if (typeDef.BaseType.IsNil)
-            {
-                continue;
-            }
-
-            if (typeDef.BaseType.Kind != HandleKind.TypeReference)
-            {
-                continue;
-            }
-
-            var baseTypeHandle = (TypeReferenceHandle)typeDef.BaseType;
-            if (!baseTypeHandle.Equals(enumTypeRefHandle.Value))
-            {
-                continue;
-            }
-
-            foreach (FieldDefinitionHandle fieldDefHandle in typeDef.GetFields())
-            {
-                FieldDefinition fieldDef = this.Reader.GetFieldDefinition(fieldDefHandle);
-                if (this.Reader.StringComparer.Equals(fieldDef.Name, enumValueName))
-                {
-                    declaringEnum = this.Reader.GetString(typeDef.Name);
-                    return true;
-                }
-            }
-        }
-
-        declaringEnum = null;
-        return false;
-    }
+    /// <inheritdoc cref="MetadataIndex.TryGetEnumName(MetadataReader, string, out string?)"/>
+    public bool TryGetEnumName(string enumValueName, [NotNullWhen(true)] out string? declaringEnum) => this.MetadataIndex.TryGetEnumName(this.Reader, enumValueName, out declaringEnum);
 
     /// <summary>
     /// Generates a projection of all extern methods and their supporting types.

--- a/src/Microsoft.Windows.CsWin32/Rental.cs
+++ b/src/Microsoft.Windows.CsWin32/Rental.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Windows.CsWin32;
+
+internal struct Rental<T> : IDisposable
+    where T : class
+{
+    private Action<T, object?>? disposeAction;
+    private T? value;
+    private object? state;
+
+    internal Rental(T value, Action<T, object?> disposeAction, object? state)
+    {
+        this.value = value;
+        this.disposeAction = disposeAction;
+        this.state = state;
+    }
+
+    public T Value => this.value ?? throw new ObjectDisposedException(this.GetType().FullName);
+
+    public void Dispose()
+    {
+        T? value = this.value;
+        this.value = null;
+        if (value is not null)
+        {
+            this.disposeAction?.Invoke(value, this.state);
+        }
+
+        this.disposeAction = null;
+        this.state = null;
+    }
+}


### PR DESCRIPTION
Toward a couple of the items on the list in #612:

- Calling PEReaderExtensions.GetMetadataReader is apparently quite slow because of some in-memory buffer copies. We can pool and recycle the result of this call.
- TryGetEnumName exhaustively searches all enum values in the metadata on every call. On subsequent generations, we should be able to reuse the result of this search rather than repeating it.