### PR TITLE
Bring back the certain dependencies

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.nuspec
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.nuspec
@@ -48,6 +48,9 @@
     <file src="$BaseOutputPath$Microsoft.Windows.CsWin32.dll" target="analyzers\cs\Microsoft.Windows.CsWin32.dll" />
     <file src="$BaseOutputPath$MessagePack.dll" target="analyzers\cs\MessagePack.dll" />
     <file src="$BaseOutputPath$MessagePack.Annotations.dll" target="analyzers\cs\MessagePack.Annotations.dll" />
+    <file src="$BaseOutputPath$Microsoft.Bcl.AsyncInterfaces.dll" target="analyzers\cs\Microsoft.Bcl.AsyncInterfaces.dll" />
+    <file src="$BaseOutputPath$System.Text.Json.dll" target="analyzers\cs\System.Text.Json.dll" />
+    <file src="$BaseOutputPath$System.Text.Encodings.Web.dll" target="analyzers\cs\System.Text.Encodings.Web.dll" />
     <file src="readme.txt" target="readme.txt" />
     <file src="..\..\README.md" target="README.md" />
     <file src="..\..\NOTICE.txt" target="NOTICE.txt" />


### PR DESCRIPTION
fd653cf352147a808af46c72aff2ba0567a3322c (merged in #843) broke the source generator in VS for Windows. Evidently removing dependencies that msbuild already ships, but are not in the roslyn subfolder, was too many.