### PR TITLE
Remove NativeMethods.json + NativeMethods.txt from the None build action

### DIFF
--- a/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.props
+++ b/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.props
@@ -2,10 +2,12 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  
+
   <ItemGroup>
+    <None Remove="NativeMethods.json" />
+    <None Remove="NativeMethods.txt" />
     <AdditionalFiles Include="NativeMethods.json" Condition="Exists('NativeMethods.json')" />
-    <AdditionalFiles Include="NativeMethods.txt" Condition="Exists('NativeMethods.txt')"  />
+    <AdditionalFiles Include="NativeMethods.txt" Condition="Exists('NativeMethods.txt')" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since NativeMethods.json and NativeMethods.txt are added to the AdditionalFiles build action they appear twice in Rider.

Before this pull request:
<img width="245" alt="image" src="https://user-images.githubusercontent.com/51363/213421997-410da152-27cc-4870-8630-1a716bf56150.png">

After this pull request:
<img width="230" alt="image" src="https://user-images.githubusercontent.com/51363/213421948-7e32431e-c62d-4cb6-9149-e226b62ac019.png">
