### PR TITLE
Use Windows active code page instead of UTF8 for decoding narrow characters

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -4938,7 +4938,7 @@ public class Generator : IDisposable
                 parameters[param.SequenceNumber - 1] = externParam
                     .WithType(PredefinedType(TokenWithSpace(SyntaxKind.StringKeyword)));
 
-                // fixed (byte* someLocal = some is object ? System.Text.Encoding.UTF8.GetBytes(some) : null)
+                // fixed (byte* someLocal = some is object ? System.Text.Encoding.Default.GetBytes(some) : null)
                 fixedBlocks.Add(VariableDeclaration(PointerType(PredefinedType(Token(SyntaxKind.ByteKeyword)))).AddVariables(
                     VariableDeclarator(localName.Identifier).WithInitializer(EqualsValueClause(
                         ConditionalExpression(
@@ -4946,7 +4946,7 @@ public class Generator : IDisposable
                             InvocationExpression(
                                 MemberAccessExpression(
                                     SyntaxKind.SimpleMemberAccessExpression,
-                                    ParseTypeName("global::System.Text.Encoding.UTF8"),
+                                    ParseTypeName("global::System.Text.Encoding.Default"),
                                     IdentifierName(nameof(Encoding.GetBytes))))
                             .WithArgumentList(
                                 ArgumentList(

--- a/src/Microsoft.Windows.CsWin32/templates/PCSTR.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/PCSTR.cs
@@ -36,7 +36,7 @@ internal unsafe readonly partial struct PCSTR
 	/// Returns a <see langword="string"/> with a copy of this character array, decoding as UTF-8.
 	/// </summary>
 	/// <returns>A <see langword="string"/>, or <see langword="null"/> if <see cref="Value"/> is <see langword="null"/>.</returns>
-	public override string ToString() => this.Value is null ? null : new string((sbyte*)this.Value, 0, this.Length, global::System.Text.Encoding.UTF8);
+	public override string ToString() => this.Value is null ? null : new string((sbyte*)this.Value, 0, this.Length, global::System.Text.Encoding.Default);
 
 #if canUseSpan
 	/// <summary>

--- a/src/Microsoft.Windows.CsWin32/templates/PCZZSTR.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/PCZZSTR.cs
@@ -45,7 +45,7 @@ internal unsafe readonly partial struct PCZZSTR
 	/// Returns a <see langword="string"/> with a copy of this character array, decoding as UTF-8.
 	/// </summary>
 	/// <returns>A <see langword="string"/>, or <see langword="null"/> if <see cref="Value"/> is <see langword="null"/>.</returns>
-	public override string ToString() => this.Value is null ? null : new string((sbyte*)this.Value, 0, this.Length, global::System.Text.Encoding.UTF8);
+	public override string ToString() => this.Value is null ? null : new string((sbyte*)this.Value, 0, this.Length, global::System.Text.Encoding.Default);
 
 #if canUseSpan
 	/// <summary>

--- a/test/GenerationSandbox.Tests/BasicTests.cs
+++ b/test/GenerationSandbox.Tests/BasicTests.cs
@@ -423,7 +423,7 @@ public class BasicTests
     }
 
     [Fact]
-    public void CHAR_MarshaledAsUtf8()
+    public void CHAR_MarshaledAsAnsi()
     {
         Assert.Equal(1, Marshal.SizeOf<CHAR>());
     }


### PR DESCRIPTION
Fixes #761
