### PR TITLE
Avoid using `UnscopedRefAttribute` on downlevel *compilers*

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Features.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Features.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Windows.CsWin32;
 
 public partial class Generator
 {
+    private readonly bool canUseUnscopedRef;
     private readonly bool canUseSpan;
     private readonly bool canCallCreateSpan;
     private readonly bool canUseUnsafeAsRef;

--- a/src/Microsoft.Windows.CsWin32/templates/VariableLengthInlineArray`1.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/VariableLengthInlineArray`1.cs
@@ -3,6 +3,8 @@
 {
 	internal T e0;
 
+#if canUseUnscopedRef
+
 #if canUseUnsafeAdd
 	internal ref T this[int index]
 	{
@@ -29,5 +31,7 @@
 		}
 #endif
 	}
+#endif
+
 #endif
 }


### PR DESCRIPTION
Fixes #1205