### PR TITLE
Use `ReadOnlySpan<T>` instead of `Span<T>` in more places

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -284,7 +284,7 @@ public partial class Generator
                         {
                             remainsRefType = false;
                             parameters[param.SequenceNumber - 1] = parameters[param.SequenceNumber - 1]
-                                .WithType((isIn && isConst ? MakeReadOnlySpanOfT(elementType) : MakeSpanOfT(elementType)).WithTrailingTrivia(TriviaList(Space)));
+                                .WithType((isIn ? MakeReadOnlySpanOfT(elementType) : MakeSpanOfT(elementType)).WithTrailingTrivia(TriviaList(Space)));
                             fixedBlocks.Add(VariableDeclaration(externParam.Type).AddVariables(
                                 VariableDeclarator(localName.Identifier).WithInitializer(EqualsValueClause(origName))));
                             arguments[param.SequenceNumber - 1] = Argument(localName);
@@ -323,7 +323,7 @@ public partial class Generator
 
                         // Accept a span instead of a pointer.
                         parameters[param.SequenceNumber - 1] = parameters[param.SequenceNumber - 1]
-                            .WithType((isIn && isConst ? MakeReadOnlySpanOfT(elementType) : MakeSpanOfT(elementType)).WithTrailingTrivia(TriviaList(Space)));
+                            .WithType((isIn ? MakeReadOnlySpanOfT(elementType) : MakeSpanOfT(elementType)).WithTrailingTrivia(TriviaList(Space)));
                         fixedBlocks.Add(VariableDeclaration(externParam.Type).AddVariables(
                             VariableDeclarator(localName.Identifier).WithInitializer(EqualsValueClause(origName))));
                         arguments[param.SequenceNumber - 1] = Argument(localName);

--- a/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
@@ -47,6 +47,16 @@ public class FriendlyOverloadTests : GeneratorTestBase
         Assert.Equal("DsGetDcCloseWSafeHandle", Assert.IsType<IdentifierNameSyntax>(method.ParameterList.Parameters.Last().Type).Identifier.ValueText);
     }
 
+    [Fact]
+    public void InAttributeOnArraysProjectedAsReadOnlySpan()
+    {
+        const string Method = "RmRegisterResources";
+        this.GenerateApi(Method);
+
+        MethodDeclarationSyntax method = Assert.Single(this.FindGeneratedMethod(Method), m => !IsOrContainsExternMethod(m));
+        Assert.Equal(3, method.ParameterList.Parameters.Count(p => p.Type is GenericNameSyntax { Identifier.ValueText: "ReadOnlySpan" }));
+    }
+
     private void Generate(string name)
     {
         this.compilation = this.compilation.WithOptions(this.compilation.Options.WithPlatform(Platform.X64));


### PR DESCRIPTION
Fixes #1211