### PR TITLE
Declare methods on COM interfaces-as-structs as `public`

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -3527,7 +3527,7 @@ public class Generator : IDisposable
 
             MethodDeclarationSyntax methodDeclaration = MethodDeclaration(
                 List<AttributeListSyntax>(),
-                modifiers: TokenList(TokenWithSpace(this.Visibility)),
+                modifiers: TokenList(TokenWithSpace(SyntaxKind.PublicKeyword)), // always use public so struct can implement the COM interface
                 returnType.Type.WithTrailingTrivia(TriviaList(Space)),
                 explicitInterfaceSpecifier: null!,
                 SafeIdentifier(methodName),


### PR DESCRIPTION
Closes #723
