### PR TITLE
Emit `Unsafe.AsRef(in Value[0])`

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.InlineArrays.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.InlineArrays.cs
@@ -212,7 +212,7 @@ public partial class Generator
                 nameColon: null,
                 TokenWithSpace(SyntaxKind.RefKeyword),
                 InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName(nameof(Unsafe)), IdentifierName(nameof(Unsafe.AsRef))))
-                    .WithArgumentList(ArgumentList().AddArguments(Argument(value0))));
+                    .WithArgumentList(ArgumentList().AddArguments(Argument(value0).WithRefKindKeyword(Token(SyntaxKind.InKeyword)))));
 
             // MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(Value[0]), Length)
             InvocationExpressionSyntax createReadOnlySpanInvocation = InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName("MemoryMarshal"), IdentifierName("CreateReadOnlySpan")))


### PR DESCRIPTION
Fixes #1014

The regression test for this requires a newer compiler than is available via nuget.org today. I have the test ready to go once we have a newer compiler available 