### PR TITLE
Fix NullReferenceException in friendly overloads of COM methods with optional pointer parameters

### DIFF
--- a/src/Microsoft.Windows.CsWin32/ArrayTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/ArrayTypeHandleInfo.cs
@@ -7,9 +7,9 @@ internal record ArrayTypeHandleInfo(TypeHandleInfo ElementType, ArrayShape Shape
 {
     public override string ToString() => this.ToTypeSyntaxForDisplay().ToString();
 
-    internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes)
+    internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, Generator.GeneratingElement forElement, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes)
     {
-        TypeSyntaxAndMarshaling element = this.ElementType.ToTypeSyntax(inputs, customAttributes);
+        TypeSyntaxAndMarshaling element = this.ElementType.ToTypeSyntax(inputs, forElement, customAttributes);
         if (inputs.AllowMarshaling || inputs.IsField)
         {
             ArrayTypeSyntax arrayType = ArrayType(element.Type, SingletonList(ArrayRankSpecifier().AddSizes(this.Shape.Sizes.Select(size => LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(size))).ToArray<ExpressionSyntax>())));

--- a/src/Microsoft.Windows.CsWin32/Generator.Constant.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Constant.cs
@@ -261,7 +261,7 @@ public partial class Generator
         {
             ArrayTypeHandleInfo { ElementType: PrimitiveTypeHandleInfo { PrimitiveTypeCode: PrimitiveTypeCode.Byte } } pointerType => this.CreateByteArrayConstant(argsAsString),
             PrimitiveTypeHandleInfo primitiveType => ToExpressionSyntax(primitiveType.PrimitiveTypeCode, argsAsString),
-            HandleTypeHandleInfo handleType => this.CreateConstant(argsAsString, targetType.ToTypeSyntax(this.fieldTypeSettings, null).Type, (TypeReferenceHandle)handleType.Handle),
+            HandleTypeHandleInfo handleType => this.CreateConstant(argsAsString, targetType.ToTypeSyntax(this.fieldTypeSettings, GeneratingElement.Constant, null).Type, (TypeReferenceHandle)handleType.Handle),
             _ => throw new GenerationFailedException($"Unsupported constant type: {targetType}"),
         };
     }
@@ -334,7 +334,7 @@ public partial class Generator
         CustomAttributeValue<TypeSyntax> args = constantAttribute.DecodeValue(CustomAttributeTypeProvider.Instance);
         return this.CreateConstant(
             ((string)args.FixedArguments[0].Value!).AsMemory(),
-            targetType.ToTypeSyntax(this.fieldTypeSettings, null).Type,
+            targetType.ToTypeSyntax(this.fieldTypeSettings, GeneratingElement.Constant, null).Type,
             targetTypeRefHandle);
     }
 
@@ -345,7 +345,7 @@ public partial class Generator
         {
             TypeHandleInfo fieldTypeInfo = fieldDef.DecodeSignature(SignatureHandleProvider.Instance, null) with { IsConstantField = true };
             CustomAttributeHandleCollection customAttributes = fieldDef.GetCustomAttributes();
-            TypeSyntaxAndMarshaling fieldType = fieldTypeInfo.ToTypeSyntax(this.fieldTypeSettings, customAttributes);
+            TypeSyntaxAndMarshaling fieldType = fieldTypeInfo.ToTypeSyntax(this.fieldTypeSettings, GeneratingElement.Constant, customAttributes);
             ExpressionSyntax value =
                 fieldDef.GetDefaultValue() is { IsNil: false } constantHandle ? ToExpressionSyntax(this.Reader, constantHandle) :
                 this.FindInteropDecorativeAttribute(customAttributes, nameof(GuidAttribute)) is CustomAttribute guidAttribute ? GuidValue(guidAttribute) :

--- a/src/Microsoft.Windows.CsWin32/Generator.Delegate.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Delegate.cs
@@ -54,10 +54,10 @@ public partial class Generator
         }
 
         this.GetSignatureForDelegate(typeDef, out MethodDefinition invokeMethodDef, out MethodSignature<TypeHandleInfo> signature, out CustomAttributeHandleCollection? returnTypeAttributes);
-        TypeSyntaxAndMarshaling returnValue = signature.ReturnType.ToTypeSyntax(typeSettings, returnTypeAttributes);
+        TypeSyntaxAndMarshaling returnValue = signature.ReturnType.ToTypeSyntax(typeSettings, GeneratingElement.Delegate, returnTypeAttributes);
 
         DelegateDeclarationSyntax result = DelegateDeclaration(returnValue.Type, Identifier(name))
-            .WithParameterList(FixTrivia(this.CreateParameterList(invokeMethodDef, signature, typeSettings)))
+            .WithParameterList(FixTrivia(this.CreateParameterList(invokeMethodDef, signature, typeSettings, GeneratingElement.Delegate)))
             .AddModifiers(TokenWithSpace(this.Visibility), TokenWithSpace(SyntaxKind.UnsafeKeyword));
         result = returnValue.AddReturnMarshalAs(result);
 
@@ -149,6 +149,6 @@ public partial class Generator
             return FunctionPointerParameter(delegateTypeDef.Generator.FunctionPointer(delegateTypeDef.Definition));
         }
 
-        return FunctionPointerParameter(parameterTypeInfo.ToTypeSyntax(this.functionPointerTypeSettings, customAttributeHandles).GetUnmarshaledType());
+        return FunctionPointerParameter(parameterTypeInfo.ToTypeSyntax(this.functionPointerTypeSettings, GeneratingElement.FunctionPointer, customAttributeHandles).GetUnmarshaledType());
     }
 }

--- a/src/Microsoft.Windows.CsWin32/Generator.Enum.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Enum.cs
@@ -21,7 +21,7 @@ public partial class Generator
             ConstantHandle valueHandle = fieldDef.GetDefaultValue();
             if (valueHandle.IsNil)
             {
-                enumBaseType = fieldDef.DecodeSignature(SignatureHandleProvider.Instance, null).ToTypeSyntax(this.enumTypeSettings, null).Type;
+                enumBaseType = fieldDef.DecodeSignature(SignatureHandleProvider.Instance, null).ToTypeSyntax(this.enumTypeSettings, GeneratingElement.EnumValue, null).Type;
                 continue;
             }
 

--- a/src/Microsoft.Windows.CsWin32/Generator.Extern.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Extern.cs
@@ -196,7 +196,7 @@ public partial class Generator
             bool requiresUnicodeCharSet = signature.ParameterTypes.Any(p => p is PrimitiveTypeHandleInfo { PrimitiveTypeCode: PrimitiveTypeCode.Char });
 
             CustomAttributeHandleCollection? returnTypeAttributes = this.GetReturnTypeCustomAttributes(methodDefinition);
-            TypeSyntaxAndMarshaling returnType = signature.ReturnType.ToTypeSyntax(typeSettings, returnTypeAttributes, ParameterAttributes.Out);
+            TypeSyntaxAndMarshaling returnType = signature.ReturnType.ToTypeSyntax(typeSettings, GeneratingElement.ExternMethod, returnTypeAttributes, ParameterAttributes.Out);
 
             // Search for any enum substitutions.
             TypeSyntax? returnTypeEnumName = this.FindAssociatedEnum(returnTypeAttributes);
@@ -231,7 +231,7 @@ public partial class Generator
                 explicitInterfaceSpecifier: null!,
                 SafeIdentifier(methodName),
                 null!,
-                this.CreateParameterList(methodDefinition, signature, typeSettings),
+                this.CreateParameterList(methodDefinition, signature, typeSettings, GeneratingElement.ExternMethod),
                 List<TypeParameterConstraintClauseSyntax>(),
                 body: null!,
                 TokenWithLineFeed(SyntaxKind.SemicolonToken));
@@ -259,7 +259,7 @@ public partial class Generator
             {
                 string ns = this.GetMethodNamespace(methodDefinition);
                 NameSyntax nsSyntax = ParseName(ReplaceCommonNamespaceWithAlias(this, ns));
-                ParameterListSyntax exposedParameterList = this.CreateParameterList(methodDefinition, signature, typeSettings);
+                ParameterListSyntax exposedParameterList = this.CreateParameterList(methodDefinition, signature, typeSettings, GeneratingElement.ExternMethod);
                 static SyntaxToken RefInOutKeyword(ParameterSyntax p) =>
                     p.Modifiers.Any(SyntaxKind.OutKeyword) ? TokenWithSpace(SyntaxKind.OutKeyword) :
                     p.Modifiers.Any(SyntaxKind.RefKeyword) ? TokenWithSpace(SyntaxKind.RefKeyword) :

--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -126,7 +126,7 @@ public partial class Generator
                         .WithModifiers(TokenList(TokenWithSpace(SyntaxKind.OutKeyword)));
 
                     // HANDLE SomeLocal;
-                    leadingStatements.Add(LocalDeclarationStatement(VariableDeclaration(pointedElementInfo.ToTypeSyntax(parameterTypeSyntaxSettings, null).Type).AddVariables(
+                    leadingStatements.Add(LocalDeclarationStatement(VariableDeclaration(pointedElementInfo.ToTypeSyntax(parameterTypeSyntaxSettings, GeneratingElement.FriendlyOverload, null).Type).AddVariables(
                         VariableDeclarator(typeDefHandleName.Identifier))));
 
                     // Argument: &SomeLocal

--- a/src/Microsoft.Windows.CsWin32/Generator.Handle.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Handle.cs
@@ -40,7 +40,7 @@ public partial class Generator
 
             MethodSignature<TypeHandleInfo> releaseMethodSignature = releaseMethodDef.DecodeSignature(SignatureHandleProvider.Instance, null);
             TypeHandleInfo releaseMethodParameterTypeHandleInfo = releaseMethodSignature.ParameterTypes[0];
-            TypeSyntaxAndMarshaling releaseMethodParameterType = releaseMethodParameterTypeHandleInfo.ToTypeSyntax(this.externSignatureTypeSettings, default);
+            TypeSyntaxAndMarshaling releaseMethodParameterType = releaseMethodParameterTypeHandleInfo.ToTypeSyntax(this.externSignatureTypeSettings, GeneratingElement.HelperClassMember, default);
 
             // If the release method takes more than one parameter, we can't generate a SafeHandle for it.
             if (releaseMethodSignature.RequiredParameterCount != 1)
@@ -80,7 +80,7 @@ public partial class Generator
             IntPtr preferredInvalidValue = GetPreferredInvalidHandleValue(invalidHandleValues, new IntPtr(-1));
 
             CustomAttributeHandleCollection? atts = this.GetReturnTypeCustomAttributes(releaseMethodDef);
-            TypeSyntaxAndMarshaling releaseMethodReturnType = releaseMethodSignature.ReturnType.ToTypeSyntax(this.externSignatureTypeSettings, atts);
+            TypeSyntaxAndMarshaling releaseMethodReturnType = releaseMethodSignature.ReturnType.ToTypeSyntax(this.externSignatureTypeSettings, GeneratingElement.HelperClassMember, atts);
 
             this.TryGetRenamedMethod(releaseMethod, out string? renamedReleaseMethod);
 
@@ -134,7 +134,7 @@ public partial class Generator
             bool implicitConversion = typeDefStructFieldType is PrimitiveTypeHandleInfo { PrimitiveTypeCode: PrimitiveTypeCode.IntPtr } or PointerTypeHandleInfo;
             ArgumentSyntax releaseHandleArgument = Argument(CastExpression(
                 releaseMethodParameterType.Type,
-                implicitConversion ? thisHandle : CheckedExpression(CastExpression(typeDefStructFieldType!.ToTypeSyntax(this.fieldTypeSettings, null).Type, CastExpression(IdentifierName("nint"), thisHandle)))));
+                implicitConversion ? thisHandle : CheckedExpression(CastExpression(typeDefStructFieldType!.ToTypeSyntax(this.fieldTypeSettings, GeneratingElement.HelperClassMember, null).Type, CastExpression(IdentifierName("nint"), thisHandle)))));
 
             // protected override bool ReleaseHandle() => ReleaseMethod((struct)this.handle);
             // Special case release functions based on their return type as follows: (https://github.com/microsoft/win32metadata/issues/25)

--- a/src/Microsoft.Windows.CsWin32/Generator.InlineArrays.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.InlineArrays.cs
@@ -722,7 +722,7 @@ public partial class Generator
             }
             else
             {
-                qualifiedElementType = fieldTypeHandleInfo.ToTypeSyntax(this.extensionMethodSignatureTypeSettings, customAttributes).Type switch
+                qualifiedElementType = fieldTypeHandleInfo.ToTypeSyntax(this.extensionMethodSignatureTypeSettings, GeneratingElement.Other, customAttributes).Type switch
                 {
                     ArrayTypeSyntax at => at.ElementType,
                     PointerTypeSyntax ptrType => ptrType.ElementType,

--- a/src/Microsoft.Windows.CsWin32/Generator.MetadataHelpers.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.MetadataHelpers.cs
@@ -444,7 +444,7 @@ public partial class Generator
             }
             catch (Exception ex)
             {
-                throw new GenerationFailedException($"Unable to determine if {new HandleTypeHandleInfo(this.Reader, typeDefinitionHandle).ToTypeSyntax(this.errorMessageTypeSettings, null)} is a managed type.", ex);
+                throw new GenerationFailedException($"Unable to determine if {new HandleTypeHandleInfo(this.Reader, typeDefinitionHandle).ToTypeSyntax(this.errorMessageTypeSettings, GeneratingElement.Other, null)} is a managed type.", ex);
             }
         }
     }

--- a/src/Microsoft.Windows.CsWin32/Generator.Struct.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Struct.cs
@@ -70,7 +70,7 @@ public partial class Generator
                         }
                     }
 
-                    TypeSyntaxAndMarshaling fieldTypeSyntax = fieldTypeInfo.ToTypeSyntax(thisFieldTypeSettings, fieldAttributes);
+                    TypeSyntaxAndMarshaling fieldTypeSyntax = fieldTypeInfo.ToTypeSyntax(thisFieldTypeSettings, GeneratingElement.StructMember, fieldAttributes);
                     (TypeSyntax FieldType, SyntaxList<MemberDeclarationSyntax> AdditionalMembers, AttributeSyntax? MarshalAsAttribute) fieldInfo = this.ReinterpretFieldType(fieldDef, fieldTypeSyntax.Type, fieldAttributes, context);
                     additionalMembers = additionalMembers.AddRange(fieldInfo.AdditionalMembers);
 
@@ -195,7 +195,7 @@ public partial class Generator
         // then we must type it as an array.
         if (context.AllowMarshaling && fieldTypeHandleInfo is PointerTypeHandleInfo ptr3 && this.IsInterface(ptr3.ElementType))
         {
-            return (ArrayType(ptr3.ElementType.ToTypeSyntax(typeSettings, null).Type).AddRankSpecifiers(ArrayRankSpecifier()), default(SyntaxList<MemberDeclarationSyntax>), marshalAs);
+            return (ArrayType(ptr3.ElementType.ToTypeSyntax(typeSettings, GeneratingElement.Field, null).Type).AddRankSpecifiers(ArrayRankSpecifier()), default(SyntaxList<MemberDeclarationSyntax>), marshalAs);
         }
 
         return (originalType, default(SyntaxList<MemberDeclarationSyntax>), marshalAs);

--- a/src/Microsoft.Windows.CsWin32/Generator.TypeDef.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.TypeDef.cs
@@ -99,7 +99,7 @@ public partial class Generator
         VariableDeclaratorSyntax fieldDeclarator = VariableDeclarator(fieldIdentifierName.Identifier);
         CustomAttributeHandleCollection fieldAttributes = fieldDef.GetCustomAttributes();
         TypeHandleInfo fieldTypeInfo = fieldDef.DecodeSignature(SignatureHandleProvider.Instance, null);
-        TypeSyntaxAndMarshaling fieldType = fieldTypeInfo.ToTypeSyntax(typeSettings, fieldAttributes);
+        TypeSyntaxAndMarshaling fieldType = fieldTypeInfo.ToTypeSyntax(typeSettings, GeneratingElement.Field, fieldAttributes);
         (TypeSyntax FieldType, SyntaxList<MemberDeclarationSyntax> AdditionalMembers, AttributeSyntax? _) fieldInfo =
             this.ReinterpretFieldType(fieldDef, fieldType.Type, fieldAttributes, this.DefaultContext);
         SyntaxList<MemberDeclarationSyntax> members = List<MemberDeclarationSyntax>();

--- a/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
@@ -41,7 +41,7 @@ internal record HandleTypeHandleInfo : TypeHandleInfo
         }
     }
 
-    internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes = default)
+    internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, Generator.GeneratingElement forElement, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes = default)
     {
         NameSyntax? nameSyntax;
         bool isInterface;

--- a/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
@@ -7,7 +7,7 @@ internal record PointerTypeHandleInfo(TypeHandleInfo ElementType) : TypeHandleIn
 {
     public override string ToString() => this.ToTypeSyntaxForDisplay().ToString();
 
-    internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes)
+    internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, Generator.GeneratingElement forElement, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes)
     {
         // We can't marshal a pointer exposed as a field, unless it's a pointer to an array.
         if (inputs.AllowMarshaling && inputs.IsField && (customAttributes is null || inputs.Generator?.FindNativeArrayInfoAttribute(customAttributes.Value) is null))
@@ -15,7 +15,7 @@ internal record PointerTypeHandleInfo(TypeHandleInfo ElementType) : TypeHandleIn
             inputs = inputs with { AllowMarshaling = false };
         }
 
-        TypeSyntaxAndMarshaling elementTypeDetails = this.ElementType.ToTypeSyntax(inputs with { PreferInOutRef = false }, customAttributes);
+        TypeSyntaxAndMarshaling elementTypeDetails = this.ElementType.ToTypeSyntax(inputs with { PreferInOutRef = false }, forElement, customAttributes);
         bool xOptional = (parameterAttributes & ParameterAttributes.Optional) == ParameterAttributes.Optional;
         if (elementTypeDetails.MarshalAsAttribute is object || inputs.Generator?.IsManagedType(this.ElementType) is true || (inputs.PreferInOutRef && !xOptional && this.ElementType is PrimitiveTypeHandleInfo { PrimitiveTypeCode: not PrimitiveTypeCode.Void }))
         {

--- a/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
@@ -9,21 +9,37 @@ internal record PointerTypeHandleInfo(TypeHandleInfo ElementType) : TypeHandleIn
 
     internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, Generator.GeneratingElement forElement, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes)
     {
+        Generator.NativeArrayInfo? nativeArrayInfo = customAttributes.HasValue ? inputs.Generator?.FindNativeArrayInfoAttribute(customAttributes.Value) : null;
+
         // We can't marshal a pointer exposed as a field, unless it's a pointer to an array.
-        if (inputs.AllowMarshaling && inputs.IsField && (customAttributes is null || inputs.Generator?.FindNativeArrayInfoAttribute(customAttributes.Value) is null))
+        if (inputs.AllowMarshaling && inputs.IsField && (customAttributes is null || nativeArrayInfo is null))
         {
             inputs = inputs with { AllowMarshaling = false };
         }
 
-        TypeSyntaxAndMarshaling elementTypeDetails = this.ElementType.ToTypeSyntax(inputs with { PreferInOutRef = false }, forElement, customAttributes);
         bool xOptional = (parameterAttributes & ParameterAttributes.Optional) == ParameterAttributes.Optional;
-        if (elementTypeDetails.MarshalAsAttribute is object || inputs.Generator?.IsManagedType(this.ElementType) is true || (inputs.PreferInOutRef && !xOptional && this.ElementType is PrimitiveTypeHandleInfo { PrimitiveTypeCode: not PrimitiveTypeCode.Void }))
+        if (xOptional && forElement == Generator.GeneratingElement.InterfaceMember && nativeArrayInfo is null)
+        {
+            // Disable marshaling because pointers to optional parameters cannot be passed by reference when used as parameters of a COM interface method.
+            return new TypeSyntaxAndMarshaling(PointerType(this.ElementType.ToTypeSyntax(
+                inputs with
+                {
+                    AllowMarshaling = false,
+                    PreferInOutRef = false,
+                },
+                forElement,
+                customAttributes,
+                parameterAttributes).Type));
+        }
+
+        TypeSyntaxAndMarshaling elementTypeDetails = this.ElementType.ToTypeSyntax(inputs with { PreferInOutRef = false }, forElement, customAttributes, parameterAttributes);
+        if (elementTypeDetails.MarshalAsAttribute is object || (inputs.Generator?.IsManagedType(this.ElementType) is true) || (inputs.PreferInOutRef && !xOptional && this.ElementType is PrimitiveTypeHandleInfo { PrimitiveTypeCode: not PrimitiveTypeCode.Void }))
         {
             bool xIn = (parameterAttributes & ParameterAttributes.In) == ParameterAttributes.In;
             bool xOut = (parameterAttributes & ParameterAttributes.Out) == ParameterAttributes.Out;
 
             // A pointer to a marshaled object is not allowed.
-            if (inputs.AllowMarshaling && customAttributes.HasValue && inputs.Generator?.FindNativeArrayInfoAttribute(customAttributes.Value) is { } nativeArrayInfo)
+            if (inputs.AllowMarshaling && customAttributes.HasValue && nativeArrayInfo is not null)
             {
                 // But this pointer represents an array, so type as an array.
                 MarshalAsAttribute marshalAsAttribute = new MarshalAsAttribute(UnmanagedType.LPArray);

--- a/src/Microsoft.Windows.CsWin32/PrimitiveTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PrimitiveTypeHandleInfo.cs
@@ -7,7 +7,7 @@ internal record PrimitiveTypeHandleInfo(PrimitiveTypeCode PrimitiveTypeCode) : T
 {
     public override string ToString() => this.ToTypeSyntaxForDisplay().ToString();
 
-    internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes)
+    internal override TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, Generator.GeneratingElement forElement, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes)
     {
         // We want to expose the enum type when there is one, but doing it *properly* requires marshaling to the underlying type.
         // The length of the enum may differ from the length of the primitive type, which means we can't just use the enum type directly.

--- a/src/Microsoft.Windows.CsWin32/TypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/TypeHandleInfo.cs
@@ -9,7 +9,7 @@ internal abstract record TypeHandleInfo
 
     internal bool IsConstantField { get; init; }
 
-    internal abstract TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes = default);
+    internal abstract TypeSyntaxAndMarshaling ToTypeSyntax(TypeSyntaxSettings inputs, Generator.GeneratingElement forElement, CustomAttributeHandleCollection? customAttributes, ParameterAttributes parameterAttributes = default);
 
     internal abstract bool? IsValueType(TypeSyntaxSettings inputs);
 
@@ -32,7 +32,7 @@ internal abstract record TypeHandleInfo
         return true;
     }
 
-    protected TypeSyntax ToTypeSyntaxForDisplay() => this.ToTypeSyntax(DebuggerDisplaySettings, null).Type;
+    protected TypeSyntax ToTypeSyntaxForDisplay() => this.ToTypeSyntax(DebuggerDisplaySettings, Generator.GeneratingElement.Other, null).Type;
 
     protected Generator.Context GetContext(TypeSyntaxSettings inputs) => inputs.Generator is not null
         ? inputs.Generator.DefaultContext with { AllowMarshaling = inputs.AllowMarshaling }

--- a/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
@@ -267,6 +267,22 @@ public class COMTests : GeneratorTestBase
         this.GenerateApi(api);
     }
 
+    /// <summary>
+    /// Verifies that COM methods that accept `[Optional, In]` parameters are declared as pointers
+    /// rather than `in` parameters, since the marshaller will throw NRE if the reference is null (via <see cref="Unsafe.NullRef{T}"/>).
+    /// </summary>
+    /// <seealso href="https://github.com/microsoft/CsWin32/issues/1081"/>
+    [Fact]
+    public void OptionalInPointerParameterExposedAsPointer()
+    {
+        this.GenerateApi("IMMDevice");
+
+        MethodDeclarationSyntax comMethod = this.FindGeneratedMethod("Activate").First(m => !m.Modifiers.Any(SyntaxKind.StaticKeyword));
+        ParameterSyntax optionalInParam = comMethod.ParameterList.Parameters[2];
+        Assert.Empty(optionalInParam.Modifiers);
+        Assert.IsType<PointerTypeSyntax>(optionalInParam.Type);
+    }
+
     [Fact]
     public void EnvironmentFailFast()
     {

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTestBase.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTestBase.cs
@@ -146,10 +146,10 @@ public abstract class GeneratorTestBase : IDisposable, IAsyncLifetime
 
     protected static IEnumerable<AttributeSyntax> FindAttribute(SyntaxList<AttributeListSyntax> attributeLists, string name) => attributeLists.SelectMany(al => al.Attributes).Where(a => a.Name.ToString() == name);
 
-    protected void GenerateApi(string methodName)
+    protected void GenerateApi(string apiName)
     {
         this.generator ??= this.CreateGenerator();
-        Assert.True(this.generator.TryGenerate(methodName, CancellationToken.None));
+        Assert.True(this.generator.TryGenerate(apiName, CancellationToken.None));
         this.CollectGeneratedCode(this.generator);
         this.AssertNoDiagnostics();
     }

--- a/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/GeneratorTests.cs
@@ -483,7 +483,7 @@ public class GeneratorTests : GeneratorTestBase
         this.CollectGeneratedCode(this.generator);
         this.AssertNoDiagnostics();
 
-        var generatedMethod = this.FindGeneratedMethod("OMSetRenderTargets").Where(m => m.ParameterList.Parameters.Count == 3 && m.ParameterList.Parameters[0].Identifier.ValueText == "NumViews").FirstOrDefault();
+        var generatedMethod = this.FindGeneratedMethod("OMSetRenderTargets").FirstOrDefault(m => m.ParameterList.Parameters.Count == 3 && m.ParameterList.Parameters[0].Identifier.ValueText == "NumViews" && (!allowMarshaling || m.Parent is InterfaceDeclarationSyntax));
         Assert.NotNull(generatedMethod);
 
         if (allowMarshaling)


### PR DESCRIPTION
Optional parameters cannot be expressed with the `ref` modifier on COM methods in order to avoid a pointer type. Doing so disallows the possibility of passing in null. Even `Unsafe.NullRef<T>()` does not work because the .NET interop layer throws `NullReferenceException` when that's done.

Instead, we leave it as a pointer type.

An alternative to this may be to declare the parameter as an array that allows `null` or exactly 1 element. But the API wouldn't describe itself very well, and enforcement wouldn't exist, leading to possible runtime failures.

Fixes #1081

--- 

## AI generated summary

This pull request includes a significant number of changes to various files in the codebase. The most important changes include adding a new enum to categorize different elements being generated in `Generator.cs`, modifying methods in `Generator.Com.cs` to generate appropriate type syntax based on the generating element, and adding a new test method in `COMTests.cs` to verify the declaration of COM methods.

Main interface changes:

* [`src/Microsoft.Windows.CsWin32/Generator.cs`](diffhunk://#diff-41c4c1d1a283b8a616eddd20d7e5f2195d189d5fbccbef58666761430e66e315R154-R221): Added an enum called `GeneratingElement` to categorize different elements being generated and modified the `GetNamespaceForPossiblyNestedType` method to include an additional parameter for the `CreateParameterList` method. [[1]](diffhunk://#diff-41c4c1d1a283b8a616eddd20d7e5f2195d189d5fbccbef58666761430e66e315R154-R221) [[2]](diffhunk://#diff-41c4c1d1a283b8a616eddd20d7e5f2195d189d5fbccbef58666761430e66e315L1344-R1423)
* [`src/Microsoft.Windows.CsWin32/Generator.Com.cs`](diffhunk://#diff-76305bec094cfc5dda198cdfa20fe3e749b142529081f895eb9d37e9421d15bfL669-R673): Introduced changes to add new parameters to various methods for generating appropriate type syntax based on the generating element. [[1]](diffhunk://#diff-76305bec094cfc5dda198cdfa20fe3e749b142529081f895eb9d37e9421d15bfL669-R673) [[2]](diffhunk://#diff-76305bec094cfc5dda198cdfa20fe3e749b142529081f895eb9d37e9421d15bfL599-R599) [[3]](diffhunk://#diff-76305bec094cfc5dda198cdfa20fe3e749b142529081f895eb9d37e9421d15bfL975-R975) [[4]](diffhunk://#diff-76305bec094cfc5dda198cdfa20fe3e749b142529081f895eb9d37e9421d15bfL158-R161)
* [`test/Microsoft.Windows.CsWin32.Tests/COMTests.cs`](diffhunk://#diff-b7b4f4862eac70e5a6d445e3d201dcabe5536a809fc7af41f2f80c121d571745R270-R285): Added a new test method to verify the declaration of COM methods that accept `[Optional, In]` parameters.

Other important changes:

* [`src/Microsoft.Windows.CsWin32/Generator.Constant.cs`](diffhunk://#diff-aac3e0b8beca1ac9d13c1cd367d02430ec574772d35daacc15567f922ae51869L264-R264): Modified the `CreateConstant` method to include a new parameter `forElement` and modified the `ToTypeSyntax` method to include a new parameter `GeneratingElement.Constant`. [[1]](diffhunk://#diff-aac3e0b8beca1ac9d13c1cd367d02430ec574772d35daacc15567f922ae51869L264-R264) [[2]](diffhunk://#diff-aac3e0b8beca1ac9d13c1cd367d02430ec574772d35daacc15567f922ae51869L348-R348)
* [`src/Microsoft.Windows.CsWin32/Generator.Extern.cs`](diffhunk://#diff-a1536a3b11e83497a3c92a9832bbd8b2a5110f6177e9d66c22519ed29eab0e7cL234-R234): Added a new parameter `forElement` to the `CreateParameterList` method and the `ToTypeSyntax` method. [[1]](diffhunk://#diff-a1536a3b11e83497a3c92a9832bbd8b2a5110f6177e9d66c22519ed29eab0e7cL234-R234) [[2]](diffhunk://#diff-a1536a3b11e83497a3c92a9832bbd8b2a5110f6177e9d66c22519ed29eab0e7cL262-R262) [[3]](diffhunk://#diff-a1536a3b11e83497a3c92a9832bbd8b2a5110f6177e9d66c22519ed29eab0e7cL199-R199)
* [`src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs`](diffhunk://#diff-e45832bbfebade23609fbc37829bfc26033e388177b72a08d8c3f0fcfe98f956L129-R129): Modified the `CreateConstant` method to add a new parameter `forElement` to the `ToTypeSyntax` method.
* [`src/Microsoft.Windows.CsWin32/Generator.Handle.cs`](diffhunk://#diff-4ecc768b6ae4aa61791f3a68ccf481776a193784c31dfa9d238dd602bbe3c42cL83-R83): Added a new parameter to the `ToTypeSyntax` method and modified the code to pass a specific value based on the generating element. [[1]](diffhunk://#diff-4ecc768b6ae4aa61791f3a68ccf481776a193784c31dfa9d238dd602bbe3c42cL83-R83) [[2]](diffhunk://#diff-4ecc768b6ae4aa61791f3a68ccf481776a193784c31dfa9d238dd602bbe3c42cL137-R137) [[3]](diffhunk://#diff-4ecc768b6ae4aa61791f3a68ccf481776a193784c31dfa9d238dd602bbe3c42cL43-R43)

Please note that due to the large number of changes and limited space, only a subset of the changes are listed here.