### PR TITLE
Use C# 13 overload resolution attribute to improve friendly overloads

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Features.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Features.cs
@@ -14,12 +14,47 @@ public partial class Generator
     private readonly bool canUseUnsafeSkipInit;
     private readonly bool canUseUnmanagedCallersOnlyAttribute;
     private readonly bool canUseSetLastPInvokeError;
+    private readonly bool overloadResolutionPriorityAttributePredefined;
     private readonly bool unscopedRefAttributePredefined;
     private readonly INamedTypeSymbol? runtimeFeatureClass;
     private readonly bool generateSupportedOSPlatformAttributes;
     private readonly bool generateSupportedOSPlatformAttributesOnInterfaces; // only supported on net6.0 (https://github.com/dotnet/runtime/pull/48838)
     private readonly bool generateDefaultDllImportSearchPathsAttribute;
     private readonly Dictionary<Feature, bool> supportedFeatures = new();
+
+    private void DeclareOverloadResolutionPriorityAttributeIfNecessary()
+    {
+        // This attribute may only be applied for C# 13 and later, or else C# errors out.
+        if (this.LanguageVersion < (LanguageVersion)1300)
+        {
+            throw new GenerationFailedException("The OverloadResolutionPriorityAttribute requires C# 13 or later.");
+        }
+
+        if (this.overloadResolutionPriorityAttributePredefined)
+        {
+            return;
+        }
+
+        // Always generate these in the context of the most common metadata so we don't emit it more than once.
+        if (!this.IsWin32Sdk)
+        {
+            this.MainGenerator.volatileCode.GenerationTransaction(() => this.MainGenerator.DeclareOverloadResolutionPriorityAttributeIfNecessary());
+            return;
+        }
+
+        const string name = "OverloadResolutionPriorityAttribute";
+        this.volatileCode.GenerateSpecialType(name, delegate
+        {
+            // This is a polyfill attribute, so never promote visibility to public.
+            if (!TryFetchTemplate(name, this, out CompilationUnitSyntax? compilationUnit))
+            {
+                throw new GenerationFailedException($"Failed to retrieve template: {name}");
+            }
+
+            MemberDeclarationSyntax templateNamespace = compilationUnit.Members.Single();
+            this.volatileCode.AddSpecialType(name, templateNamespace, topLevel: true);
+        });
+    }
 
     private void DeclareUnscopedRefAttributeIfNecessary()
     {
@@ -28,6 +63,7 @@ public partial class Generator
             return;
         }
 
+        // Always generate these in the context of the most common metadata so we don't emit it more than once.
         if (!this.IsWin32Sdk)
         {
             this.MainGenerator.volatileCode.GenerationTransaction(() => this.MainGenerator.DeclareUnscopedRefAttributeIfNecessary());

--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -630,6 +630,13 @@ public partial class Generator
                 friendlyDeclaration = friendlyDeclaration.AddAttributeLists(AttributeList().AddAttributes(supportedOSPlatformAttribute));
             }
 
+            // If we're using C# 13 or later, consider adding the overload resolution attribute if it would likely resolve ambiguities.
+            if (this.LanguageVersion >= (LanguageVersion)1300 && parameters.Count == externMethodDeclaration.ParameterList.Parameters.Count)
+            {
+                this.DeclareOverloadResolutionPriorityAttributeIfNecessary();
+                friendlyDeclaration = friendlyDeclaration.AddAttributeLists(AttributeList().AddAttributes(OverloadResolutionPriorityAttribute(1)));
+            }
+
             friendlyDeclaration = friendlyDeclaration
                 .WithLeadingTrivia(leadingTrivia);
 

--- a/src/Microsoft.Windows.CsWin32/Generator.Templates.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Templates.cs
@@ -35,6 +35,27 @@ public partial class Generator
         }
 
         member = generator?.ElevateVisibility(member) ?? member;
+
+        return true;
+    }
+
+    private static bool TryFetchTemplate(string name, Generator? generator, [NotNullWhen(true)] out CompilationUnitSyntax? compilationUnit)
+    {
+        string? template = FetchTemplateText(name);
+        if (template == null)
+        {
+            compilationUnit = null;
+            return false;
+        }
+
+        compilationUnit = SyntaxFactory.ParseCompilationUnit(template, options: generator?.parseOptions) ?? throw new GenerationFailedException($"Unable to parse compilation unit from a template: {name}");
+
+        // Strip out #if/#else/#endif trivia, which was already evaluated with the parse options we passed in.
+        if (generator?.parseOptions is not null)
+        {
+            compilationUnit = (CompilationUnitSyntax)compilationUnit.Accept(DirectiveTriviaRemover.Instance)!;
+        }
+
         return true;
     }
 

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -111,6 +111,7 @@ public partial class Generator : IGenerator, IDisposable
         this.canUseUnmanagedCallersOnlyAttribute = this.FindTypeSymbolsIfAlreadyAvailable("System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute").Count > 0;
         this.canUseSetLastPInvokeError = this.compilation?.GetTypeByMetadataName("System.Runtime.InteropServices.Marshal")?.GetMembers("GetLastSystemError").IsEmpty is false;
         this.unscopedRefAttributePredefined = this.FindTypeSymbolIfAlreadyAvailable("System.Diagnostics.CodeAnalysis.UnscopedRefAttribute") is not null;
+        this.overloadResolutionPriorityAttributePredefined = this.FindTypeSymbolIfAlreadyAvailable("System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute") is not null;
         this.runtimeFeatureClass = (INamedTypeSymbol?)this.FindTypeSymbolIfAlreadyAvailable("System.Runtime.CompilerServices.RuntimeFeature");
         this.comIIDInterfacePredefined = this.FindTypeSymbolIfAlreadyAvailable($"{this.Namespace}.{IComIIDGuidInterfaceName}") is not null;
         this.getDelegateForFunctionPointerGenericExists = this.compilation?.GetTypeByMetadataName(typeof(Marshal).FullName)?.GetMembers(nameof(Marshal.GetDelegateForFunctionPointer)).Any(m => m is IMethodSymbol { IsGenericMethod: true }) is true;

--- a/src/Microsoft.Windows.CsWin32/SimpleSyntaxFactory.cs
+++ b/src/Microsoft.Windows.CsWin32/SimpleSyntaxFactory.cs
@@ -111,6 +111,8 @@ internal static class SimpleSyntaxFactory
     internal static readonly IdentifierNameSyntax ComIIDGuidPropertyName = IdentifierName("Guid");
     internal static readonly AttributeSyntax FieldOffsetAttributeSyntax = Attribute(IdentifierName("FieldOffset"));
 
+    internal static AttributeSyntax OverloadResolutionPriorityAttribute(int priority) => Attribute(ParseName("OverloadResolutionPriority")).AddArgumentListArguments(AttributeArgument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(priority))));
+
     [return: NotNullIfNotNull("marshalAs")]
     internal static AttributeSyntax? MarshalAs(MarshalAsAttribute? marshalAs, Generator.NativeArrayInfo? nativeArrayInfo)
     {

--- a/src/Microsoft.Windows.CsWin32/templates/OverloadResolutionPriorityAttribute.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/OverloadResolutionPriorityAttribute.cs
@@ -1,0 +1,24 @@
+﻿namespace System.Runtime.CompilerServices
+{
+	/// <summary>
+	/// Specifies the priority of a member in overload resolution.
+	/// When unspecified, the default priority is 0.
+	/// </summary>
+	[global::System.AttributeUsage(global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+	internal sealed class OverloadResolutionPriorityAttribute : global::System.Attribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="OverloadResolutionPriorityAttribute"/> class.
+		/// </summary>
+		/// <param name="priority">The priority of the attributed member. Higher numbers are prioritized, lower numbers are deprioritized. 0 is the default if no attribute is present.</param>
+		public OverloadResolutionPriorityAttribute(int priority)
+		{
+			this.Priority = priority;
+		}
+
+		/// <summary>
+		/// The priority of the member.
+		/// </summary>
+		public int Priority { get; }
+	}
+}

--- a/test/SpellChecker/SpellChecker.csproj
+++ b/test/SpellChecker/SpellChecker.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0-windows8.0;net472</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
+    <DisablePolyfill>true</DisablePolyfill>
   </PropertyGroup>
 
 </Project>

--- a/test/WinRTInteropTest/WinRTInteropTest.csproj
+++ b/test/WinRTInteropTest/WinRTInteropTest.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <Nullable>disable</Nullable>
     <IsTestProject>false</IsTestProject>
+    <DisablePolyfill>true</DisablePolyfill>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
As brought up in https://github.com/microsoft/CsWin32/issues/1049#issuecomment-2607994476

C# supports using a polyfill attribute, so this works on any target framework. But it _does_ require C# 13 to reference the attribute on an API or an error results, so CsWin32 only emits or uses the attribute when C# 13 is in operation.