### PR TITLE
Remove System.Drawing type references when the assembly isn't referenced

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -113,6 +113,7 @@ public partial class Generator : IDisposable
             AddSymbolIf(this.canCallCreateSpan, "canCallCreateSpan");
             AddSymbolIf(this.canUseUnsafeAsRef, "canUseUnsafeAsRef");
             AddSymbolIf(this.canUseUnsafeNullRef, "canUseUnsafeNullRef");
+            AddSymbolIf(compilation?.GetTypeByMetadataName("System.Drawing.Point") is not null, "canUseSystemDrawing");
 
             if (extraSymbols.Count > 0)
             {

--- a/src/Microsoft.Windows.CsWin32/templates/RECT.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/RECT.cs
@@ -1,9 +1,11 @@
 ﻿partial struct RECT
 {
+#if canUseSystemDrawing
 	internal RECT(global::System.Drawing.Rectangle value) :
 		this(value.Left, value.Top, value.Right, value.Bottom) { }
 	internal RECT(global::System.Drawing.Point location, global::System.Drawing.Size size) :
 		this(location.X, location.Y, unchecked(location.X + size.Width), unchecked(location.Y + size.Height)) { }
+#endif
 	internal RECT(int left, int top, int right, int bottom)
 	{
 		this.left = left;
@@ -19,8 +21,10 @@
 	internal readonly bool IsEmpty => this.left == 0 && this.top == 0 && this.right == 0 && this.bottom == 0;
 	internal readonly int X => this.left;
 	internal readonly int Y => this.top;
+#if canUseSystemDrawing
 	internal readonly global::System.Drawing.Size Size => new global::System.Drawing.Size(this.Width, this.Height);
 	public static implicit operator global::System.Drawing.Rectangle(RECT value) => new global::System.Drawing.Rectangle(value.left, value.top, value.Width, value.Height);
 	public static implicit operator global::System.Drawing.RectangleF(RECT value) => new global::System.Drawing.RectangleF(value.left, value.top, value.Width, value.Height);
 	public static implicit operator RECT(global::System.Drawing.Rectangle value) => new RECT(value);
+#endif
 }

--- a/src/Microsoft.Windows.CsWin32/templates/SIZE.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/SIZE.cs
@@ -1,6 +1,8 @@
 ﻿partial struct SIZE
 {
+#if canUseSystemDrawing
 	internal SIZE(global::System.Drawing.Size value) : this(value.Width, value.Height) { }
+#endif
 	internal SIZE(int width, int height)
 	{
 		this.cx = width;
@@ -10,6 +12,8 @@
 	internal readonly int Width => this.cx;
 	internal readonly int Height => this.cy;
 	internal readonly bool IsEmpty => this.cx == 0 && this.cy == 0;
+#if canUseSystemDrawing
 	public static implicit operator global::System.Drawing.Size(SIZE value) => new global::System.Drawing.Size(value.cx, value.cy);
 	public static implicit operator SIZE(global::System.Drawing.Size value) => new SIZE(value);
+#endif
 }


### PR DESCRIPTION
Fixes #934