### PR TITLE
Emit an explanatory warning when users request generation of `IDispatch` or `IUnknown`

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Invariants.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Invariants.cs
@@ -320,7 +320,9 @@ public partial class Generator
         .Add("ULARGE_INTEGER", "Use the C# ulong keyword instead.")
         .Add("OVERLAPPED", "Use System.Threading.NativeOverlapped instead.")
         .Add("POINT", "Use System.Drawing.Point instead.")
-        .Add("POINTF", "Use System.Drawing.PointF instead.");
+        .Add("POINTF", "Use System.Drawing.PointF instead.")
+        .Add("IUnknown", "This COM interface is implicit in the runtime. Interfaces that derive from it should apply the [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)] attribute instead.")
+        .Add("IDispatch", "This COM interface is implicit in the runtime. Interfaces that derive from it should apply the [InterfaceType(ComInterfaceType.InterfaceIsIDispatch)] attribute instead.");
 
     /// <summary>
     /// Gets a map of interop APIs that should not be generated when marshaling is allowed, and messages to emit in diagnostics if these APIs are ever directly requested.


### PR DESCRIPTION
Closes #861
