### PR TITLE
Preserve pointer return types

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.MetadataHelpers.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.MetadataHelpers.cs
@@ -509,6 +509,12 @@ public partial class Generator
                     // Delegates appear as unmanaged function pointers when using structs instead of COM interfaces.
                     // But certain delegates are never declared as delegates.
                     result = this.options.AllowMarshaling && !this.IsUntypedDelegate(typeDef);
+                    if (this.UseSourceGenerators)
+                    {
+                        // We never allow managed delegates in fields for source-generated marshalling so these are always unmanaged.
+                        result = false;
+                    }
+
                     this.managedTypesCheck.Add(typeDefinitionHandle, result);
                     return result;
                 }

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -588,7 +588,10 @@ public partial class Generator : IGenerator, IDisposable
     /// <inheritdoc/>
     public void GenerateAllInteropTypes(CancellationToken cancellationToken)
     {
-        foreach (TypeDefinitionHandle typeDefinitionHandle in this.Reader.TypeDefinitions)
+        var sortedInteropTypes = this.Reader.TypeDefinitions.OrderBy(x => this.Reader.GetString(this.Reader.GetTypeDefinition(x).Namespace))
+                                                           .ThenBy(x => this.Reader.GetString(this.Reader.GetTypeDefinition(x).Name));
+
+        foreach (TypeDefinitionHandle typeDefinitionHandle in sortedInteropTypes)
         {
             cancellationToken.ThrowIfCancellationRequested();
             TypeDefinition typeDef = this.Reader.GetTypeDefinition(typeDefinitionHandle);

--- a/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PointerTypeHandleInfo.cs
@@ -28,6 +28,7 @@ internal record PointerTypeHandleInfo(TypeHandleInfo ElementType) : TypeHandleIn
         bool xOptional = (parameterAttributes & ParameterAttributes.Optional) == ParameterAttributes.Optional;
         bool mustUsePointers = xOptional && forElement == Generator.GeneratingElement.InterfaceMember && nativeArrayInfo is null;
         mustUsePointers |= this.ElementType is HandleTypeHandleInfo handleElementType && handleElementType.Generator.IsStructWithFlexibleArray(handleElementType) is true;
+        mustUsePointers |= inputs.IsReturnValue;
         if (mustUsePointers)
         {
             // Disable marshaling because pointers to optional parameters cannot be passed by reference when used as parameters of a COM interface method.

--- a/src/Microsoft.Windows.CsWin32/TypeSyntaxSettings.cs
+++ b/src/Microsoft.Windows.CsWin32/TypeSyntaxSettings.cs
@@ -11,6 +11,7 @@ internal record TypeSyntaxSettings(
     bool QualifyNames,
     bool IsField = false,
     bool PreferInOutRef = false,
-    bool AvoidWinmdRootAlias = false)
+    bool AvoidWinmdRootAlias = false,
+    bool IsReturnValue = false)
 {
 }

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -157,6 +157,15 @@ public partial class CsWin32GeneratorTests : CsWin32GeneratorTestsBase
         Assert.Contains(shellLinkType.DescendantNodes().OfType<MethodDeclarationSyntax>(), method => method.Identifier.Text == "CreateInstance");
     }
 
+    [Fact]
+    public async Task PointerReturnValueIsPreserved()
+    {
+        this.nativeMethods.Add("WTHelperProvDataFromStateData");
+        await this.InvokeGeneratorAndCompileFromFact();
+        var methodReturnTypes = this.FindGeneratedMethod("WTHelperProvDataFromStateData").Select(x => x.ReturnType.ToString());
+        Assert.Contains("winmdroot.Security.WinTrust.CRYPT_PROVIDER_DATA*", methodReturnTypes);
+    }
+
     public static IList<object[]> TestSignatureData => [
         ["IMFMediaKeySession", "get_KeySystem", "winmdroot.Foundation.BSTR* keySystem"],
         ["AddPrinterW", "AddPrinter", "winmdroot.Foundation.PWSTR pName, uint Level, Span<byte> pPrinter"],


### PR DESCRIPTION
When a function returns a pointer, like WTHelperProvDataFromStateData, we need to make sure that type is preserved in the cswin32 signature. We were losing the pointer indirection when PointerTypeHandleInfo was thinking it could use `out`. We can't do anything fancy to marshal pointer returns so we'll just pass along another bit in the TypeSyntaxSettings to let callees know it's a return value and force it to stay as pointer type.

I've also been diffing the outputs of the "FullGeneration" before/after changes like this but I kept getting stymied because the list of types and methods was not always in the same order. I added a step to sort those lists in the "GenerateAll" step. These methods are only called during testing so adding a sort doesn't seem too bad.

Fixes #992