### PR TITLE
[Retained] parameters need to project as pointer

### DIFF
--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -171,6 +171,7 @@ public partial class CsWin32GeneratorTests : CsWin32GeneratorTestsBase
         ["SetupDiGetClassInstallParams", "SetupDiGetClassInstallParams", "SafeHandle DeviceInfoSet, winmdroot.Devices.DeviceAndDriverInstallation.SP_DEVINFO_DATA? DeviceInfoData, Span<byte> ClassInstallParams, out uint RequiredSize"],
         ["IEnumString", "Next", "this winmdroot.System.Com.IEnumString @this, Span<winmdroot.Foundation.PWSTR> rgelt, out uint pceltFetched"],
         ["PSCreateMemoryPropertyStore", "PSCreateMemoryPropertyStore", "in global::System.Guid riid, out void* ppv"],
+        ["DeviceIoControl", "DeviceIoControl", "SafeHandle hDevice, uint dwIoControlCode, ReadOnlySpan<byte> lpInBuffer, Span<byte> lpOutBuffer, out uint lpBytesReturned, global::System.Threading.NativeOverlapped* lpOverlapped"],
     ];
 
     [Theory]


### PR DESCRIPTION
Per discussion in https://github.com/microsoft/CsWin32/issues/1066 and https://github.com/microsoft/win32metadata/pull/1792, a new [Retained] attribute was added in win32 metadata to help indicate that a parameter will outlive the method call.

The best way we have to communicate that is to always type the parameter as a pointer so that at least the caller has to think about the lifetime of the pointer existing beyond the life of the method call.