### PR TITLE
Add IPicture test and fix the failure

### DIFF
--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -632,6 +632,19 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
         Assert.NotEmpty(structSyntax.Members.OfType<MethodDeclarationSyntax>().Where(m => m.Identifier.ValueText == "put_ClassName"));
     }
 
+    /// <summary>
+    /// Verifies that IPicture can be generated.
+    /// It is a special case because of <see href="https://github.com/microsoft/win32metadata/issues/1367">this metadata bug</see>.
+    /// </summary>
+    [Fact]
+    public void COMPropertiesAreGeneratedAsStructProperties_NonConsecutiveAccessors_IPicture()
+    {
+        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions with { AllowMarshaling = false });
+        Assert.True(this.generator.TryGenerate("IPicture", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+    }
+
     [Theory, PairwiseData]
     public void COMPropertiesAreGeneratedAsMethodsWhenTheirReturnTypesDiffer([CombinatorialValues(0, 1, 2)] int marshaling)
     {


### PR DESCRIPTION
Fixes the non-compilable generated code reported in #774.
This change does _not_ turn off property declarations in COM structs. That (if necessary) can come in a follow-up change.