### PR TITLE
Fix ArithmeticOverflow in HANDLE types and other helpers when CheckForOverflowUnderflow is enabled

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.TypeDef.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.TypeDef.cs
@@ -278,7 +278,7 @@ public partial class Generator
             yield return ConstructorDeclaration(structName.Identifier)
                 .AddModifiers(TokenWithSpace(this.Visibility))
                 .AddParameterListParameters(Parameter(valueParameter.Identifier).WithType(IntPtrTypeSyntax.WithTrailingTrivia(TriviaList(Space))))
-                .WithInitializer(ConstructorInitializer(SyntaxKind.ThisConstructorInitializer).AddArgumentListArguments(Argument(CastExpression(fieldType, valueParameter))))
+                .WithInitializer(ConstructorInitializer(SyntaxKind.ThisConstructorInitializer).AddArgumentListArguments(Argument(UncheckedExpression(CastExpression(fieldType, valueParameter)))))
                 .WithBody(Block());
         }
 

--- a/src/Microsoft.Windows.CsWin32/templates/HRESULT.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/HRESULT.cs
@@ -38,7 +38,7 @@
 partial struct HRESULT
 {
 	public static implicit operator uint(HRESULT value) => (uint)value.Value;
-	public static explicit operator HRESULT(uint value) => new HRESULT((int)value);
+	public static explicit operator HRESULT(uint value) => new HRESULT(unchecked((int)value));
 
 	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 	internal bool Succeeded => this.Value >= 0;

--- a/src/Microsoft.Windows.CsWin32/templates/NTSTATUS.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/NTSTATUS.cs
@@ -26,9 +26,9 @@
 partial struct NTSTATUS
 {
 	public static implicit operator uint(NTSTATUS value) => (uint)value.Value;
-	public static explicit operator NTSTATUS(uint value) => new NTSTATUS((int)value);
+	public static explicit operator NTSTATUS(uint value) => new NTSTATUS(unchecked((int)value));
 
-	internal Severity SeverityCode => (Severity)(((uint)this.Value & 0xc0000000) >> 30);
+	internal Severity SeverityCode => (Severity)unchecked(((uint)this.Value & 0xc0000000) >> 30);
 
 	internal enum Severity
 	{

--- a/src/Microsoft.Windows.CsWin32/templates/PInvokeClassMacros.cs
+++ b/src/Microsoft.Windows.CsWin32/templates/PInvokeClassMacros.cs
@@ -19,7 +19,7 @@ internal class PInvokeClassMacros
 	/// <param name="a">The low word.</param>
 	/// <param name="b">The high word.</param>
 	/// <returns>A 32-bit unsigned integer.</returns>
-	internal static uint MAKELONG(ushort a, ushort b) => (uint)(a | b << 16);
+	internal static uint MAKELONG(ushort a, ushort b) => unchecked((uint)(a | b << 16));
 
 	/// <summary>
 	/// Constructs a <see cref="global::Windows.Win32.Foundation.WPARAM"/> from two 16-bit values.
@@ -57,5 +57,5 @@ internal class PInvokeClassMacros
 	/// </summary>
 	/// <param name="value">The 32-bit value.</param>
 	/// <returns>The high-order word.</returns>
-	internal static ushort HIWORD(uint value) => (ushort)(value >> 16);
+	internal static ushort HIWORD(uint value) => unchecked((ushort)(value >> 16));
 }

--- a/test/GenerationSandbox.Tests/BasicTests.cs
+++ b/test/GenerationSandbox.Tests/BasicTests.cs
@@ -201,6 +201,13 @@ public class BasicTests
     }
 
     [Fact]
+    public void HANDLE_CanCreateFromNegative()
+    {
+        // unchecked this will throw overflow exception in .NET Core.
+        var handle = new HANDLE(new IntPtr(-3));
+    }
+
+    [Fact]
     public void GetWindowText_FriendlyOverload()
     {
         HWND hwnd = PInvoke.GetForegroundWindow();

--- a/test/GenerationSandbox.Tests/GenerationSandbox.Tests.csproj
+++ b/test/GenerationSandbox.Tests/GenerationSandbox.Tests.csproj
@@ -5,6 +5,10 @@
     <Compile Remove="ComRuntimeTests.cs" Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+
   <ProjectExtensions>
     <VisualStudio><UserProperties nativemethods_1json__JsonSchema="..\..\src\Microsoft.Windows.CsWin32\settings.schema.json" /></VisualStudio>
   </ProjectExtensions>


### PR DESCRIPTION
A number of arithmetic casts in the HANDLE types and other helpers were not unchecked by default. Add test coverage and fix up the issues the tests caught.

Fixes #1412