### PR TITLE
Fix nuspec to refer to only signed files and drop apphost.exe from the nuget

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.nuspec
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.nuspec
@@ -50,15 +50,7 @@
     <file src="$BaseOutputPath$Microsoft.Bcl.AsyncInterfaces.dll" target="analyzers\cs\Microsoft.Bcl.AsyncInterfaces.dll" />
     <file src="$BaseOutputPath$System.Text.Json.dll" target="analyzers\cs\System.Text.Json.dll" />
     <file src="$BaseOutputPath$System.Text.Encodings.Web.dll" target="analyzers\cs\System.Text.Encodings.Web.dll" />
-    <file src="$CsWin32GeneratorBasePath$CsWin32Generator.dll" target="build\tools\" />
-    <file src="$CsWin32GeneratorBasePath$Microsoft.CodeAnalysis.CSharp.dll" target="build\tools\" />
-    <file src="$CsWin32GeneratorBasePath$Microsoft.CodeAnalysis.dll" target="build\tools\" />
-    <file src="$CsWin32GeneratorBasePath$Microsoft.Windows.CsWin32.dll" target="build\tools\" />
-    <file src="$CsWin32GeneratorBasePath$Microsoft.Windows.SDK.Win32Docs.dll" target="build\tools\" />
-    <file src="$CsWin32GeneratorBasePath$System.Collections.Immutable.dll" target="build\tools\" />
-    <file src="$CsWin32GeneratorBasePath$System.CommandLine.dll" target="build\tools\" />
-    <file src="$CsWin32GeneratorBasePath$System.Reflection.Metadata.dll" target="build\tools\" />
-    <file src="$CsWin32GeneratorBasePath$System.Text.Encodings.Web.dll" target="build\tools\" />
+    <file src="$CsWin32GeneratorBasePath$**" target="build\tools\" exclude="**\*.exe;**\MessagePack*.dll" />
     <file src="$SignedOutputPath$MessagePack.dll" target="build\tools\" />
     <file src="$SignedOutputPath$MessagePack.Annotations.dll" target="build\tools\" />
     <file src="readme.txt" target="readme.txt" />


### PR DESCRIPTION
Official pipeline was failing on files in the nuget package not being officially signed. We can drop the .exe and use the already signed MessagePack files from the analyzer dir.

Ran the unofficial pipelines on this branch manually and things are looking ok now:

https://dev.azure.com/azure-public/winsdk/_build/results?buildId=22341&view=results
https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=12594105&view=results