### PR TITLE
Revert "Observe `DangerousAddRef` result before proceeding."

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -4745,12 +4745,6 @@ public class Generator : IDisposable
                     //// hTemplateFile.DangerousAddRef(ref hTemplateFileAddRef);
                     ExpressionStatement(InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, origName, IdentifierName(nameof(SafeHandle.DangerousAddRef))))
                         .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(refAddedName).WithRefKindKeyword(TokenWithSpace(SyntaxKind.RefKeyword)))))),
-                    //// if (!hTemplateFileAddRef) throw new ArgumentException("Already released.", nameof(hTemplateFile));
-                    IfStatement(
-                        PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, refAddedName),
-                        ThrowStatement(ObjectCreationExpression(IdentifierName(nameof(ArgumentException))).AddArgumentListArguments(
-                            Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal("Already released."))),
-                            Argument(NameOfExpression(origName))))),
                     //// hTemplateFileLocal = (HANDLE)hTemplateFile.DangerousGetHandle();
                     ExpressionStatement(
                         AssignmentExpression(

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -2651,7 +2651,6 @@ namespace Windows.Win32
 					if (hTemplateFile is object)
 					{{
 						hTemplateFile.DangerousAddRef(ref hTemplateFileAddRef);
-						if (!hTemplateFileAddRef)throw new ArgumentException(""Already released."", nameof(hTemplateFile));
 						hTemplateFileLocal = (winmdroot.Foundation.HANDLE)hTemplateFile.DangerousGetHandle();
 					}}
 					else


### PR DESCRIPTION
Reverts microsoft/CsWin32#762

Per @aaronrobinsonMSFT, this isn't necessary because `DangerousAddRef` will throw rather than return having set the `ref` parameter to `false`.