### PR TITLE
Emit a stable reference to the interface guid

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.401-focal
+FROM mcr.microsoft.com/dotnet/sdk:7.0.100-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Microsoft.Windows.CsWin32.sln
+++ b/Microsoft.Windows.CsWin32.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29322.22
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33110.383
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1CE9670B-D5FF-46A7-9D00-24E70E6ED48B}"
 	ProjectSection(SolutionItems) = preProject
@@ -27,6 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{36CCE840-6
 		test\.editorconfig = test\.editorconfig
 		test\Directory.Build.props = test\Directory.Build.props
 		test\Directory.Build.targets = test\Directory.Build.targets
+		test\GenerationSandbox.props = test\GenerationSandbox.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Windows.CsWin32", "src\Microsoft.Windows.CsWin32\Microsoft.Windows.CsWin32.csproj", "{E3E96466-44B6-41AF-BBC8-9D30183ED8A9}"
@@ -40,6 +41,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpellChecker", "test\SpellChecker\SpellChecker.csproj", "{744BE74F-8C4A-49E8-9683-52D987224285}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinRTInteropTest", "test\WinRTInteropTest\WinRTInteropTest.csproj", "{0E067B66-C2EC-4106-87D2-5310CFCDC5B8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenerationSandbox.Unmarshalled.Tests", "test\GenerationSandbox.Unmarshalled.Tests\GenerationSandbox.Unmarshalled.Tests.csproj", "{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -95,6 +98,14 @@ Global
 		{0E067B66-C2EC-4106-87D2-5310CFCDC5B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E067B66-C2EC-4106-87D2-5310CFCDC5B8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0E067B66-C2EC-4106-87D2-5310CFCDC5B8}.Release|NonWindows.ActiveCfg = Release|Any CPU
+		{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3}.Debug|NonWindows.ActiveCfg = Debug|Any CPU
+		{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3}.Debug|NonWindows.Build.0 = Debug|Any CPU
+		{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3}.Release|NonWindows.ActiveCfg = Release|Any CPU
+		{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3}.Release|NonWindows.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -106,6 +117,7 @@ Global
 		{7E8A5179-F94C-410F-8BBE-FDAAA95A19C3} = {36CCE840-6FE5-4DB9-A8D5-8CF3CB6D342A}
 		{744BE74F-8C4A-49E8-9683-52D987224285} = {36CCE840-6FE5-4DB9-A8D5-8CF3CB6D342A}
 		{0E067B66-C2EC-4106-87D2-5310CFCDC5B8} = {36CCE840-6FE5-4DB9-A8D5-8CF3CB6D342A}
+		{3D303454-7DB0-4F9F-BD9E-07F09D3C70E3} = {36CCE840-6FE5-4DB9-A8D5-8CF3CB6D342A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E3944F6A-384B-4B0F-B93F-3BD513DC57BD}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.401",
+    "version": "7.0.100",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/test/GenerationSandbox.Tests/GenerationSandbox.Tests.csproj
+++ b/test/GenerationSandbox.Tests/GenerationSandbox.Tests.csproj
@@ -1,41 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\src\Microsoft.Windows.CsWin32\build\Microsoft.Windows.CsWin32.props" />
-
-  <PropertyGroup>
-    <TargetFrameworks>net6.0-windows7.0;net472</TargetFrameworks>
-    <RootNamespace />
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
-    <Using Include="Xunit.Abstractions" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Windows.CsWin32\Microsoft.Windows.CsWin32.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <Analyzer Include="$(RepoRootPath)\bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\System.Text.Json.dll" />
-    <Analyzer Include="$(RepoRootPath)\bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll" />
-    <Analyzer Include="$(RepoRootPath)\bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\System.Text.Encodings.Web.dll" />
-    <Analyzer Include="$(RepoRootPath)\bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\Microsoft.Windows.SDK.Win32Docs.dll" />
-    <Analyzer Include="$(RepoRootPath)\bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\MessagePack.dll" />
-    <Analyzer Include="$(RepoRootPath)\bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\MessagePack.Annotations.dll" />
-  </ItemGroup>
+  <Import Project="..\GenerationSandbox.props" />
 
   <ProjectExtensions>
     <VisualStudio><UserProperties nativemethods_1json__JsonSchema="..\..\src\Microsoft.Windows.CsWin32\settings.schema.json" /></VisualStudio>
   </ProjectExtensions>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="$(MetadataVersion)" GeneratePathProperty="true" PrivateAssets="none" />
-    <!-- <PackageReference Include="Microsoft.Dia.Win32Metadata" Version="$(DiaMetadataVersion)" PrivateAssets="none" /> -->
-    <PackageReference Include="coverlet.msbuild" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-  </ItemGroup>
 
 </Project>

--- a/test/GenerationSandbox.Unmarshalled.Tests/COMTests.cs
+++ b/test/GenerationSandbox.Unmarshalled.Tests/COMTests.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable IDE0005
+
+using Windows.Win32;
+using Windows.Win32.System.Com;
+
+public class COMTests
+{
+#if NET7_0_OR_GREATER
+    [Fact]
+    public void COMStaticGuid()
+    {
+        Assert.Equal(typeof(IPersistFile).GUID, IPersistFile.IID_Guid);
+        Assert.Equal(typeof(IPersistFile).GUID, GetGuid<IPersistFile>());
+    }
+
+    private static Guid GetGuid<T>()
+        where T : IComIID
+        => T.Guid;
+#endif
+}

--- a/test/GenerationSandbox.Unmarshalled.Tests/GenerationSandbox.Unmarshalled.Tests.csproj
+++ b/test/GenerationSandbox.Unmarshalled.Tests/GenerationSandbox.Unmarshalled.Tests.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\GenerationSandbox.props" />
+  <ItemGroup>
+    <None Remove="NativeMethods.json" />
+    <None Remove="NativeMethods.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="NativeMethods.json" />
+    <AdditionalFiles Include="NativeMethods.txt" />
+  </ItemGroup>
+</Project>

--- a/test/GenerationSandbox.Unmarshalled.Tests/NativeMethods.json
+++ b/test/GenerationSandbox.Unmarshalled.Tests/NativeMethods.json
@@ -1,0 +1,6 @@
+﻿{
+  "$schema": "..\\..\\src\\Microsoft.Windows.CsWin32\\settings.schema.json",
+  "emitSingleFile": true,
+  "multiTargetingFriendlyAPIs": true,
+  "allowMarshaling": false
+}

--- a/test/GenerationSandbox.Unmarshalled.Tests/NativeMethods.txt
+++ b/test/GenerationSandbox.Unmarshalled.Tests/NativeMethods.txt
@@ -1,0 +1,1 @@
+﻿IPersistFile

--- a/test/GenerationSandbox.props
+++ b/test/GenerationSandbox.props
@@ -1,0 +1,37 @@
+<Project>
+  <Import Project="$(RepoRootPath)src\Microsoft.Windows.CsWin32\build\Microsoft.Windows.CsWin32.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0-windows7.0;net6.0-windows7.0;net472</TargetFrameworks>
+    <RootNamespace />
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRootPath)src\Microsoft.Windows.CsWin32\Microsoft.Windows.CsWin32.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <Analyzer Include="$(RepoRootPath)bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\System.Text.Json.dll" />
+    <Analyzer Include="$(RepoRootPath)bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll" />
+    <Analyzer Include="$(RepoRootPath)bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\System.Text.Encodings.Web.dll" />
+    <Analyzer Include="$(RepoRootPath)bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\Microsoft.Windows.SDK.Win32Docs.dll" />
+    <Analyzer Include="$(RepoRootPath)bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\MessagePack.dll" />
+    <Analyzer Include="$(RepoRootPath)bin\Microsoft.Windows.CsWin32\$(Configuration)\netstandard2.0\MessagePack.Annotations.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="$(MetadataVersion)" GeneratePathProperty="true" PrivateAssets="none" />
+    <!-- <PackageReference Include="Microsoft.Dia.Win32Metadata" Version="$(DiaMetadataVersion)" PrivateAssets="none" /> -->
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This way, the reference can be converted by others into a pointer and passed around without fear that the data will move.

The new property looks like this:

```cs
static ref readonly Guid IComIID.Guid
{
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    get
    {
        ReadOnlySpan<byte> data = new byte[] {
            0x0B,0x01,0x00,0x00,0x00,0x00,0x00,0x00,0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46 };
        return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
    }
}
```

Also add non-marshaling runtime test project so we can verify the emitted guid has the right value.