### PR TITLE
Always use pointers when referencing structs with variable-length inline arrays

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -103,9 +103,16 @@ public partial class Generator
 
             TypeHandleInfo parameterTypeInfo = originalSignature.ParameterTypes[param.SequenceNumber - 1];
             bool isManagedParameterType = this.IsManagedType(parameterTypeInfo);
+            bool mustRemainAsPointer = parameterTypeInfo is PointerTypeHandleInfo { ElementType: HandleTypeHandleInfo pointedElement } && this.IsStructWithFlexibleArray(pointedElement);
+
             IdentifierNameSyntax origName = IdentifierName(externParam.Identifier.ValueText);
 
-            if (isReserved && !isOut)
+            if (mustRemainAsPointer)
+            {
+                // This block intentionally left blank, so as to disable further processing that might try to
+                // replace a pointer with a `ref` or similar modifier.
+            }
+            else if (isReserved && !isOut)
             {
                 // Remove the parameter and supply the default value for the type to the extern method.
                 arguments[param.SequenceNumber - 1] = Argument(LiteralExpression(SyntaxKind.DefaultLiteralExpression));

--- a/src/Microsoft.Windows.CsWin32/Generator.Invariants.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Invariants.cs
@@ -77,6 +77,7 @@ public partial class Generator
     private const string AlsoUsableForAttribute = "AlsoUsableForAttribute";
     private const string InvalidHandleValueAttribute = "InvalidHandleValueAttribute";
     private const string CanReturnMultipleSuccessValuesAttribute = "CanReturnMultipleSuccessValuesAttribute";
+    private const string FlexibleArrayAttribute = "FlexibleArrayAttribute";
     private const string CanReturnErrorsAsSuccessAttribute = "CanReturnErrorsAsSuccessAttribute";
     private const string SimpleFileNameAnnotation = "SimpleFileName";
     private const string NamespaceContainerAnnotation = "NamespaceContainer";

--- a/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
@@ -18,7 +18,9 @@ internal record PointerTypeHandleInfo(TypeHandleInfo ElementType) : TypeHandleIn
         }
 
         bool xOptional = (parameterAttributes & ParameterAttributes.Optional) == ParameterAttributes.Optional;
-        if (xOptional && forElement == Generator.GeneratingElement.InterfaceMember && nativeArrayInfo is null)
+        bool mustUsePointers = xOptional && forElement == Generator.GeneratingElement.InterfaceMember && nativeArrayInfo is null;
+        mustUsePointers |= this.ElementType is HandleTypeHandleInfo handleElementType && inputs.Generator?.IsStructWithFlexibleArray(handleElementType) is true;
+        if (mustUsePointers)
         {
             // Disable marshaling because pointers to optional parameters cannot be passed by reference when used as parameters of a COM interface method.
             return new TypeSyntaxAndMarshaling(PointerType(this.ElementType.ToTypeSyntax(

--- a/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
@@ -380,6 +380,17 @@ public class COMTests : GeneratorTestBase
         this.GenerateApi(typeName);
     }
 
+    [Fact]
+    public void ReferencesToStructWithFlexibleArrayAreAlwaysPointers()
+    {
+        this.GenerateApi("IAMLine21Decoder");
+        Assert.All(this.FindGeneratedMethod("SetOutputFormat"), m => Assert.IsType<PointerTypeSyntax>(m.ParameterList.Parameters[0].Type));
+
+        // Assert that the 'unmanaged' declaration of the struct is the *only* declaration.
+        Assert.Single(this.FindGeneratedType("BITMAPINFO"));
+        Assert.Empty(this.FindGeneratedType("BITMAPINFO_unmanaged"));
+    }
+
     [Theory]
     [CombinatorialData]
     public void COMInterfaceIIDInterfaceOnAppropriateTFMs(

--- a/test/Microsoft.Windows.CsWin32.Tests/ExternMethodTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/ExternMethodTests.cs
@@ -75,6 +75,17 @@ public class ExternMethodTests : GeneratorTestBase
         Assert.DoesNotContain(attribute.ArgumentList!.Arguments, a => a.NameEquals?.Name.Identifier.ValueText == "EntryPoint");
     }
 
+    [Fact]
+    public void ReferencesToStructWithFlexibleArrayAreAlwaysPointers()
+    {
+        this.GenerateApi("CreateDIBSection");
+        Assert.All(this.FindGeneratedMethod("CreateDIBSection"), m => Assert.IsType<PointerTypeSyntax>(m.ParameterList.Parameters[1].Type));
+
+        // Assert that the 'unmanaged' declaration of the struct is the *only* declaration.
+        Assert.Single(this.FindGeneratedType("BITMAPINFO"));
+        Assert.Empty(this.FindGeneratedType("BITMAPINFO_unmanaged"));
+    }
+
     private static AttributeSyntax? FindDllImportAttribute(SyntaxList<AttributeListSyntax> attributeLists) => attributeLists.SelectMany(al => al.Attributes).FirstOrDefault(a => a.Name.ToString() == "DllImport");
 
     private IEnumerable<MethodDeclarationSyntax> GenerateMethod(string methodName)


### PR DESCRIPTION
Fixes #195