### PR TITLE
Fixed incorrect parameters generated for pointer-to-pointer types #1229

### DIFF
--- a/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
@@ -42,7 +42,7 @@ internal record PointerTypeHandleInfo(TypeHandleInfo ElementType) : TypeHandleIn
                 parameterAttributes).Type));
         }
 
-        TypeSyntaxAndMarshaling elementTypeDetails = this.ElementType.ToTypeSyntax(inputs with { PreferInOutRef = false }, forElement, customAttributes, parameterAttributes);
+        TypeSyntaxAndMarshaling elementTypeDetails = this.ElementType.ToTypeSyntax(inputs with { PreferInOutRef = false }, forElement, customAttributes);
         if (elementTypeDetails.MarshalAsAttribute is object ||
             elementTypeDetails.MarshalUsingType is string ||
             (inputs.Generator?.IsManagedType(this.ElementType) is true) || (inputs.PreferInOutRef && !xOptional && this.ElementType is PrimitiveTypeHandleInfo { PrimitiveTypeCode: not PrimitiveTypeCode.Void }))


### PR DESCRIPTION
After this change, it looks like it generates the correct array type for the MFTEnumEx:

```cs
[LibraryImport("MFPlat.dll")]
internal static unsafe partial winmdroot.Foundation.HRESULT MFTEnumEx(global::System.Guid guidCategory, [global::System.Runtime.InteropServices.Marshalling.MarshalUsing(typeof(global::Windows.Win32.Media.MediaFoundation.InteropServices.MFT_ENUM_FLAGToU4Marshaler))] winmdroot.Media.MediaFoundation.MFT_ENUM_FLAG Flags, [Optional] winmdroot.Media.MediaFoundation.MFT_REGISTER_TYPE_INFO* pInputType, [Optional] winmdroot.Media.MediaFoundation.MFT_REGISTER_TYPE_INFO* pOutputType, out winmdroot.Media.MediaFoundation.IMFActivate[] pppMFTActivate, uint* pnumMFTActivate);

```