### PR TITLE
Fix constant wildcard ambiguity warnings

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Constant.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Constant.cs
@@ -85,7 +85,7 @@ public partial class Generator
     /// <param name="possiblyQualifiedName">The name of the constant, optionally qualified with a namespace.</param>
     /// <param name="preciseApi">Receives the canonical API names that <paramref name="possiblyQualifiedName"/> matched on.</param>
     /// <returns><see langword="true"/> if a match was found and the constant generated; otherwise <see langword="false"/>.</returns>
-    public bool TryGenerateConstant(string possiblyQualifiedName, out IReadOnlyList<string> preciseApi)
+    public bool TryGenerateConstant(string possiblyQualifiedName, out IReadOnlyCollection<string> preciseApi)
     {
         if (possiblyQualifiedName is null)
         {

--- a/src/Microsoft.Windows.CsWin32/Generator.Extern.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Extern.cs
@@ -92,7 +92,7 @@ public partial class Generator
     }
 
     /// <inheritdoc/>
-    public bool TryGenerateExternMethod(string possiblyQualifiedName, out IReadOnlyList<string> preciseApi)
+    public bool TryGenerateExternMethod(string possiblyQualifiedName, out IReadOnlyCollection<string> preciseApi)
     {
         if (possiblyQualifiedName is null)
         {

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -315,7 +315,7 @@ public partial class Generator : IGenerator, IDisposable
     }
 
     /// <inheritdoc/>
-    public bool TryGenerate(string apiNameOrModuleWildcard, out IReadOnlyList<string> preciseApi, CancellationToken cancellationToken)
+    public bool TryGenerate(string apiNameOrModuleWildcard, out IReadOnlyCollection<string> preciseApi, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(apiNameOrModuleWildcard))
         {
@@ -390,7 +390,7 @@ public partial class Generator : IGenerator, IDisposable
     /// <param name="namespace">The namespace to generate APIs for.</param>
     /// <param name="preciseApi">Receives the canonical API names that <paramref name="namespace"/> matched on.</param>
     /// <returns><see langword="true"/> if a matching namespace was found; otherwise <see langword="false"/>.</returns>
-    public bool TryGenerateNamespace(string @namespace, out IReadOnlyList<string> preciseApi)
+    public bool TryGenerateNamespace(string @namespace, out IReadOnlyCollection<string> preciseApi)
     {
         if (@namespace is null)
         {
@@ -506,7 +506,7 @@ public partial class Generator : IGenerator, IDisposable
     }
 
     /// <inheritdoc/>
-    public bool TryGenerateType(string possiblyQualifiedName, out IReadOnlyList<string> preciseApi)
+    public bool TryGenerateType(string possiblyQualifiedName, out IReadOnlyCollection<string> preciseApi)
     {
         if (possiblyQualifiedName is null)
         {
@@ -575,7 +575,7 @@ public partial class Generator : IGenerator, IDisposable
     /// <param name="macroName">The name of the macro. Never qualified with a namespace.</param>
     /// <param name="preciseApi">Receives the canonical API names that <paramref name="macroName"/> matched on.</param>
     /// <returns><see langword="true"/> if a match was found and the macro generated; otherwise <see langword="false"/>.</returns>
-    public bool TryGenerateMacro(string macroName, out IReadOnlyList<string> preciseApi)
+    public bool TryGenerateMacro(string macroName, out IReadOnlyCollection<string> preciseApi)
     {
         if (macroName is null)
         {

--- a/src/Microsoft.Windows.CsWin32/GeneratorExtensions.cs
+++ b/src/Microsoft.Windows.CsWin32/GeneratorExtensions.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Windows.CsWin32;
 /// </summary>
 public static class GeneratorExtensions
 {
-    /// <inheritdoc cref="IGenerator.TryGenerate(string, out IReadOnlyList{string}, CancellationToken)"/>
+    /// <inheritdoc cref="IGenerator.TryGenerate(string, out IReadOnlyCollection{string}, CancellationToken)"/>
     public static bool TryGenerate(this IGenerator generator, string apiNameOrModuleWildcard, CancellationToken cancellationToken) => generator.TryGenerate(apiNameOrModuleWildcard, out _, cancellationToken);
 
-    /// <inheritdoc cref="IGenerator.TryGenerateType(string, out IReadOnlyList{string})"/>
+    /// <inheritdoc cref="IGenerator.TryGenerateType(string, out IReadOnlyCollection{string})"/>
     public static bool TryGenerateType(this IGenerator generator, string possiblyQualifiedName) => generator.TryGenerateType(possiblyQualifiedName, out _);
 }

--- a/src/Microsoft.Windows.CsWin32/IGenerator.cs
+++ b/src/Microsoft.Windows.CsWin32/IGenerator.cs
@@ -15,7 +15,7 @@ public interface IGenerator : IDisposable
     /// <param name="preciseApi">Receives the canonical API names that <paramref name="apiNameOrModuleWildcard"/> matched on.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns><see langword="true" /> if any matching APIs were found and generated; <see langword="false"/> otherwise.</returns>
-    bool TryGenerate(string apiNameOrModuleWildcard, out IReadOnlyList<string> preciseApi, CancellationToken cancellationToken);
+    bool TryGenerate(string apiNameOrModuleWildcard, out IReadOnlyCollection<string> preciseApi, CancellationToken cancellationToken);
 
     /// <summary>
     /// Collects the result of code generation.
@@ -30,7 +30,7 @@ public interface IGenerator : IDisposable
     /// <param name="possiblyQualifiedName">The name of the interop type, optionally qualified with a namespace.</param>
     /// <param name="preciseApi">Receives the canonical API names that <paramref name="possiblyQualifiedName"/> matched on.</param>
     /// <returns><see langword="true"/> if a match was found and the type generated; otherwise <see langword="false"/>.</returns>
-    bool TryGenerateType(string possiblyQualifiedName, out IReadOnlyList<string> preciseApi);
+    bool TryGenerateType(string possiblyQualifiedName, out IReadOnlyCollection<string> preciseApi);
 
     /// <summary>
     /// Generates a projection of all extern methods and their supporting types.
@@ -56,7 +56,7 @@ public interface IGenerator : IDisposable
     /// <param name="possiblyQualifiedName">The name of the extern method, optionally qualified with a namespace.</param>
     /// <param name="preciseApi">Receives the canonical API names that <paramref name="possiblyQualifiedName"/> matched on.</param>
     /// <returns><see langword="true"/> if a match was found and the extern method generated; otherwise <see langword="false"/>.</returns>
-    bool TryGenerateExternMethod(string possiblyQualifiedName, out IReadOnlyList<string> preciseApi);
+    bool TryGenerateExternMethod(string possiblyQualifiedName, out IReadOnlyCollection<string> preciseApi);
 
     /// <summary>
     /// Generates a projection of all macros.

--- a/src/Microsoft.Windows.CsWin32/PrimitiveTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PrimitiveTypeHandleInfo.cs
@@ -14,10 +14,10 @@ internal record PrimitiveTypeHandleInfo(PrimitiveTypeCode PrimitiveTypeCode) : T
         // Even if the lengths match, if the enum's underlying base type conflicts with the primitive's signed type (e.g. int != uint),
         // certain CPU architectures can fail as well.
         // So we just have to use the primitive type when marshaling is not allowed.
-        if (inputs.AllowMarshaling && inputs.Generator?.FindAssociatedEnum(customAttributes) is NameSyntax enumTypeName && inputs.Generator.TryGenerateType(enumTypeName.ToString(), out IReadOnlyList<string> preciseMatch))
+        if (inputs.AllowMarshaling && inputs.Generator?.FindAssociatedEnum(customAttributes) is NameSyntax enumTypeName && inputs.Generator.TryGenerateType(enumTypeName.ToString(), out IReadOnlyCollection<string> preciseMatch))
         {
             // Use the qualified name.
-            enumTypeName = ParseName(Generator.ReplaceCommonNamespaceWithAlias(inputs.Generator, preciseMatch[0]));
+            enumTypeName = ParseName(Generator.ReplaceCommonNamespaceWithAlias(inputs.Generator, preciseMatch.First()));
             MarshalAsAttribute marshalAs = new(GetUnmanagedType(this.PrimitiveTypeCode));
             return new TypeSyntaxAndMarshaling(enumTypeName, marshalAs, nativeArrayInfo: null);
         }

--- a/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
+++ b/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
@@ -233,7 +233,7 @@ public class SourceGenerator : ISourceGenerator
                             continue;
                         }
 
-                        superGenerator.TryGenerate(name, out IReadOnlyList<string> matchingApis, out IReadOnlyList<string> redirectedEnums, context.CancellationToken);
+                        superGenerator.TryGenerate(name, out IReadOnlyCollection<string> matchingApis, out IReadOnlyCollection<string> redirectedEnums, context.CancellationToken);
                         foreach (string declaringEnum in redirectedEnums)
                         {
                             context.ReportDiagnostic(Diagnostic.Create(UseEnumValueDeclaringType, location, declaringEnum));
@@ -269,18 +269,19 @@ public class SourceGenerator : ISourceGenerator
                 context.AddSource(unit.Key, unit.Value.GetText(Encoding.UTF8));
             }
 
-            string ConcatSuggestions(IReadOnlyList<string> suggestions)
+            string ConcatSuggestions(IReadOnlyCollection<string> suggestions)
             {
                 var suggestionBuilder = new StringBuilder();
-                for (int i = 0; i < suggestions.Count; i++)
+                int i = 0;
+                foreach (string suggestion in suggestions)
                 {
-                    if (i > 0)
+                    if (++i > 0)
                     {
                         suggestionBuilder.Append(i < suggestions.Count - 1 ? ", " : " or ");
                     }
 
                     suggestionBuilder.Append('"');
-                    suggestionBuilder.Append(suggestions[i]);
+                    suggestionBuilder.Append(suggestion);
                     suggestionBuilder.Append('"');
                 }
 

--- a/src/Microsoft.Windows.CsWin32/SuperGenerator.cs
+++ b/src/Microsoft.Windows.CsWin32/SuperGenerator.cs
@@ -59,28 +59,28 @@ public class SuperGenerator : IGenerator, IDisposable
     }
 
     /// <inheritdoc/>
-    public bool TryGenerate(string apiNameOrModuleWildcard, out IReadOnlyList<string> preciseApi, CancellationToken cancellationToken) => this.TryGenerate(apiNameOrModuleWildcard, out preciseApi, out _, cancellationToken);
+    public bool TryGenerate(string apiNameOrModuleWildcard, out IReadOnlyCollection<string> preciseApi, CancellationToken cancellationToken) => this.TryGenerate(apiNameOrModuleWildcard, out preciseApi, out _, cancellationToken);
 
-    /// <inheritdoc cref="TryGenerate(string, out IReadOnlyList{string}, CancellationToken)"/>
-    /// <param name="apiNameOrModuleWildcard"><inheritdoc cref="TryGenerate(string, out IReadOnlyList{string}, CancellationToken)" path="/param[@name='apiNameOrModuleWildcard']"/></param>
-    /// <param name="preciseApi"><inheritdoc cref="TryGenerate(string, out IReadOnlyList{string}, CancellationToken)" path="/param[@name='preciseApi']"/></param>
+    /// <inheritdoc cref="TryGenerate(string, out IReadOnlyCollection{string}, CancellationToken)"/>
+    /// <param name="apiNameOrModuleWildcard"><inheritdoc cref="TryGenerate(string, out IReadOnlyCollection{string}, CancellationToken)" path="/param[@name='apiNameOrModuleWildcard']"/></param>
+    /// <param name="preciseApi"><inheritdoc cref="TryGenerate(string, out IReadOnlyCollection{string}, CancellationToken)" path="/param[@name='preciseApi']"/></param>
     /// <param name="redirectedEnums">Receives names of the enum that declares <paramref name="apiNameOrModuleWildcard"/> as an enum value.</param>
-    /// <param name="cancellationToken"><inheritdoc cref="TryGenerate(string, out IReadOnlyList{string}, CancellationToken)" path="/param[@name='cancellationToken']"/></param>
-    public bool TryGenerate(string apiNameOrModuleWildcard, out IReadOnlyList<string> preciseApi, out IReadOnlyList<string> redirectedEnums, CancellationToken cancellationToken)
+    /// <param name="cancellationToken"><inheritdoc cref="TryGenerate(string, out IReadOnlyCollection{string}, CancellationToken)" path="/param[@name='cancellationToken']"/></param>
+    public bool TryGenerate(string apiNameOrModuleWildcard, out IReadOnlyCollection<string> preciseApi, out IReadOnlyCollection<string> redirectedEnums, CancellationToken cancellationToken)
     {
-        List<string> preciseApiAccumulator = new();
-        List<string> redirectedEnumsAccumulator = new();
+        HashSet<string> preciseApiAccumulator = new(StringComparer.Ordinal);
+        HashSet<string> redirectedEnumsAccumulator = new(StringComparer.Ordinal);
         bool success = false;
         foreach (Generator generator in this.Generators.Values)
         {
             if (generator.TryGenerate(apiNameOrModuleWildcard, out preciseApi, cancellationToken))
             {
-                preciseApiAccumulator.AddRange(preciseApi);
+                preciseApiAccumulator.UnionWith(preciseApi);
                 success = true;
                 continue;
             }
 
-            preciseApiAccumulator.AddRange(preciseApi);
+            preciseApiAccumulator.UnionWith(preciseApi);
             if (generator.TryGetEnumName(apiNameOrModuleWildcard, out string? declaringEnum))
             {
                 redirectedEnumsAccumulator.Add(declaringEnum);
@@ -89,7 +89,7 @@ public class SuperGenerator : IGenerator, IDisposable
                     success = true;
                 }
 
-                preciseApiAccumulator.AddRange(preciseApi);
+                preciseApiAccumulator.UnionWith(preciseApi);
             }
         }
 
@@ -99,7 +99,7 @@ public class SuperGenerator : IGenerator, IDisposable
     }
 
     /// <inheritdoc/>
-    public bool TryGenerateType(string possiblyQualifiedName, out IReadOnlyList<string> preciseApi)
+    public bool TryGenerateType(string possiblyQualifiedName, out IReadOnlyCollection<string> preciseApi)
     {
         List<string> preciseApiAccumulator = new();
         bool success = false;
@@ -141,7 +141,7 @@ public class SuperGenerator : IGenerator, IDisposable
     }
 
     /// <inheritdoc/>
-    public bool TryGenerateExternMethod(string possiblyQualifiedName, out IReadOnlyList<string> preciseApi)
+    public bool TryGenerateExternMethod(string possiblyQualifiedName, out IReadOnlyCollection<string> preciseApi)
     {
         List<string> preciseApiAccumulator = new();
         bool success = false;

--- a/test/Microsoft.Windows.CsWin32.Tests/StructTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/StructTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Windows.Sdk
     public void SpecialStruct_ByRequest(string structName)
     {
         this.generator = this.CreateGenerator();
-        Assert.True(this.generator.TryGenerate(structName, out IReadOnlyList<string> preciseApi, CancellationToken.None));
+        Assert.True(this.generator.TryGenerate(structName, out IReadOnlyCollection<string> preciseApi, CancellationToken.None));
         Assert.Single(preciseApi);
         this.CollectGeneratedCode(this.generator);
         this.AssertNoDiagnostics();


### PR DESCRIPTION
When a wildcard matches against multiple metadata assemblies, the source generator would report a senseless diagnostic to the user about an ambiguity that they cannot and need not resolve.

Fixes #988