### PR TITLE
Fix full generation tests

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -10,7 +10,7 @@ parameters:
 
 jobs:
 - job: Windows
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   pool: ${{ parameters.windowsPool }}
   variables:
     TestFilter: ""
@@ -30,7 +30,7 @@ jobs:
       RunTests: ${{ parameters.RunTests }}
 
 - job: Linux
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   pool:
     vmImage: Ubuntu 20.04
   variables:
@@ -48,7 +48,7 @@ jobs:
 
 - job: macOS
   condition: ${{ parameters.includeMacOS }}
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   pool:
     vmImage: macOS-12
   variables:

--- a/azure-pipelines/dotnet-test-cloud.ps1
+++ b/azure-pipelines/dotnet-test-cloud.ps1
@@ -50,7 +50,7 @@ if ($x86) {
     --filter "TestCategory!=FailsInCloudTest$env:TESTFILTER" `
     --collect "Code Coverage;Format=cobertura" `
     --settings "$PSScriptRoot/test.runsettings" `
-    --blame-hang-timeout 600s `
+    --blame-hang-timeout 1500s `
     --blame-crash `
     -bl:"$ArtifactStagingFolder/build_logs/test.binlog" `
     --diag "$ArtifactStagingFolder/test_logs/diag.log;TraceLevel=info" `

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -1473,7 +1473,7 @@ public class Generator : IDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
             TypeDefinition typeDef = this.Reader.GetTypeDefinition(typeDefinitionHandle);
-            if (typeDef.BaseType.IsNil)
+            if (typeDef.BaseType.IsNil && (typeDef.Attributes & TypeAttributes.Interface) != TypeAttributes.Interface)
             {
                 continue;
             }


### PR DESCRIPTION
Our full generation testing was actually omitting many COM interfaces. Closing that hole revealed a few bugs where we can emit C# that will not compile.
These changes address the test hole and the issues that closing it exposed.