### PR TITLE
Fix for non-remotable COM interfaces

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -251,6 +251,7 @@ public partial class Generator
                     if (sizeParamIndex.HasValue
                         && externMethodDeclaration.ParameterList.Parameters.Count > sizeParamIndex.Value
                         && !(externMethodDeclaration.ParameterList.Parameters[sizeParamIndex.Value].Type is PointerTypeSyntax)
+                        && !(externMethodDeclaration.ParameterList.Parameters[sizeParamIndex.Value].Modifiers.Any(SyntaxKind.OutKeyword) || externMethodDeclaration.ParameterList.Parameters[sizeParamIndex.Value].Modifiers.Any(SyntaxKind.RefKeyword))
                         && !isPointerToPointer)
                     {
                         signatureChanged = true;
@@ -290,7 +291,7 @@ public partial class Generator
 
                         arguments[sizeParamIndex.Value] = Argument(sizeArgExpression);
                     }
-                    else if (sizeConst.HasValue && !isPointerToPointer && this.canUseSpan)
+                    else if (sizeConst.HasValue && !isPointerToPointer && this.canUseSpan && externParam.Type is PointerTypeSyntax)
                     {
                         // TODO: add support for lists of pointers via a generated pointer-wrapping struct
                         signatureChanged = true;

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -136,7 +136,7 @@ public partial class Generator : IDisposable
         this.fieldOfHandleTypeDefTypeSettings = this.generalTypeSettings with { PreferNativeInt = false };
         this.externSignatureTypeSettings = this.generalTypeSettings with { QualifyNames = true, PreferMarshaledTypes = options.AllowMarshaling };
         this.externReleaseSignatureTypeSettings = this.externSignatureTypeSettings with { PreferNativeInt = false, PreferMarshaledTypes = false };
-        this.comSignatureTypeSettings = this.generalTypeSettings with { QualifyNames = true };
+        this.comSignatureTypeSettings = this.generalTypeSettings with { QualifyNames = true, PreferInOutRef = options.AllowMarshaling };
         this.extensionMethodSignatureTypeSettings = this.generalTypeSettings with { QualifyNames = true };
         this.functionPointerTypeSettings = this.generalTypeSettings with { QualifyNames = true };
         this.errorMessageTypeSettings = this.generalTypeSettings with { QualifyNames = true, Generator = null }; // Avoid risk of infinite recursion from errors in ToTypeSyntax

--- a/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
@@ -9,8 +9,8 @@ internal record PointerTypeHandleInfo(TypeHandleInfo ElementType) : TypeHandleIn
 
     internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes)
     {
-        TypeSyntaxAndMarshaling elementTypeDetails = this.ElementType.ToTypeSyntax(inputs, customAttributes);
-        if (elementTypeDetails.MarshalAsAttribute is object || inputs.Generator?.IsManagedType(this.ElementType) is true)
+        TypeSyntaxAndMarshaling elementTypeDetails = this.ElementType.ToTypeSyntax(inputs with { PreferInOutRef = false }, customAttributes);
+        if (elementTypeDetails.MarshalAsAttribute is object || inputs.Generator?.IsManagedType(this.ElementType) is true || (inputs.PreferInOutRef && this.ElementType is PrimitiveTypeHandleInfo { PrimitiveTypeCode: not PrimitiveTypeCode.Void }))
         {
             bool xIn = (parameterAttributes & ParameterAttributes.In) == ParameterAttributes.In;
             bool xOut = (parameterAttributes & ParameterAttributes.Out) == ParameterAttributes.Out;

--- a/src/Microsoft.Windows.CsWin32/TypeSyntaxSettings.cs
+++ b/src/Microsoft.Windows.CsWin32/TypeSyntaxSettings.cs
@@ -3,6 +3,6 @@
 
 namespace Microsoft.Windows.CsWin32;
 
-internal record TypeSyntaxSettings(Generator? Generator, bool PreferNativeInt, bool PreferMarshaledTypes, bool AllowMarshaling, bool QualifyNames, bool IsField = false)
+internal record TypeSyntaxSettings(Generator? Generator, bool PreferNativeInt, bool PreferMarshaledTypes, bool AllowMarshaling, bool QualifyNames, bool IsField = false, bool PreferInOutRef = false)
 {
 }

--- a/test/GenerationSandbox.Tests/ComRuntimeTests.cs
+++ b/test/GenerationSandbox.Tests/ComRuntimeTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Windows.Win32;
+using Windows.Win32.UI.Shell;
+using IServiceProvider = Windows.Win32.System.Com.IServiceProvider;
+
+public class ComRuntimeTests
+{
+    [Fact]
+    public void RemotableInterface()
+    {
+        IShellWindows shellWindows = (IShellWindows)new ShellWindows();
+        IServiceProvider serviceProvider = (IServiceProvider)shellWindows.FindWindowSW(
+            PInvoke.CSIDL_DESKTOP,
+            null,
+            (int)ShellWindowTypeConstants.SWC_DESKTOP,
+            out int hwnd,
+            (int)ShellWindowFindWindowOptions.SWFO_NEEDDISPATCH);
+    }
+}

--- a/test/GenerationSandbox.Tests/GenerationSandbox.Tests.csproj
+++ b/test/GenerationSandbox.Tests/GenerationSandbox.Tests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\GenerationSandbox.props" />
 
+  <ItemGroup>
+    <Compile Remove="ComRuntimeTests.cs" Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />
+  </ItemGroup>
+
   <ProjectExtensions>
     <VisualStudio><UserProperties nativemethods_1json__JsonSchema="..\..\src\Microsoft.Windows.CsWin32\settings.schema.json" /></VisualStudio>
   </ProjectExtensions>

--- a/test/GenerationSandbox.Tests/NativeMethods.txt
+++ b/test/GenerationSandbox.Tests/NativeMethods.txt
@@ -3,6 +3,7 @@ BOOLEAN
 CHAR
 CreateCursor
 CreateFile
+CSIDL_DESKTOP
 DISPLAYCONFIG_VIDEO_SIGNAL_INFO
 EnumWindows
 GetProcAddress
@@ -13,6 +14,8 @@ HDC_UserSize
 IDirectorySearch
 IEnumDebugPropertyInfo
 IPersistFile
+IServiceProvider
+IShellWindows
 KEY_EVENT_RECORD
 LoadLibrary
 MainAVIHeader
@@ -25,6 +28,9 @@ RECT
 RegLoadAppKey
 RM_PROCESS_INFO
 ShellLink
+ShellWindowFindWindowOptions
+ShellWindows
+ShellWindowTypeConstants
 SHFILEOPSTRUCTW
 SIZE
 VARDESC

--- a/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
@@ -241,14 +241,21 @@ public class COMTests : GeneratorTestBase
     }
 
     [Theory]
-    [InlineData("IVssCreateWriterMetadata")] // A non-COM compliant interface (since it doesn't derive from IUnknown).
-    [InlineData("IProtectionPolicyManagerInterop3")] // An IInspectable-derived interface.
-    [InlineData("ICompositionCapabilitiesInteropFactory")] // An interface with managed types.
-    [InlineData("IPicture")] // An interface with properties that cannot be represented as properties.
-    public void InterestingComInterfaces(string api)
+    [CombinatorialData]
+    public void InterestingComInterfaces(
+        [CombinatorialValues(
+            "IVssCreateWriterMetadata", // A non-COM compliant interface (since it doesn't derive from IUnknown).
+            "IProtectionPolicyManagerInterop3", // An IInspectable-derived interface.
+            "ICompositionCapabilitiesInteropFactory", // An interface with managed types.
+            "IPicture", // An interface with properties that cannot be represented as properties.
+            "ID2D1DeviceContext2", // CreateLookupTable3D takes fixed length arrays as parameters
+            "IVPBaseConfig", // GetConnectInfo has a CountParamIndex that points to an [In, Out] parameter.
+            "IWMDMDevice2")] // The GetSpecifyPropertyPages method has an NativeArrayInfo.CountParamIndex pointing at an [Out] parameter.
+        string api,
+        bool allowMarshaling)
     {
         this.compilation = this.starterCompilations["net6.0"];
-        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions with { AllowMarshaling = false });
+        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions with { AllowMarshaling = allowMarshaling });
         Assert.True(this.generator.TryGenerate(api, CancellationToken.None));
         this.CollectGeneratedCode(this.generator);
         this.AssertNoDiagnostics();

--- a/test/SpellChecker/Program.cs
+++ b/test/SpellChecker/Program.cs
@@ -60,7 +60,7 @@ unsafe
                 IEnumString suggestions = spellChecker.Suggest(word);
                 do
                 {
-                    suggestions.Next(suggestionResult, null);
+                    suggestions.Next(suggestionResult, out _);
                     if (suggestionResult[0].Value is not null)
                     {
                         Console.WriteLine($"\t{suggestionResult[0]}");


### PR DESCRIPTION
We now prefer to use `in`, `out` and `ref` modifiers on parameters instead of pointers, even on the original interface method definition. The reason is the CLR and Core CLR cannot marshal pointers across processes, but it can marshal these modifiers without a problem. Some interfaces are used across these boundaries, although CsWin32 doesn't know which. So we just err on generating interfaces that _can_ be used in this way.

This does unfortunately mean that some methods that took pointers and had overloads that took `Span<T>` no longer will, which means more marshaling and more array allocations. This only impacts the less perf-critical (and default) scenario where marshaling is allowed though, so I don't think it will be a big problem.

Fixes #860