### PR TITLE
Generate more friendly overloads on net35

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -203,8 +203,7 @@ public partial class Generator
             }
             else if ((externParam.Type is PointerTypeSyntax { ElementType: TypeSyntax ptrElementType }
                 && !IsVoid(ptrElementType)
-                && !this.IsInterface(parameterTypeInfo)
-                && this.canUseSpan) ||
+                && !this.IsInterface(parameterTypeInfo)) ||
                 externParam.Type is ArrayTypeSyntax)
             {
                 TypeSyntax elementType = externParam.Type is PointerTypeSyntax ptr ? ptr.ElementType
@@ -249,6 +248,7 @@ public partial class Generator
                     // It is possible that sizeParamIndex points to a parameter that is not on the extern method
                     // when the parameter is the last one and was moved to a return value.
                     if (sizeParamIndex.HasValue
+                        && this.canUseSpan
                         && externMethodDeclaration.ParameterList.Parameters.Count > sizeParamIndex.Value
                         && !(externMethodDeclaration.ParameterList.Parameters[sizeParamIndex.Value].Type is PointerTypeSyntax)
                         && !(externMethodDeclaration.ParameterList.Parameters[sizeParamIndex.Value].Modifiers.Any(SyntaxKind.OutKeyword) || externMethodDeclaration.ParameterList.Parameters[sizeParamIndex.Value].Modifiers.Any(SyntaxKind.RefKeyword))

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -50,6 +50,17 @@ public class GeneratorTests : GeneratorTestBase
 
     [Theory]
     [MemberData(nameof(TFMData))]
+    public void CoCreateInstance(string tfm)
+    {
+        this.compilation = this.starterCompilations[tfm];
+        this.generator = this.CreateGenerator(includeDocs: true);
+        Assert.True(this.generator.TryGenerateExternMethod("CoCreateInstance", out _));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+    }
+
+    [Theory]
+    [MemberData(nameof(TFMData))]
     public void SimplestMethod(string tfm)
     {
         this.compilation = this.starterCompilations[tfm];


### PR DESCRIPTION
We were excluding certain friendly overloads on net35 on the basis that `Span<T>` isn't supported there, even when the friendly overloads didn't require that type. With this change, we have fine-tuned the exclusion to only restrict the friendly overloads' parameter changes that would require `Span<T>`. This fixes #888.