### PR TITLE
Add the ability to choose a custom generation namespace

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -299,7 +299,7 @@ public partial class Generator : IGenerator, IDisposable
 
     private bool WideCharOnly => this.options.WideCharOnly;
 
-    private string Namespace => this.MetadataIndex.CommonNamespace;
+    private string Namespace => this.options.Namespace ?? this.MetadataIndex.CommonNamespace;
 
     private SyntaxKind Visibility => this.options.Public ? SyntaxKind.PublicKeyword : SyntaxKind.InternalKeyword;
 
@@ -817,7 +817,7 @@ public partial class Generator : IGenerator, IDisposable
             usingDirectives.Add(UsingDirective(ParseName(GlobalNamespacePrefix + "System.Runtime.Versioning")));
         }
 
-        usingDirectives.Add(UsingDirective(NameEquals(GlobalWinmdRootNamespaceAlias), ParseName(GlobalNamespacePrefix + this.MetadataIndex.CommonNamespace)));
+        usingDirectives.Add(UsingDirective(NameEquals(GlobalWinmdRootNamespaceAlias), ParseName(GlobalNamespacePrefix + this.Namespace)));
 
         var normalizedResults = new Dictionary<string, CompilationUnitSyntax>(StringComparer.OrdinalIgnoreCase);
         results.AsParallel().WithCancellation(cancellationToken).ForAll(kv =>

--- a/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
+++ b/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
@@ -20,6 +20,14 @@ public record GeneratorOptions
     public string ClassName { get; init; } = "PInvoke";
 
     /// <summary>
+    /// Gets the root namespace to use for the generated code. This is used to determine the namespace of the generated types.
+    /// </summary>
+    /// <value>
+    /// The default namespace is the namespace of the metadata assembly that the generator generates interop code for, e.g. "Windows.Win32".
+    /// </value>
+    public string? Namespace { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether to emit a single source file as opposed to types spread across many files.
     /// </summary>
     /// <value>The default value is <see langword="false" />.</value>

--- a/src/Microsoft.Windows.CsWin32/settings.schema.json
+++ b/src/Microsoft.Windows.CsWin32/settings.schema.json
@@ -78,6 +78,12 @@
       "description": "A value indicating whether to expose the generated APIs publicly (as opposed to internally).",
       "type": "boolean",
       "default": false
+    },
+    "namespace": {
+      "description": "The namespace under which all p/invoke methods and constants are generated.",
+      "type": "string",
+      "default": null,
+      "pattern": "^\\w+(?:\\.\\w+)*$"
     }
   }
 }


### PR DESCRIPTION
This PR adds the ability (back) to choose a custom generation namespace (#1312)

Not having the ability to customise this namespace causes lots of problems:
- Closes https://github.com/Lamparter/Win32/issues/2
- Closes https://github.com/Lamparter/CubeKit/issues/117

---

![image](https://github.com/user-attachments/assets/5280478e-e3b9-4880-9d0c-5a8e08de906f)
