### PR TITLE
Perf enhancements

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -7490,9 +7490,10 @@ public class Generator : IDisposable
 
         private static SyntaxList<MemberDeclarationSyntax> AddSpacingBetweenMembers(SyntaxList<MemberDeclarationSyntax> members, bool insertLineAboveFirstMember = false)
         {
-            for (int i = members.Count - 1; i > 0; i--)
+            List<MemberDeclarationSyntax> mutableMembers = members.ToList();
+            for (int i = mutableMembers.Count - 1; i > 0; i--)
             {
-                if (members[i] is
+                if (mutableMembers[i] is
                     ClassDeclarationSyntax or
                     StructDeclarationSyntax or
                     NamespaceDeclarationSyntax or
@@ -7501,16 +7502,16 @@ public class Generator : IDisposable
                     IndexerDeclarationSyntax or
                     PropertyDeclarationSyntax)
                 {
-                    members = members.Replace(members[i], members[i].WithLeadingTrivia(members[i].GetLeadingTrivia().Insert(0, LineFeed)));
+                    mutableMembers[i] = mutableMembers[i].WithLeadingTrivia(mutableMembers[i].GetLeadingTrivia().Insert(0, LineFeed));
                 }
             }
 
-            if (insertLineAboveFirstMember && members.Count > 0)
+            if (insertLineAboveFirstMember && mutableMembers.Count > 0)
             {
-                members = members.Replace(members[0], members[0].WithLeadingTrivia(members[0].GetLeadingTrivia().Insert(0, LineFeed)));
+                mutableMembers[0] = mutableMembers[0].WithLeadingTrivia(mutableMembers[0].GetLeadingTrivia().Insert(0, LineFeed));
             }
 
-            return members;
+            return new SyntaxList<MemberDeclarationSyntax>(mutableMembers);
         }
 
         private TSyntax WithIndentingTrivia<TSyntax>(TSyntax node, SyntaxTrivia indentTrivia)

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -378,6 +378,7 @@ public class Generator : IDisposable
     private readonly TypeSyntaxSettings functionPointerTypeSettings;
     private readonly TypeSyntaxSettings errorMessageTypeSettings;
 
+    private readonly Dictionary<string, ISymbol?> findTypeSymbolIfAlreadyAvailableCache = new(StringComparer.Ordinal);
     private readonly Rental<MetadataReader> metadataReader;
     private readonly GeneratorOptions options;
     private readonly CSharpCompilation? compilation;
@@ -3004,16 +3005,22 @@ public class Generator : IDisposable
 
     private ISymbol? FindTypeSymbolIfAlreadyAvailable(string fullyQualifiedMetadataName)
     {
-        ISymbol? result = null;
+        if (this.findTypeSymbolIfAlreadyAvailableCache.TryGetValue(fullyQualifiedMetadataName, out ISymbol? result))
+        {
+            return result;
+        }
+
         if (this.compilation is object)
         {
             if (this.compilation.Assembly.GetTypeByMetadataName(fullyQualifiedMetadataName) is { } ownSymbol)
             {
                 // This assembly defines it.
                 // But if it defines it as a partial, we should not consider it as fully defined so we populate our side.
-                return ownSymbol.DeclaringSyntaxReferences.Any(sr => sr.GetSyntax() is BaseTypeDeclarationSyntax type && type.Modifiers.Any(SyntaxKind.PartialKeyword))
+                result = ownSymbol.DeclaringSyntaxReferences.Any(sr => sr.GetSyntax() is BaseTypeDeclarationSyntax type && type.Modifiers.Any(SyntaxKind.PartialKeyword))
                     ? null
                     : ownSymbol;
+                this.findTypeSymbolIfAlreadyAvailableCache.Add(fullyQualifiedMetadataName, result);
+                return result;
             }
 
             foreach (MetadataReference? reference in this.compilation.References)
@@ -3035,6 +3042,7 @@ public class Generator : IDisposable
                             // In such a case, we'll prefer to just declare our own local symbol.
                             if (result is not null)
                             {
+                                this.findTypeSymbolIfAlreadyAvailableCache.Add(fullyQualifiedMetadataName, null);
                                 return null;
                             }
 
@@ -3045,6 +3053,7 @@ public class Generator : IDisposable
             }
         }
 
+        this.findTypeSymbolIfAlreadyAvailableCache.Add(fullyQualifiedMetadataName, result);
         return result;
     }
 

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -187,7 +187,7 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
     public void SimplestMethod(string tfm)
     {
         this.compilation = this.starterCompilations[tfm];
-        this.generator = this.CreateGenerator();
+        this.generator = this.CreateGenerator(includeDocs: true);
         const string methodName = "GetTickCount";
         Assert.True(this.generator.TryGenerateExternMethod(methodName, out _));
         this.CollectGeneratedCode(this.generator);
@@ -3208,9 +3208,9 @@ namespace Windows.Win32
         return compilation;
     }
 
-    private Generator CreateGenerator(GeneratorOptions? options = null, CSharpCompilation? compilation = null) => this.CreateGenerator(MetadataPath, options, compilation);
+    private Generator CreateGenerator(GeneratorOptions? options = null, CSharpCompilation? compilation = null, bool includeDocs = false) => this.CreateGenerator(MetadataPath, options, compilation, includeDocs);
 
-    private Generator CreateGenerator(string path, GeneratorOptions? options = null, CSharpCompilation? compilation = null) => new Generator(path, Docs.Get(ApiDocsPath), options ?? DefaultTestGeneratorOptions, compilation ?? this.compilation, this.parseOptions);
+    private Generator CreateGenerator(string path, GeneratorOptions? options = null, CSharpCompilation? compilation = null, bool includeDocs = false) => new Generator(path, includeDocs ? Docs.Get(ApiDocsPath) : null, options ?? DefaultTestGeneratorOptions, compilation ?? this.compilation, this.parseOptions);
 
     private static class MyReferenceAssemblies
     {


### PR DESCRIPTION
- Turn off API docs generation in most tests.
- Avoid mutating SyntaxList in a loop.  This was the single worst source of bad perf in the FullGeneration test, costing 20 seconds out of 1.9 minutes.
- Add cache for slow `FindTypeSymbolIfAlreadyAvailable` method.