### PR TITLE
Add custom DebuggerDisplay for HRESULT

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.TypeDef.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.TypeDef.cs
@@ -239,12 +239,22 @@ public partial class Generator
             structModifiers = structModifiers.Add(TokenWithSpace(SyntaxKind.UnsafeKeyword));
         }
 
+        string debuggerDisplay;
+        if (members.Where(x => x is PropertyDeclarationSyntax && ((PropertyDeclarationSyntax)x).Identifier.ValueText == "DebuggerDisplay").Any())
+        {
+            debuggerDisplay = "{DebuggerDisplay,nq}";
+        }
+        else
+        {
+            debuggerDisplay = "{" + fieldName + "}";
+        }
+
         structModifiers = structModifiers.Add(TokenWithSpace(SyntaxKind.ReadOnlyKeyword)).Add(TokenWithSpace(SyntaxKind.PartialKeyword));
         StructDeclarationSyntax result = StructDeclaration(name.Identifier)
             .WithBaseList(BaseList(SingletonSeparatedList<BaseTypeSyntax>(SimpleBaseType(GenericName(nameof(IEquatable<int>), TypeArgumentList().WithGreaterThanToken(TokenWithLineFeed(SyntaxKind.GreaterThanToken))).AddTypeArgumentListArguments(name)))).WithColonToken(TokenWithSpace(SyntaxKind.ColonToken)))
             .WithMembers(members)
             .WithModifiers(structModifiers)
-            .AddAttributeLists(AttributeList().WithCloseBracketToken(TokenWithLineFeed(SyntaxKind.CloseBracketToken)).AddAttributes(DebuggerDisplay("{" + fieldName + "}")));
+            .AddAttributeLists(AttributeList().WithCloseBracketToken(TokenWithLineFeed(SyntaxKind.CloseBracketToken)).AddAttributes(DebuggerDisplay(debuggerDisplay)));
 
         result = this.AddApiDocumentation(name.Identifier.ValueText, result);
         return result;

--- a/src/Microsoft.Windows.CsWin32/templates/HRESULT.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/HRESULT.cs
@@ -61,6 +61,19 @@ partial struct HRESULT
 		return this;
 	}
 
+	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+	private string DebuggerDisplay
+	{
+		get
+		{
+#if NET7_0_OR_GREATER
+			return string.Format("{0} {1}", ToString(), global::System.Runtime.InteropServices.Marshal.GetPInvokeErrorMessage((int)this.Value));
+#else
+			return string.Format("{0} {1}", ToString(), new global::System.ComponentModel.Win32Exception((int)this.Value).Message);
+#endif
+		}
+	}
+
 	public override string ToString() => string.Format(global::System.Globalization.CultureInfo.InvariantCulture, "0x{0:X8}", this.Value);
 
 	internal string ToString(string format, IFormatProvider formatProvider) => ((uint)this.Value).ToString(format, formatProvider);


### PR DESCRIPTION
PR adds support for using customized DebuggerDisplay for customized types (templates) instead of hardocoding `DebuggerDisplay` to structure's first field name. It is designed to work in a way, that when there is property named `DebuggerDisplay`, it is used instead. Actually there already were some custom DebuggerDisplays in templates, but these only work with [`SpecialTypeDefNames`](https://github.com/microsoft/CsWin32/blob/main/src/Microsoft.Windows.CsWin32/Generator.Invariants.cs#L63) because for normal types, only Members are obtained and rest of the template is thrown away and recrated including [DebuggerDisplay attribute](https://github.com/microsoft/CsWin32/blob/main/src/Microsoft.Windows.CsWin32/Generator.TypeDef.cs#L247).

PR also uses newly introduced capability and adds custom `DebuggerDisplay` for HRESULT type. Custom visualizer show HEX error code number followed by humman readable description of HRESULT error code:

<img width="801" height="71" alt="obrazek" src="https://github.com/user-attachments/assets/9414c2cd-2de1-48df-af97-72331cc2b1e8" />

It allows developer debugging apps to understand errors without need to use Error Lookup tool or searching online.

Message is internally obtained using avalaible .NET APIs (two variants are implemented depending on .NET version, both should produce same results because internally both end up using `FormatMessageW`). As you can see, FormatMessage provides localized message. I use Czech windows, so message is in Czech. For debugging it should be no problem.

It also brings debugger visualization experience on par with native debugger which has similar natvis (or maybe hardcoded, who knows?) visualizer for HRESULT as well.

I was also considering adding similar for NTSTATUS, but obtaining message for NTSTATUSes is not that easy because it requires passing NTDLL module handle (+ one more flag) to FormatMessageW and this is not exposed to .NET API. But it can be done manually. Instead of bloating NTSTATUS template in horroble way, I decided to step back on it. Also note, that native debugger do not support visualizer for NTSTATUS as well.
