### PR TITLE
Allow PreserveSig to apply to all APIs

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Com.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Com.cs
@@ -661,6 +661,7 @@ public partial class Generator
     {
         return !IsHresult(signature.ReturnType)
             || (methodDefinition.ImplAttributes & MethodImplAttributes.PreserveSig) == MethodImplAttributes.PreserveSig
+            || this.options.ComInterop.PreserveSigMethods.Contains("*")
             || this.FindInteropDecorativeAttribute(methodDefinition.GetCustomAttributes(), CanReturnMultipleSuccessValuesAttribute) is not null
             || this.FindInteropDecorativeAttribute(methodDefinition.GetCustomAttributes(), CanReturnErrorsAsSuccessAttribute) is not null
             || this.options.ComInterop.PreserveSigMethods.Contains($"{ifaceName}.{methodName}")

--- a/src/Microsoft.Windows.CsWin32/Generator.Com.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Com.cs
@@ -86,7 +86,8 @@ public partial class Generator
     private TypeDeclarationSyntax DeclareInterfaceAsStruct(TypeDefinitionHandle typeDefHandle, ImmutableStack<QualifiedTypeDefinitionHandle> baseTypes, Context context)
     {
         TypeDefinition typeDef = this.Reader.GetTypeDefinition(typeDefHandle);
-        IdentifierNameSyntax ifaceName = IdentifierName(this.GetMangledIdentifier(this.Reader.GetString(typeDef.Name), context.AllowMarshaling, isManagedType: true));
+        string originalIfaceName = this.Reader.GetString(typeDef.Name);
+        IdentifierNameSyntax ifaceName = IdentifierName(this.GetMangledIdentifier(originalIfaceName, context.AllowMarshaling, isManagedType: true));
         IdentifierNameSyntax vtblFieldName = IdentifierName("lpVtbl");
         var members = new List<MemberDeclarationSyntax>();
         var vtblMembers = new List<MemberDeclarationSyntax>();
@@ -107,6 +108,7 @@ public partial class Generator
         HashSet<string> helperMethodsInStruct = new();
         ISet<string> declaredProperties = this.GetDeclarableProperties(
             allMethods.Select(qh => qh.Reader.GetMethodDefinition(qh.MethodHandle)),
+            originalIfaceName,
             allowNonConsecutiveAccessors: true);
         foreach (QualifiedMethodDefinitionHandle methodDefHandle in allMethods)
         {
@@ -154,7 +156,7 @@ public partial class Generator
 
             // We can declare this method as a property accessor if it represents a property.
             // We must also confirm that the property type is the same in both cases, because sometimes they aren't (e.g. IUIAutomationProxyFactoryEntry.ClassName).
-            if (this.TryGetPropertyAccessorInfo(methodDefinition.Method, out IdentifierNameSyntax? propertyName, out SyntaxKind? accessorKind, out TypeSyntax? propertyType) &&
+            if (this.TryGetPropertyAccessorInfo(methodDefinition.Method, originalIfaceName, out IdentifierNameSyntax? propertyName, out SyntaxKind? accessorKind, out TypeSyntax? propertyType) &&
                 declaredProperties.Contains(propertyName.Identifier.ValueText))
             {
                 StatementSyntax ThrowOnHRFailure(ExpressionSyntax hrExpression) => ExpressionStatement(InvocationExpression(
@@ -425,7 +427,7 @@ public partial class Generator
 
         var members = new List<MemberDeclarationSyntax>();
         var friendlyOverloads = new List<MethodDeclarationSyntax>();
-        ISet<string> declaredProperties = this.GetDeclarableProperties(allMethods.Select(this.Reader.GetMethodDefinition), allowNonConsecutiveAccessors: false);
+        ISet<string> declaredProperties = this.GetDeclarableProperties(allMethods.Select(this.Reader.GetMethodDefinition), actualIfaceName, allowNonConsecutiveAccessors: false);
 
         foreach (MethodDefinitionHandle methodDefHandle in allMethods)
         {
@@ -441,7 +443,7 @@ public partial class Generator
                 // Even if it could be represented as a property accessor, we cannot do so if a property by the same name was already declared in anything other than the previous row.
                 // Adding an accessor to a property later than the very next row would screw up the virtual method table ordering.
                 // We must also confirm that the property type is the same in both cases, because sometimes they aren't (e.g. IUIAutomationProxyFactoryEntry.ClassName).
-                if (this.TryGetPropertyAccessorInfo(methodDefinition, out IdentifierNameSyntax? propertyName, out SyntaxKind? accessorKind, out TypeSyntax? propertyType) && declaredProperties.Contains(propertyName.Identifier.ValueText))
+                if (this.TryGetPropertyAccessorInfo(methodDefinition, actualIfaceName, out IdentifierNameSyntax? propertyName, out SyntaxKind? accessorKind, out TypeSyntax? propertyType) && declaredProperties.Contains(propertyName.Identifier.ValueText))
                 {
                     AccessorDeclarationSyntax accessor = AccessorDeclaration(accessorKind.Value).WithSemicolonToken(Semicolon);
 
@@ -665,7 +667,7 @@ public partial class Generator
             || this.options.ComInterop.PreserveSigMethods.Contains(ifaceName.ToString());
     }
 
-    private ISet<string> GetDeclarableProperties(IEnumerable<MethodDefinition> methods, bool allowNonConsecutiveAccessors)
+    private ISet<string> GetDeclarableProperties(IEnumerable<MethodDefinition> methods, string ifaceName, bool allowNonConsecutiveAccessors)
     {
         Dictionary<string, (TypeSyntax Type, int Index)> goodProperties = new(StringComparer.Ordinal);
         HashSet<string> badProperties = new(StringComparer.Ordinal);
@@ -673,7 +675,7 @@ public partial class Generator
         foreach (MethodDefinition methodDefinition in methods)
         {
             rowIndex++;
-            if (this.TryGetPropertyAccessorInfo(methodDefinition, out IdentifierNameSyntax? propertyName, out SyntaxKind? accessorKind, out TypeSyntax? propertyType))
+            if (this.TryGetPropertyAccessorInfo(methodDefinition, ifaceName, out IdentifierNameSyntax? propertyName, out SyntaxKind? accessorKind, out TypeSyntax? propertyType))
             {
                 if (badProperties.Contains(propertyName.Identifier.ValueText))
                 {
@@ -709,7 +711,7 @@ public partial class Generator
         return goodProperties.Count == 0 ? ImmutableHashSet<string>.Empty : new HashSet<string>(goodProperties.Keys, StringComparer.Ordinal);
     }
 
-    private bool TryGetPropertyAccessorInfo(MethodDefinition methodDefinition, [NotNullWhen(true)] out IdentifierNameSyntax? propertyName, [NotNullWhen(true)] out SyntaxKind? accessorKind, [NotNullWhen(true)] out TypeSyntax? propertyType)
+    private bool TryGetPropertyAccessorInfo(MethodDefinition methodDefinition, string ifaceName, [NotNullWhen(true)] out IdentifierNameSyntax? propertyName, [NotNullWhen(true)] out SyntaxKind? accessorKind, [NotNullWhen(true)] out TypeSyntax? propertyType)
     {
         propertyName = null;
         accessorKind = null;
@@ -729,7 +731,9 @@ public partial class Generator
             return false;
         }
 
-        if ((methodDefinition.ImplAttributes & MethodImplAttributes.PreserveSig) == MethodImplAttributes.PreserveSig)
+        MethodSignature<TypeHandleInfo> signature = methodDefinition.DecodeSignature(SignatureHandleProvider.Instance, null);
+        string methodName = this.Reader.GetString(methodDefinition.Name);
+        if (this.UsePreserveSigForComMethod(methodDefinition, signature, ifaceName, methodName))
         {
             return false;
         }
@@ -740,7 +744,6 @@ public partial class Generator
             return false;
         }
 
-        string methodName = this.Reader.GetString(methodDefinition.Name);
         const string getterPrefix = "get_";
         const string setterPrefix = "put_";
         bool isGetter = methodName.StartsWith(getterPrefix, StringComparison.Ordinal);
@@ -748,7 +751,6 @@ public partial class Generator
 
         if (isGetter || isSetter)
         {
-            MethodSignature<TypeHandleInfo> signature = methodDefinition.DecodeSignature(SignatureHandleProvider.Instance, null);
             if (!IsHresult(signature.ReturnType))
             {
                 return false;

--- a/src/Microsoft.Windows.CsWin32/settings.schema.json
+++ b/src/Microsoft.Windows.CsWin32/settings.schema.json
@@ -17,12 +17,12 @@
       "type": "object",
       "properties": {
         "preserveSigMethods": {
-          "description": "Identifies methods or interfaces that should be generated as [PreserveSig].",
+          "description": "Identifies methods or interfaces that should be generated as [PreserveSig]. Use * to always generate PreserveSig methods.",
           "type": "array",
           "items": {
             "type": "string",
             "uniqueItems": true,
-            "pattern": "^[\\w_]+(?:\\.[\\w_]+)?$"
+            "pattern": "^[\\w_]+(?:\\.[\\w_]+)?$|^\\*$"
           }
         },
         "useIntPtrForComOutPointers": {

--- a/test/GenerationSandbox.Unmarshalled.Tests/GeneratedForm.cs
+++ b/test/GenerationSandbox.Unmarshalled.Tests/GeneratedForm.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable CA1812 // dead code
 
+using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Com.Events;
@@ -18,8 +19,11 @@ internal static unsafe class GeneratedForm
 
         // Default is non-preservesig
         VARIANT v = o.GetPublisherProperty(null);
+        BSTR bstr = o.MethodName;
 
-        // NativeMethods.json opts into PreserveSig for this particular method.
+        // NativeMethods.json opts into PreserveSig for these particular methods.
         HRESULT hr = o.GetSubscriberProperty(null, out v);
+        hr = o.get_MachineName(out SysFreeStringSafeHandle sh);
+        o.MachineName = bstr;
     }
 }

--- a/test/GenerationSandbox.Unmarshalled.Tests/NativeMethods.json
+++ b/test/GenerationSandbox.Unmarshalled.Tests/NativeMethods.json
@@ -5,7 +5,8 @@
   "allowMarshaling": false,
   "comInterop": {
     "preserveSigMethods": [
-      "IEventSubscription.GetSubscriberProperty"
+      "IEventSubscription.GetSubscriberProperty",
+      "IEventSubscription.get_MachineName"
     ]
   }
 }


### PR DESCRIPTION
This makes `*` a valid specifier to generate *all* APIs with `[PreserveSig]`.