### PR TITLE
Use MSBuild computed full paths for input metadata

### DIFF
--- a/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.props
+++ b/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.props
@@ -19,8 +19,8 @@
   <Target Name="AssembleCsWin32InputPaths" BeforeTargets="GenerateMSBuildEditorConfigFileCore">
     <!-- Roslyn only allows source generators to see msbuild properties, to lift msbuild items into semicolon-delimited properties. -->
     <PropertyGroup>
-      <CsWin32InputMetadataPaths>@(ProjectionMetadataWinmd,'|')</CsWin32InputMetadataPaths>
-      <CsWin32InputDocPaths>@(ProjectionDocs,'|')</CsWin32InputDocPaths>
+      <CsWin32InputMetadataPaths>@(ProjectionMetadataWinmd->'%(FullPath)','|')</CsWin32InputMetadataPaths>
+      <CsWin32InputDocPaths>@(ProjectionDocs->'%(FullPath)','|')</CsWin32InputDocPaths>
     </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
This fixes an issue @riverar reported in #356.