### PR TITLE
Define constant members of structs as constants

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Struct.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Struct.cs
@@ -34,13 +34,28 @@ public partial class Generator
         foreach (FieldDefinitionHandle fieldDefHandle in typeDef.GetFields())
         {
             FieldDefinition fieldDef = this.Reader.GetFieldDefinition(fieldDefHandle);
+            FieldDeclarationSyntax field;
+
+            if (fieldDef.Attributes.HasFlag(FieldAttributes.Static))
+            {
+                if (fieldDef.Attributes.HasFlag(FieldAttributes.Literal))
+                {
+                    field = this.DeclareConstant(fieldDef);
+                    members.Add(field);
+                    continue;
+                }
+                else
+                {
+                    throw new NotSupportedException();
+                }
+            }
+
             string fieldName = this.Reader.GetString(fieldDef.Name);
 
             try
             {
                 CustomAttribute? fixedBufferAttribute = this.FindAttribute(fieldDef.GetCustomAttributes(), SystemRuntimeCompilerServices, nameof(FixedBufferAttribute));
 
-                FieldDeclarationSyntax field;
                 VariableDeclaratorSyntax fieldDeclarator = VariableDeclarator(SafeIdentifier(fieldName));
                 if (fixedBufferAttribute.HasValue)
                 {

--- a/test/Microsoft.Windows.CsWin32.Tests/StructTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/StructTests.cs
@@ -234,6 +234,16 @@ namespace Microsoft.Windows.Sdk
         var type = (StructDeclarationSyntax)Assert.Single(this.FindGeneratedType(structName));
     }
 
+    [Fact]
+    public void StructConstantsAreGeneratedAsConstants()
+    {
+        this.GenerateApi("Color");
+        var type = (StructDeclarationSyntax)Assert.Single(this.FindGeneratedType("Color"));
+        FieldDeclarationSyntax argb = Assert.Single(type.Members.OfType<FieldDeclarationSyntax>().Where(f => !(f.Modifiers.Any(SyntaxKind.StaticKeyword) || f.Modifiers.Any(SyntaxKind.ConstKeyword))));
+        Assert.Equal("Argb", argb.Declaration.Variables.Single().Identifier.ValueText);
+        Assert.NotEmpty(type.Members.OfType<FieldDeclarationSyntax>().Where(f => f.Modifiers.Any(SyntaxKind.ConstKeyword)));
+    }
+
     [Theory]
     [CombinatorialData]
     public void InterestingStructs(


### PR DESCRIPTION
Before this change, they were emitted as instance fields.

Fixes #1121