### PR TITLE
Add helpful operators and constants to `BOOL`

### DIFF
--- a/src/Microsoft.Windows.CsWin32/templates/BOOL.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/BOOL.cs
@@ -1,6 +1,11 @@
 ﻿partial struct BOOL
 {
+	public const int Size = sizeof(int);
+	public static BOOL TRUE { get; } = new(true);
+	public static BOOL FALSE { get; } = new(false);
 	internal BOOL(bool value) => this.Value = value ? 1 : 0;
 	public static implicit operator bool(BOOL value) => value.Value != 0;
 	public static implicit operator BOOL(bool value) => new BOOL(value);
+	public static bool operator true(BOOL value) => value.Value != 0;
+	public static bool operator false(BOOL value) => value.Value == 0;
 }


### PR DESCRIPTION
These are things we found useful in Winforms and now would like to use in `System.Drawing` without having to link our partial file to both projects.

https://github.com/dotnet/winforms/blob/7bfbde5453eeeaea582006a683f247f6912fc7ac/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/BOOL.cs