### PR TITLE
Don't make void* params Span<byte> in friendly methods

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -222,12 +222,10 @@ public partial class Generator
                 }
                 else if (!countParamIndex.HasValue && !isComOutPtr)
                 {
-                    // void* param with no size annotations and without [ComOutPtr] is assumed to be
-                    // arbitrary memory block which we represent as Span<byte>
-                    isArray = true;
-                    projectAsSpanBytes = true;
+                    // void* param with no size annotations and without [ComOutPtr] can't really be improved,
+                    // so leave it alone.
                 }
-                else
+                else if (countParamIndex.HasValue)
                 {
                     // If it's void* but annotated with a count-of-elements (like OfferVirtualMemory or TokenBindingGenerateMessage) then
                     // just leave it as raw pointer because it's not clear what the developer meant and projecting as Span<byte> will require

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
@@ -22,6 +22,7 @@ public partial class CsWin32GeneratorFullTests : CsWin32GeneratorTestsBase
         this.fullGeneration = true;
         this.compilation = this.starterCompilations[tfm];
         this.parseOptions = this.parseOptions.WithLanguageVersion(langVersion);
+        this.nativeMethodsJson = "NativeMethods.EmitSingleFile.json";
         await this.InvokeGeneratorAndCompile($"FullGeneration_{tfm}_{langVersion}", TestOptions.None);
     }
 }

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -162,14 +162,15 @@ public partial class CsWin32GeneratorTests : CsWin32GeneratorTestsBase
         ["SetupDiGetDeviceInterfaceDetail", "SetupDiGetDeviceInterfaceDetail", "SafeHandle DeviceInfoSet, in winmdroot.Devices.DeviceAndDriverInstallation.SP_DEVICE_INTERFACE_DATA DeviceInterfaceData, Span<byte> DeviceInterfaceDetailData, out uint RequiredSize, ref winmdroot.Devices.DeviceAndDriverInstallation.SP_DEVINFO_DATA DeviceInfoData"],
         // Optional params omitted
         ["SetupDiGetDeviceInterfaceDetail", "SetupDiGetDeviceInterfaceDetail", "SafeHandle DeviceInfoSet, in winmdroot.Devices.DeviceAndDriverInstallation.SP_DEVICE_INTERFACE_DATA DeviceInterfaceData, Span<byte> DeviceInterfaceDetailData"],
-        ["WinHttpReadData", "WinHttpReadData", "Span<byte> hRequest, Span<byte> lpBuffer, ref uint lpdwNumberOfBytesRead"],
+        ["WinHttpReadData", "WinHttpReadData", "void* hRequest, Span<byte> lpBuffer, ref uint lpdwNumberOfBytesRead"],
         ["IsTextUnicode", "IsTextUnicode", "ReadOnlySpan<byte> lpv, ref winmdroot.Globalization.IS_TEXT_UNICODE_RESULT lpiResult"],
         // Omitted ref param
         ["IsTextUnicode", "IsTextUnicode", "ReadOnlySpan<byte> lpv"],
-        ["GetAce", "GetAce", "in winmdroot.Security.ACL pAcl, uint dwAceIndex, Span<byte> pAce"],
+        ["GetAce", "GetAce", "in winmdroot.Security.ACL pAcl, uint dwAceIndex, out void* pAce"],
         // Optional and MemorySize-d struct params, optional params included
         ["SetupDiGetClassInstallParams", "SetupDiGetClassInstallParams", "SafeHandle DeviceInfoSet, winmdroot.Devices.DeviceAndDriverInstallation.SP_DEVINFO_DATA? DeviceInfoData, Span<byte> ClassInstallParams, out uint RequiredSize"],
         ["IEnumString", "Next", "this winmdroot.System.Com.IEnumString @this, Span<winmdroot.Foundation.PWSTR> rgelt, out uint pceltFetched"],
+        ["PSCreateMemoryPropertyStore", "PSCreateMemoryPropertyStore", "in global::System.Guid riid, out void* ppv"],
     ];
 
     [Theory]

--- a/test/CsWin32Generator.Tests/TestContent/NativeMethods.EmitSingleFile.json
+++ b/test/CsWin32Generator.Tests/TestContent/NativeMethods.EmitSingleFile.json
@@ -1,0 +1,4 @@
+﻿{
+  "$schema": "..\\..\\..\\src\\Microsoft.Windows.CsWin32\\settings.schema.json",
+  "emitSingleFile": true
+}

--- a/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
@@ -21,6 +21,8 @@ using Windows.Win32.System.Com;
 using Windows.Win32.System.WinRT.Composition;
 using Windows.Win32.UI.Shell;
 
+namespace GenerationSandbox.BuildTask.Tests;
+
 [Trait("WindowsOnly", "true")]
 public partial class COMTests
 {

--- a/test/GenerationSandbox.BuildTask.Tests/NativeMethods.json
+++ b/test/GenerationSandbox.BuildTask.Tests/NativeMethods.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "..\\..\\src\\Microsoft.Windows.CsWin32\\settings.schema.json",
-  "emitSingleFile": false,
+  "emitSingleFile": true,
   "allowMarshaling": true,
   "public": false,
   "comInterop": {

--- a/test/GenerationSandbox.BuildTask.Tests/NativeMethods.txt
+++ b/test/GenerationSandbox.BuildTask.Tests/NativeMethods.txt
@@ -42,3 +42,8 @@ SHGetFileInfo
 SHGFI_FLAGS
 FILE_FLAGS_AND_ATTRIBUTES
 InitializeAcl
+DeviceIoControl
+SetupDiCreateDeviceInterface
+GetFileVersionInfoSizeEx
+GetFileVersionInfoEx
+VerQueryValue

--- a/test/GenerationSandbox.BuildTask.Tests/SpanOverloadTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/SpanOverloadTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Windows.Win32.Storage.FileSystem;
+using static Windows.Win32.PInvoke;
+
+#pragma warning disable SA1201, CS0649
+
+namespace GenerationSandbox.BuildTask.Tests;
+
+[Trait("WindowsOnly", "true")]
+public partial class SpanOverloadTests
+{
+    [Fact]
+    public void CanCallGetFileVersionApis()
+    {
+        var appName = GetAppName("C:\\windows\\notepad.exe");
+        Assert.True(appName is not null);
+    }
+
+    internal struct LANGANDCODEPAGE
+    {
+        public ushort Language;
+        public ushort Codepage;
+    }
+
+    internal static unsafe string GetAppName(string processPath)
+    {
+        uint infoSize = GetFileVersionInfoSizeEx(GET_FILE_VERSION_INFO_FLAGS.FILE_VER_GET_NEUTRAL, processPath, out uint handle);
+        if (infoSize > 0)
+        {
+            // Try whatever language is supported
+            // https://learn.microsoft.com/en-us/windows/win32/api/winver/nf-winver-verqueryvaluew
+            Span<byte> versionInfo = new byte[infoSize];
+            if (GetFileVersionInfoEx(GET_FILE_VERSION_INFO_FLAGS.FILE_VER_GET_NEUTRAL, processPath, versionInfo))
+            {
+                fixed (void* pvVersionInfo = versionInfo)
+                {
+                    if (VerQueryValue(pvVersionInfo, @"\VarFileInfo\Translation", out void* pvLangCodePage, out uint cbTranslate) &&
+                        pvLangCodePage is not null &&
+                        cbTranslate >= sizeof(LANGANDCODEPAGE))
+                    {
+                        LANGANDCODEPAGE* langCodePage = (LANGANDCODEPAGE*)pvLangCodePage;
+                        string path = $@"\StringFileInfo\{langCodePage->Language.ToString("x4", CultureInfo.InvariantCulture.NumberFormat)}{langCodePage->Codepage.ToString("x4", CultureInfo.InvariantCulture.NumberFormat)}\FileDescription";
+                        if (VerQueryValue(pvVersionInfo, path, out void* descPtr, out uint desLen) &&
+                            descPtr is not null &&
+                            desLen > 0)
+                        {
+                            return Marshal.PtrToStringAuto(new(descPtr)) ?? string.Empty;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback to the process name
+        return Path.GetFileNameWithoutExtension(processPath);
+    }
+}


### PR DESCRIPTION
Previous change to improve pointer signatures went a little further than intended. There were cases where un-annotated `void*` parameters were getting turned into `Span<byte>` which made these methods harder to work with. This restores the behavior of those parameters back to the way they were. You can see some of the deltas in the VerifySignature test cases that I changed back.

I also added a test case to call some of the functions like VerQueryValue which were problematic with the previous change.

I also noticed that the build task mode wasn't giving line numbers in NativeMethods.txt when an API failed to generate so I fixed that.