### PR TITLE
Fix analyzer test break in devdiv AzDO account

### DIFF
--- a/test/Microsoft.Windows.CsWin32.Tests/InlineArrayTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/InlineArrayTests.cs
@@ -37,9 +37,9 @@ public class InlineArrayTests : GeneratorTestBase
     {
         ReferenceAssemblies referenceAssemblies = tfm switch
         {
-            "net35" => ReferenceAssemblies.NetFramework.Net35.WindowsForms,
-            "net472" => ReferenceAssemblies.NetFramework.Net472.WindowsForms,
-            "netstandard2.0" => ReferenceAssemblies.NetStandard.NetStandard20,
+            "net35" => ReferenceAssemblies.NetFramework.Net35.WindowsForms.WithNuGetConfigFilePath(MyReferenceAssemblies.NuGetConfigPath),
+            "net472" => ReferenceAssemblies.NetFramework.Net472.WindowsForms.WithNuGetConfigFilePath(MyReferenceAssemblies.NuGetConfigPath),
+            "netstandard2.0" => ReferenceAssemblies.NetStandard.NetStandard20.WithNuGetConfigFilePath(MyReferenceAssemblies.NuGetConfigPath),
             _ => throw new ArgumentOutOfRangeException(nameof(tfm)),
         };
         if (referenceUnsafe)

--- a/test/Microsoft.Windows.CsWin32.Tests/MyReferenceAssemblies.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/MyReferenceAssemblies.cs
@@ -5,7 +5,7 @@
 
 internal static class MyReferenceAssemblies
 {
-    private static readonly string NuGetConfigPath = FindNuGetConfigPath();
+    internal static readonly string NuGetConfigPath = FindNuGetConfigPath();
 
     private static readonly ImmutableArray<PackageIdentity> AdditionalModernPackages = [
         ExtraPackages.Unsafe,

--- a/test/Microsoft.Windows.CsWin32.Tests/SourceGeneratorTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/SourceGeneratorTests.cs
@@ -36,7 +36,7 @@ public class SourceGeneratorTests(ITestOutputHelper logger)
     {
         await new VerifyCS.Test(logger)
         {
-            ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default,
+            ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default.WithNuGetConfigFilePath(MyReferenceAssemblies.NuGetConfigPath),
         }.RunAsync(TestContext.Current.CancellationToken);
     }
 
@@ -48,7 +48,7 @@ public class SourceGeneratorTests(ITestOutputHelper logger)
     {
         await new VerifyCS.Test(logger)
         {
-            ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default,
+            ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default.WithNuGetConfigFilePath(MyReferenceAssemblies.NuGetConfigPath),
             NativeMethodsTxt = "CreateFile",
             ExpectedDiagnostics =
             {
@@ -65,7 +65,7 @@ public class SourceGeneratorTests(ITestOutputHelper logger)
     {
         await new VerifyCS.Test(logger)
         {
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80.WithNuGetConfigFilePath(MyReferenceAssemblies.NuGetConfigPath),
             NativeMethodsTxt = "CreateFile",
         }.RunAsync(TestContext.Current.CancellationToken);
     }
@@ -75,7 +75,7 @@ public class SourceGeneratorTests(ITestOutputHelper logger)
     {
         await new VerifyCS.Test(logger)
         {
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80.WithNuGetConfigFilePath(MyReferenceAssemblies.NuGetConfigPath),
             LanguageVersion = LanguageVersion.CSharp12,
             NativeMethodsTxt = "gdi32.*",
         }.RunAsync(TestContext.Current.CancellationToken);


### PR DESCRIPTION
Fix analyzer tests to pull packages from our nuget.config feed

This fixes a Azure Pipeline break in the devdiv project where network isolation is enabled.