### PR TITLE
Allow disabling of friendly overload generation

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -14,7 +14,7 @@ public partial class Generator
 
     private IEnumerable<MethodDeclarationSyntax> DeclareFriendlyOverloads(MethodDefinition methodDefinition, MethodDeclarationSyntax externMethodDeclaration, NameSyntax declaringTypeName, FriendlyOverloadOf overloadOf, HashSet<string> helperMethodsAdded)
     {
-        if (!this.options.FriendlyOverloads)
+        if (!this.options.FriendlyOverloads.Enabled)
         {
             yield break;
         }

--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -14,6 +14,11 @@ public partial class Generator
 
     private IEnumerable<MethodDeclarationSyntax> DeclareFriendlyOverloads(MethodDefinition methodDefinition, MethodDeclarationSyntax externMethodDeclaration, NameSyntax declaringTypeName, FriendlyOverloadOf overloadOf, HashSet<string> helperMethodsAdded)
     {
+        if (!this.options.FriendlyOverloads)
+        {
+            yield break;
+        }
+
         // If/when we ever need helper methods for the friendly overloads again, they can be added when used with code like this:
         ////if (helperMethodsAdded.Add(SomeHelperMethodName))
         ////{

--- a/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
+++ b/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
@@ -42,9 +42,9 @@ public record GeneratorOptions
     public bool AllowMarshaling { get; init; } = true;
 
     /// <summary>
-    /// Gets a value indicating whether to generate method overloads that may be easier to consume or be more idiomatic C#.
+    /// Gets options related to friendly overloads.
     /// </summary>
-    public bool FriendlyOverloads { get; init; } = true;
+    public FriendlyOverloadOptions FriendlyOverloads { get; init; } = new();
 
     /// <summary>
     /// Gets a value indicating whether to generate APIs judged to be unnecessary or redundant given the target framework
@@ -87,5 +87,17 @@ public record GeneratorOptions
         /// This may be useful on .NET when using ComWrappers. See <see href="https://github.com/microsoft/CsWin32/issues/328">this issue</see> for more details.
         /// </remarks>
         public bool UseIntPtrForComOutPointers { get; init; }
+    }
+
+    /// <summary>
+    /// Options for friendly overloads.
+    /// </summary>
+    public record FriendlyOverloadOptions
+    {
+        /// <summary>
+        /// Gets a value indicating whether to generate method overloads that may be easier to consume or be more idiomatic C#.
+        /// </summary>
+        /// <value>The default value is <see langword="true" />.</value>
+        public bool Enabled { get; init; } = true;
     }
 }

--- a/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
+++ b/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
@@ -42,6 +42,11 @@ public record GeneratorOptions
     public bool AllowMarshaling { get; init; } = true;
 
     /// <summary>
+    /// Gets a value indicating whether to generate method overloads that may be easier to consume or be more idiomatic C#.
+    /// </summary>
+    public bool FriendlyOverloads { get; init; } = true;
+
+    /// <summary>
     /// Gets a value indicating whether to generate APIs judged to be unnecessary or redundant given the target framework
     /// because the project multi-targets to frameworks that need the APIs consistently for easier coding.
     /// </summary>

--- a/src/Microsoft.Windows.CsWin32/settings.schema.json
+++ b/src/Microsoft.Windows.CsWin32/settings.schema.json
@@ -38,9 +38,15 @@
       "default": true
     },
     "friendlyOverloads": {
-      "description": "A value indicating whether to generate method overloads that may be easier to consume or be more idiomatic C#. These may use fewer pointers, accept or return SafeHandles, etc.",
-      "type": "boolean",
-      "default": true
+      "description": "An object with properties that control generation of friendly overloads.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "A value indicating whether to generate method overloads that may be easier to consume or be more idiomatic C#. These may use fewer pointers, accept or return SafeHandles, etc.",
+          "type": "boolean",
+          "default": true
+        }
+      }
     },
     "multiTargetingFriendlyAPIs": {
       "description": "A value indicating whether to generate APIs judged to be unnecessary or redundant given the target framework. This is useful for multi-targeting projects that need a consistent set of APIs across target frameworks to avoid too many conditional compilation regions.",

--- a/src/Microsoft.Windows.CsWin32/settings.schema.json
+++ b/src/Microsoft.Windows.CsWin32/settings.schema.json
@@ -37,6 +37,11 @@
       "type": "boolean",
       "default": true
     },
+    "friendlyOverloads": {
+      "description": "A value indicating whether to generate method overloads that may be easier to consume or be more idiomatic C#. These may use fewer pointers, accept or return SafeHandles, etc.",
+      "type": "boolean",
+      "default": true
+    },
     "multiTargetingFriendlyAPIs": {
       "description": "A value indicating whether to generate APIs judged to be unnecessary or redundant given the target framework. This is useful for multi-targeting projects that need a consistent set of APIs across target frameworks to avoid too many conditional compilation regions.",
       "type": "boolean",

--- a/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
@@ -22,7 +22,7 @@ public class FullGenerationTests : GeneratorTestBase
     [Fact]
     public void Everything_NoFriendlyOverloads()
     {
-        this.TestHelper(new GeneratorOptions { FriendlyOverloads = false }, Platform.X64, "net7.0", generator => generator.GenerateAll(CancellationToken.None));
+        this.TestHelper(new GeneratorOptions { FriendlyOverloads = new() { Enabled = false } }, Platform.X64, "net7.0", generator => generator.GenerateAll(CancellationToken.None));
     }
 
     [Trait("TestCategory", "FailsInCloudTest")] // these take ~4GB of memory to run.

--- a/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
@@ -19,6 +19,13 @@ public class FullGenerationTests : GeneratorTestBase
     }
 
     [Trait("TestCategory", "FailsInCloudTest")] // these take ~4GB of memory to run.
+    [Fact]
+    public void Everything_NoFriendlyOverloads()
+    {
+        this.TestHelper(new GeneratorOptions { FriendlyOverloads = false }, Platform.X64, "net7.0", generator => generator.GenerateAll(CancellationToken.None));
+    }
+
+    [Trait("TestCategory", "FailsInCloudTest")] // these take ~4GB of memory to run.
     [Theory, PairwiseData]
     public void Everything(
         MarshalingOptions marshaling,
@@ -26,7 +33,7 @@ public class FullGenerationTests : GeneratorTestBase
         [CombinatorialMemberData(nameof(AnyCpuArchitectures))] Platform platform,
         [CombinatorialMemberData(nameof(TFMDataNoNetFx35))] string tfm)
     {
-        this.TestHelper(marshaling, useIntPtrForComOutPtr, platform, tfm, generator => generator.GenerateAll(CancellationToken.None));
+        this.TestHelper(OptionsForMarshaling(marshaling, useIntPtrForComOutPtr), platform, tfm, generator => generator.GenerateAll(CancellationToken.None));
     }
 
     [Trait("TestCategory", "FailsInCloudTest")] // these take ~4GB of memory to run.
@@ -36,13 +43,13 @@ public class FullGenerationTests : GeneratorTestBase
         bool useIntPtrForComOutPtr,
         [CombinatorialMemberData(nameof(TFMDataNoNetFx35))] string tfm)
     {
-        this.TestHelper(marshaling, useIntPtrForComOutPtr, Platform.X64, tfm, generator => generator.GenerateAllInteropTypes(CancellationToken.None));
+        this.TestHelper(OptionsForMarshaling(marshaling, useIntPtrForComOutPtr), Platform.X64, tfm, generator => generator.GenerateAllInteropTypes(CancellationToken.None));
     }
 
     [Fact]
     public void Constants()
     {
-        this.TestHelper(marshaling: MarshalingOptions.FullMarshaling, useIntPtrForComOutPtr: false, Platform.X64, DefaultTFM, generator => generator.GenerateAllConstants(CancellationToken.None));
+        this.TestHelper(new GeneratorOptions(), Platform.X64, DefaultTFM, generator => generator.GenerateAllConstants(CancellationToken.None));
     }
 
     [Theory, PairwiseData]
@@ -52,23 +59,27 @@ public class FullGenerationTests : GeneratorTestBase
         [CombinatorialMemberData(nameof(SpecificCpuArchitectures))] Platform platform,
         [CombinatorialMemberData(nameof(TFMDataNoNetFx35))] string tfm)
     {
-        this.TestHelper(marshaling, useIntPtrForComOutPtr, platform, tfm, generator => generator.GenerateAllExternMethods(CancellationToken.None));
+        this.TestHelper(OptionsForMarshaling(marshaling, useIntPtrForComOutPtr), platform, tfm, generator => generator.GenerateAllExternMethods(CancellationToken.None));
     }
 
     [Fact]
     public void Macros()
     {
-        this.TestHelper(marshaling: MarshalingOptions.FullMarshaling, useIntPtrForComOutPtr: false, Platform.X64, DefaultTFM, generator => generator.GenerateAllMacros(CancellationToken.None));
+        this.TestHelper(new GeneratorOptions(), Platform.X64, DefaultTFM, generator => generator.GenerateAllMacros(CancellationToken.None));
     }
 
-    private void TestHelper(MarshalingOptions marshaling, bool useIntPtrForComOutPtr, Platform platform, string targetFramework, Action<IGenerator> generationCommands)
+    private static GeneratorOptions OptionsForMarshaling(MarshalingOptions marshaling, bool useIntPtrForComOutPtr) => new()
     {
-        var generatorOptions = new GeneratorOptions
+        AllowMarshaling = marshaling >= MarshalingOptions.MarshalingWithoutSafeHandles,
+        UseSafeHandles = marshaling == MarshalingOptions.FullMarshaling,
+        ComInterop = new()
         {
-            AllowMarshaling = marshaling >= MarshalingOptions.MarshalingWithoutSafeHandles,
-            UseSafeHandles = marshaling == MarshalingOptions.FullMarshaling,
-            ComInterop = new() { UseIntPtrForComOutPointers = useIntPtrForComOutPtr },
-        };
+            UseIntPtrForComOutPointers = useIntPtrForComOutPtr,
+        },
+    };
+
+    private void TestHelper(GeneratorOptions generatorOptions, Platform platform, string targetFramework, Action<IGenerator> generationCommands)
+    {
         this.compilation = this.starterCompilations[targetFramework];
         this.compilation = this.compilation.WithOptions(this.compilation.Options.WithPlatform(platform));
 


### PR DESCRIPTION
For amusing stats, generating "everything" produces 97MB of C# source code. Without friendly overloads, that number drops to 70MB.

Closes #1116 