### PR TITLE
Distribute COM interface friendly overloads across many classes

### DIFF
--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -896,11 +896,12 @@ public class GeneratorTests : IDisposable, IAsyncLifetime
         ClassDeclarationSyntax arrayExtensions = Assert.IsType<ClassDeclarationSyntax>(this.FindGeneratedType("InlineArrayIndexerExtensions").Single());
         Assert.Contains(arrayExtensions.AttributeLists, al => al.Attributes.Any(a => a.Name.ToString().Contains("GeneratedCode")));
 
-        ClassDeclarationSyntax overloadsExtensions = Assert.IsType<ClassDeclarationSyntax>(this.FindGeneratedType("FriendlyOverloadExtensions").Single());
-        Assert.Contains(overloadsExtensions.AttributeLists, al => al.Attributes.Any(a => a.Name.ToString().Contains("GeneratedCode")));
+        Assert.All(
+            this.compilation.SyntaxTrees.SelectMany(st => st.GetRoot().DescendantNodes().OfType<BaseTypeDeclarationSyntax>()).Where(btd => btd.Identifier.ValueText.EndsWith("_Extensions", StringComparison.Ordinal)),
+            e => Assert.Contains(e.AttributeLists, al => al.Attributes.Any(a => a.Name.ToString().Contains("GeneratedCode"))));
 
         ClassDeclarationSyntax sysFreeStringSafeHandleClass = Assert.IsType<ClassDeclarationSyntax>(this.FindGeneratedType("SysFreeStringSafeHandle").Single());
-        Assert.Contains(overloadsExtensions.AttributeLists, al => al.Attributes.Any(a => a.Name.ToString().Contains("GeneratedCode")));
+        Assert.Contains(sysFreeStringSafeHandleClass.AttributeLists, al => al.Attributes.Any(a => a.Name.ToString().Contains("GeneratedCode")));
     }
 
     [Fact]


### PR DESCRIPTION
In full generation, the `FriendlyOverloadExtensions.g.cs` file was by far the largest (over 10MB in size). The C# compiler compiles types in parallel, so a very large type represents a huge unit of work that cannot be broken down into parallel compilations. It also means very large allocations for the string that renders the entire string. Splitting this up into one class per COM interface should help compilation performance, particularly in our full generation test.