### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.4.3",
+      "version": "7.4.5",
       "commands": [
         "pwsh"
       ]
     },
     "dotnet-coverage": {
-      "version": "17.11.3",
+      "version": "17.12.3",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.139",
+      "version": "3.6.143",
       "commands": [
         "nbgv"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:8.0.300-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.400-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.editorconfig
+++ b/.editorconfig
@@ -198,5 +198,8 @@ dotnet_diagnostic.CA1062.severity = suggestion
 dotnet_diagnostic.MsgPack001.severity = error
 dotnet_diagnostic.MsgPack002.severity = error
 
+# CA2016: Forward the CancellationToken parameter
+dotnet_diagnostic.CA2016.severity = warning
+
 [*.sln]
 indent_style = tab

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
-    <MicroBuildVersion>2.0.162</MicroBuildVersion>
+    <MicroBuildVersion>2.0.165</MicroBuildVersion>
     <MetadataVersion>61.0.15-preview</MetadataVersion>
     <WDKMetadataVersion>0.12.8-experimental</WDKMetadataVersion>
     <!-- <DiaMetadataVersion>0.2.185-preview-g7e1e6a442c</DiaMetadataVersion> -->
@@ -23,7 +23,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />
     <!-- <PackageVersion Include="Microsoft.Dia.Win32Metadata" Version="0.2.185-preview-g7e1e6a442c" /> -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.Win32Docs" Version="$(ApiDocsVersion)" />
@@ -51,7 +51,7 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/azure-pipelines/OptProf.yml
+++ b/azure-pipelines/OptProf.yml
@@ -29,6 +29,8 @@ variables:
   value: false # avoid using nice version since we're building a preliminary/unoptimized package
 - name: IsOptProf
   value: true
+- name: MicroBuild_NuPkgSigningEnabled
+  value: false # test-signed nuget packages fail to restore in the VS insertion PR validations. Just don't sign them *at all*.
 
 stages:
 - stage: Library
@@ -40,12 +42,13 @@ stages:
   - template: build.yml
     parameters:
       Is1ESPT: false
-      RealSign: true
+      RealSign: false
       windowsPool: VSEngSS-MicroBuild2022-1ES
       EnableMacOSBuild: false
       ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
       IsOptProf: true
       RunTests: false
+      SkipCodesignVerify: true
 - stage: QueueVSBuild
   jobs:
   - job: QueueOptProf

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -65,6 +65,11 @@ parameters:
   type: boolean
   default: true
 
+# Whether this is a special one-off build for inserting into VS for a validation insertion PR (that will never be merged).
+- name: SkipCodesignVerify
+  type: boolean
+  default: false
+
 - name: EnableAPIScan
   type: boolean
   default: false
@@ -193,6 +198,7 @@ jobs:
       parameters:
         EnableOptProf: ${{ parameters.EnableOptProf }}
         IsOptProf: ${{ parameters.IsOptProf }}
+        SkipCodesignVerify: ${{ parameters.SkipCodesignVerify }}
 
 - ${{ if not(parameters.IsOptProf) }}:
   - ${{ if parameters.EnableLinuxBuild }}:

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -5,14 +5,17 @@ parameters:
 - name: IsOptProf
   type: boolean
   default: false
+- name: SkipCodesignVerify
+  type: boolean
 
 steps:
-- task: MicroBuildCodesignVerify@3
-  displayName: 🔍 Verify Signed Files
-  inputs:
-    TargetFolders: |
-      $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+- ${{ if not(parameters.SkipCodesignVerify) }}: # skip CodesignVerify on validation builds because we don't even test-sign nupkg's.
+  - task: MicroBuildCodesignVerify@3
+    displayName: 🔍 Verify Signed Files
+    inputs:
+      TargetFolders: |
+        $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - ${{ if parameters.IsOptProf }}:
   - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -9,7 +9,6 @@ parameters:
 stages:
 - stage: release
   displayName: Publish
-  condition: and(succeeded(), eq('${{ parameters.RealSign }}', 'true'))
   jobs:
   - ${{ if parameters.ArchiveSymbols }}:
     - job: symbol_archive
@@ -34,7 +33,10 @@ stages:
 
   - ${{ if true }}: # Switch to true to enable, but leave the condition to avoid merge conflicts later.
     - job: push
-      displayName: azure-public/winsdk feed
+      ${{ if parameters.RealSign }}:
+        displayName: azure-public/winsdk feed
+      ${{ else }}:
+        displayName: devdiv/vs-impl feed # Leave this as-is, since non-signed builds must not be pushed to public feeds.
       ${{ if parameters.ArchiveSymbols }}:
         dependsOn: symbol_archive
       pool:
@@ -49,8 +51,12 @@ stages:
           packagesToPush: '$(Pipeline.Workspace)/deployables-Windows/NuGet/*.nupkg'
           packageParentPath: $(Pipeline.Workspace)/deployables-Windows/NuGet
           allowPackageConflicts: true
-          nuGetFeedType: external
-          publishFeedCredentials: azure-public/winsdk/CI
+          ${{ if parameters.RealSign }}:
+            nuGetFeedType: external
+            publishFeedCredentials: azure-public/winsdk/CI
+          ${{ else }}:
+            nuGetFeedType: internal
+            publishVstsFeed: vs-impl # Leave this as-is, since non-signed builds must not be pushed to public feeds.
       steps:
       - checkout: none
       - download: current
@@ -61,7 +67,8 @@ stages:
       - download: current
         artifact: deployables-Windows
         displayName: 🔻 Download deployables-Windows artifact
-      - template: WIFtoPATauth.yml
-        parameters:
-          wifServiceConnectionName: azure-public/vside package push
-          deadPATServiceConnectionId: 9c66bbfe-03da-40f0-8ed7-23f599039d5d # azure-public/winsdk/CI
+      - ${{ if parameters.RealSign }}:
+        - template: WIFtoPATauth.yml
+          parameters:
+            wifServiceConnectionName: azure-public/vside package push
+            deadPATServiceConnectionId: 9c66bbfe-03da-40f0-8ed7-23f599039d5d # azure-public/winsdk/CI

--- a/azure-pipelines/publish-codecoverage.yml
+++ b/azure-pipelines/publish-codecoverage.yml
@@ -21,9 +21,8 @@ steps:
     continueOnError: true
 - powershell: azure-pipelines/Merge-CodeCoverage.ps1 -Path '$(Pipeline.Workspace)' -OutputFile coveragereport/merged.cobertura.xml -Format Cobertura -Verbose
   displayName: ⚙ Merge coverage
-- task: PublishCodeCoverageResults@1
+- task: PublishCodeCoverageResults@2
   displayName: 📢 Publish code coverage results to Azure DevOps
   inputs:
-    codeCoverageTool: cobertura
     summaryFileLocation: coveragereport/merged.cobertura.xml
     failIfCoverageEmpty: true

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -14,6 +14,8 @@ resources:
 
 variables:
 - template: GlobalVariables.yml
+- name: MicroBuild_NuPkgSigningEnabled
+  value: false # test-signed nuget packages fail to restore in the VS insertion PR validations. Just don't sign them *at all*.
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
@@ -27,21 +29,31 @@ extends:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages/
         BuildConfiguration: Release
-        ValidationBuild: true
+        SkipCodesignVerify: true
 
       jobs:
       - template: /azure-pipelines/build.yml@self
         parameters:
           Is1ESPT: true
-          RealSign: true
+          RealSign: false
           windowsPool: VSEngSS-MicroBuild2022-1ES
+          linuxPool:
+            name: AzurePipelines-EO
+            demands:
+            - ImageOverride -equals 1ESPT-Ubuntu22.04
+            os: Linux
+          macOSPool:
+            name: Azure Pipelines
+            vmImage: macOS-12
+            os: macOS
           EnableMacOSBuild: false
           RunTests: false
+          SkipCodesignVerify: true
 
     - template: /azure-pipelines/prepare-insertion-stages.yml@self
       parameters:
         ArchiveSymbols: false
-        RealSign: true
+        RealSign: false
 
     - stage: insertion
       displayName: VS insertion
@@ -73,12 +85,13 @@ extends:
           inputs:
             TeamName: $(TeamName)
             TeamEmail: $(TeamEmail)
-            InsertionPayloadName: $(Build.Repository.Name) VALIDATION BUILD $(Build.BuildNumber) ($(Build.SourceBranch)) [Skip-SymbolCheck]
+            InsertionPayloadName: $(Build.Repository.Name) VALIDATION BUILD $(Build.BuildNumber) ($(Build.SourceBranch)) [Skip-SymbolCheck] [Skip-HashCheck] [Skip-SignCheck]
             InsertionDescription: |
               This PR is for **validation purposes only** for !$(System.PullRequest.PullRequestId). **Do not complete**.
             CustomScriptExecutionCommand: src/VSSDK/NuGet/AllowUnstablePackages.ps1
             InsertionBuildPolicy: Request Perf DDRITs
             InsertionReviewers: $(Build.RequestedFor)
+            DraftPR: false # set to true and update InsertionBuildPolicy when we can specify all the validations we want to run (https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2224288)
             AutoCompletePR: false
             ShallowClone: true
         - powershell: |

--- a/azurepipelines-coverage.yml
+++ b/azurepipelines-coverage.yml
@@ -1,0 +1,6 @@
+# https://learn.microsoft.com/azure/devops/pipelines/test/codecoverage-for-pullrequests?view=azure-devops
+coverage:
+  status:
+    comments: on    # add comment to PRs reporting diff in coverage of modified files
+    diff:           # diff coverage is code coverage only for the lines changed in a pull request.
+      target: 70%   # set this to a desired %. Default is 70%

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "8.0.400",
     "rollForward": "patch",
     "allowPrerelease": false
   },


### PR DESCRIPTION
- **Update PublishCodeCoverageResults task to v2**
- **Enable CA2016: forward the CancellationToken**
- **Bump powershell from 7.4.3 to 7.4.4 (#277)**
- **Bump Nerdbank.GitVersioning from 3.6.139 to 3.6.141 (#280)**
- **Bump nbgv from 3.6.139 to 3.6.141 (#279)**
- **Bump dotnet-coverage from 17.11.3 to 17.11.5 (#278)**
- **Bump .NET SDK to 8.0.400**
- **Post code coverage diff comments for AzDO PRs**
- **Fix 1ES PT compliance of vs-validation pipeline**
- **Speed up validation insertions**
- **Bump MicroBuild to 2.0.165**
- **Bump Microsoft.NET.Test.Sdk to 17.11**
- **Bump powershell from 7.4.4 to 7.4.5 (#282)**
- **Change OptProf to not require real-signing**
- **Bump Nerdbank.GitVersioning from 3.6.141 to 3.6.143 (#283)**
- **Bump nbgv from 3.6.141 to 3.6.143 (#284)**
- **Bump dotnet-coverage from 17.11.5 to 17.12.2 (#285)**
- **Bump dotnet-coverage from 17.12.2 to 17.12.3 (#288)**
- **Bump Microsoft.NET.Test.Sdk from 17.11.0 to 17.11.1 (#287)**
