### PR TITLE
Fix out ** pointer parameters

### DIFF
--- a/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
@@ -24,6 +24,6 @@ public partial class CsWin32GeneratorFullTests : CsWin32GeneratorTestsBase
         this.compilation = this.starterCompilations[tfm];
         this.parseOptions = this.parseOptions.WithLanguageVersion(langVersion);
         this.nativeMethodsJson = includePointerOverloads ? "NativeMethods.IncludePointerOverloads.json" : "NativeMethods.EmitSingleFile.json";
-        await this.InvokeGeneratorAndCompile($"FullGeneration_{tfm}_{langVersion}", TestOptions.None);
+        await this.InvokeGeneratorAndCompile($"FullGeneration_{tfm}_{langVersion}{(includePointerOverloads ? "_pointers" : string.Empty)}", TestOptions.None);
     }
 }

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -186,6 +186,10 @@ public partial class CsWin32GeneratorTests : CsWin32GeneratorTestsBase
         ["DeviceIoControl", "DeviceIoControl", "SafeHandle hDevice, uint dwIoControlCode, ReadOnlySpan<byte> lpInBuffer, Span<byte> lpOutBuffer, out uint lpBytesReturned, global::System.Threading.NativeOverlapped* lpOverlapped"],
         ["DeviceIoControl", "DeviceIoControl", "SafeHandle hDevice, uint dwIoControlCode, ReadOnlySpan<byte> lpInBuffer, Span<byte> lpOutBuffer, out uint lpBytesReturned, global::System.Threading.NativeOverlapped* lpOverlapped", true, "NativeMethods.IncludePointerOverloads.json"],
         ["NtQueryObject", "NtQueryObject", "global::Windows.Win32.Foundation.HANDLE Handle, winmdroot.Foundation.OBJECT_INFORMATION_CLASS ObjectInformationClass, Span<byte> ObjectInformation, out uint ReturnLength"],
+        // ["IWbemServices", "GetObject", "winmdroot.Foundation.BSTR, winmdroot.System.Wmi.WBEM_GENERIC_FLAG_TYPE, winmdroot.System.Wmi.IWbemContext, out winmdroot.System.Wmi.IWbemClassObject ppObject, out winmdroot.System.Wmi.IWbemCallResult ppCallResult"],
+        ["ITypeInfo", "GetFuncDesc", "uint index, out winmdroot.System.Com.FUNCDESC_unmanaged* ppFuncDesc"],
+        ["ITsSbResourcePluginStore", "EnumerateTargets", "winmdroot.Foundation.BSTR FarmName, winmdroot.Foundation.BSTR EnvName, winmdroot.System.RemoteDesktop.TS_SB_SORT_BY sortByFieldId, winmdroot.Foundation.BSTR sortyByPropName, ref uint pdwCount, out winmdroot.System.RemoteDesktop.ITsSbTarget_unmanaged** pVal"],
+        ["MFEnumDeviceSources", "MFEnumDeviceSources", "winmdroot.Media.MediaFoundation.IMFAttributes pAttributes, out winmdroot.Media.MediaFoundation.IMFActivate_unmanaged** pppSourceActivate, out uint pcSourceActivate"],
     ];
 
     [Theory]


### PR DESCRIPTION
Parameters that are out pointers were losing levels of indirection in the PointerTypeHandleInfo.ToTypeSyntax conversion. Handle that case so at least these methods aren't completely broken. They're still not the most friendly to use because we don't have custom marshallers for these kinds of params, but at least they should function now.

Fixes #1257, Fixes #1463, Fixes #1229