### PR TITLE
Add option to avoid SafeHandle friendly overloads

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -1509,6 +1509,11 @@ public class Generator : IDisposable
 
     internal TypeSyntax? RequestSafeHandle(string releaseMethod)
     {
+        if (!this.options.UseSafeHandles)
+        {
+            return null;
+        }
+
         try
         {
             if (this.volatileCode.TryGetSafeHandleForReleaseMethod(releaseMethod, out TypeSyntax? safeHandleType))
@@ -4339,7 +4344,7 @@ public class Generator : IDisposable
                             Argument(LiteralExpression(SyntaxKind.TrueLiteralExpression)).WithNameColon(NameColon(IdentifierName("ownsHandle")))))));
                 }
             }
-            else if (isIn && !isOut && !isReleaseMethod && parameterTypeInfo is HandleTypeHandleInfo parameterHandleTypeInfo && this.TryGetHandleReleaseMethod(parameterHandleTypeInfo.Handle, out string? releaseMethod) && !this.Reader.StringComparer.Equals(methodDefinition.Name, releaseMethod))
+            else if (this.options.UseSafeHandles && isIn && !isOut && !isReleaseMethod && parameterTypeInfo is HandleTypeHandleInfo parameterHandleTypeInfo && this.TryGetHandleReleaseMethod(parameterHandleTypeInfo.Handle, out string? releaseMethod) && !this.Reader.StringComparer.Equals(methodDefinition.Name, releaseMethod))
             {
                 IdentifierNameSyntax typeDefHandleName = IdentifierName(externParam.Identifier.ValueText + "Local");
                 signatureChanged = true;

--- a/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
+++ b/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
@@ -45,6 +45,12 @@ public record GeneratorOptions
     public bool AllowMarshaling { get; init; } = true;
 
     /// <summary>
+    /// Gets a value indicating whether friendly overloads should use safe handles.
+    /// </summary>
+    /// <value>The default value is <see langword="true"/>.</value>
+    public bool UseSafeHandles { get; init; } = true;
+
+    /// <summary>
     /// Throws an exception when this instance is not initialized with a valid set of values.
     /// </summary>
     /// <exception cref="InvalidOperationException">Thrown when some setting is invalid.</exception>

--- a/src/Microsoft.Windows.CsWin32/settings.schema.json
+++ b/src/Microsoft.Windows.CsWin32/settings.schema.json
@@ -37,6 +37,11 @@
       "type": "boolean",
       "default": true
     },
+    "useSafeHandles": {
+      "description": "A value indicating whether friendly overloads should use safe handles.",
+      "type": "boolean",
+      "default": true
+    },
     "wideCharOnly": {
       "description": "Omit ANSI functions and remove `W` suffix from UTF-16 functions.",
       "type": "boolean",


### PR DESCRIPTION
`SafeHandle` can be avoided in friendly overloads by adding the `useSafeHandles: false` property to the NativeMethods.json file.

Closes #605