### PR TITLE
Address "High" severity nuget dependencies by moving System.Text.Json to 9.0.0

### DIFF
--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -11,6 +11,6 @@
     <PackageVersion Update="System.Memory" Version="4.5.5" />
     <PackageVersion Update="System.Reflection.Metadata" Version="9.0.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="Xunit.Combinatorial" Version="2.0.24" />
     <PackageVersion Include="Xunit.Assert" Version="2.9.3" />
   </ItemGroup>


### PR DESCRIPTION
I had downgraded this during development of a previous change when I thought we might multi-target but that is no longer needed. Restoring this dependency to its rightful version.