### PR TITLE
Friendly overloads replace `PCWSTR*` parameters with `ReadOnlySpan<string>`

### DIFF
--- a/src/Microsoft.Windows.CsWin32/FastSyntaxFactory.cs
+++ b/src/Microsoft.Windows.CsWin32/FastSyntaxFactory.cs
@@ -82,6 +82,8 @@ internal static class FastSyntaxFactory
         return SyntaxFactory.ForStatement(Token(SyntaxKind.ForKeyword), Token(SyntaxKind.OpenParenToken), declaration!, default, semicolonToken, condition, semicolonToken, incrementors, Token(SyntaxKind.CloseParenToken), statement);
     }
 
+    internal static ForEachStatementSyntax ForEachStatement(TypeSyntax type, SyntaxToken identifier, ExpressionSyntax expression, StatementSyntax statement) => SyntaxFactory.ForEachStatement(type, identifier, expression, statement);
+
     internal static StatementSyntax EmptyStatement() => SyntaxFactory.EmptyStatement(Token(SyntaxKind.SemicolonToken));
 
     internal static NamespaceDeclarationSyntax NamespaceDeclaration(NameSyntax name) => SyntaxFactory.NamespaceDeclaration(Token(TriviaList(), SyntaxKind.NamespaceKeyword, TriviaList(Space)), name.WithTrailingTrivia(LineFeed), OpenBrace, default, default, default, CloseBrace, default);

--- a/src/Microsoft.Windows.CsWin32/Generator.WhitespaceRewriter.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.WhitespaceRewriter.cs
@@ -282,6 +282,20 @@ public partial class Generator
             }
         }
 
+        public override SyntaxNode? VisitForEachStatement(ForEachStatementSyntax node)
+        {
+            node = this.WithIndentingTrivia(node);
+            if (node.Statement is BlockSyntax)
+            {
+                return base.VisitForEachStatement(node);
+            }
+            else
+            {
+                using var indent = new Indent(this);
+                return base.VisitForEachStatement(node);
+            }
+        }
+
         public override SyntaxNode? VisitReturnStatement(ReturnStatementSyntax node)
         {
             return base.VisitReturnStatement(this.WithIndentingTrivia(node));

--- a/test/GenerationSandbox.Tests/GeneratedForm.cs
+++ b/test/GenerationSandbox.Tests/GeneratedForm.cs
@@ -8,6 +8,7 @@ using Windows.Win32.Foundation;
 using Windows.Win32.Networking.ActiveDirectory;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Diagnostics.Debug;
+using Windows.Win32.System.RestartManager;
 using Windows.Win32.System.Threading;
 
 #pragma warning disable CA1812 // dead code
@@ -79,6 +80,11 @@ internal static unsafe class GeneratedForm
     {
         uint written = 0;
         PInvoke.WriteFile((SafeHandle?)null, new byte[2], &written, (NativeOverlapped*)null);
+    }
+
+    private static void RmRegisterResources()
+    {
+        PInvoke.RmRegisterResources(0, ["a", "b"], [default(RM_UNIQUE_PROCESS)], ["a", "b"]);
     }
 
     private class MyStream : IStream

--- a/test/GenerationSandbox.Tests/NativeMethods.txt
+++ b/test/GenerationSandbox.Tests/NativeMethods.txt
@@ -15,6 +15,7 @@ GetProcAddress
 GetTickCount 
 GetWindowText
 GetWindowTextLength
+RmRegisterResources
 HDC_UserSize
 HRESULT_FROM_WIN32
 IDirectorySearch

--- a/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
@@ -68,6 +68,7 @@ public class FriendlyOverloadTests : GeneratorTestBase
 
     [Theory]
     [InlineData("WSManGetSessionOptionAsString")] // Uses the reserved keyword 'string' as a parameter name
+    [InlineData("RmRegisterResources")] // Parameter with PCWSTR* (an array of native strings)
     public void InterestingAPIs(string name)
     {
         this.Generate(name);


### PR DESCRIPTION
Closes #322