### PR TITLE
Unmarshaled COM 'interface' struct trimmability

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -3506,9 +3506,10 @@ public class Generator : IDisposable
             members.Add(methodDeclaration);
         }
 
+        // We expose the vtbl struct, not because we expect folks to use it directly, but because some folks may use it to manually generate CCWs.
         StructDeclarationSyntax? vtblStruct = StructDeclaration(Identifier("Vtbl"))
             .AddMembers(vtblMembers.ToArray())
-            .AddModifiers(TokenWithSpace(SyntaxKind.PrivateKeyword));
+            .AddModifiers(TokenWithSpace(this.Visibility));
         members.Add(vtblStruct);
 
         // private Vtbl* lpVtbl;


### PR DESCRIPTION
This change does two things:
1. Exposes the Vtbl struct itself. This may be useful for CCW generation, although that is outside the scope of CsWin32 (at present, at least.)
2. Makes the generated code more trimmable by *not* using the Vtbl struct at all. Each method directly indexes into the vtbl by pointers and then casts the desired pointer to the appropriate unmanaged delegate for invocation.

For example, here is the effective code change:

```diff
 internal uint AddRef()
 {
     fixed (ISpellChecker* pThis = &this)
-        return lpVtbl->AddRef_2(pThis);
+        return ((delegate *unmanaged [Stdcall]<IUnknown_unmanaged*,uint>)lpVtbl[1])(pThis);
 }

-private Vtbl* lpVtbl;
+private void** lpVtbl;

-private struct Vtbl
+internal struct Vtbl
```

This PR has no effect on generated code when `allowMarshaling: true`.

Closes #668