### PR TITLE
Improve null checking of safe handles in friendly overloads

### DIFF
--- a/src/Microsoft.Windows.CsWin32/FastSyntaxFactory.cs
+++ b/src/Microsoft.Windows.CsWin32/FastSyntaxFactory.cs
@@ -194,7 +194,9 @@ internal static class FastSyntaxFactory
 
     internal static InitializerExpressionSyntax InitializerExpression(SyntaxKind kind, SeparatedSyntaxList<ExpressionSyntax> expressions) => SyntaxFactory.InitializerExpression(kind, OpenBrace, expressions, CloseBrace);
 
-    internal static ObjectCreationExpressionSyntax ObjectCreationExpression(TypeSyntax type) => SyntaxFactory.ObjectCreationExpression(Token(TriviaList(), SyntaxKind.NewKeyword, TriviaList(Space)), type, ArgumentList(), null);
+    internal static ObjectCreationExpressionSyntax ObjectCreationExpression(TypeSyntax type) => ObjectCreationExpression(type, ArgumentList());
+
+    internal static ObjectCreationExpressionSyntax ObjectCreationExpression(TypeSyntax type, ArgumentListSyntax argumentList) => SyntaxFactory.ObjectCreationExpression(Token(TriviaList(), SyntaxKind.NewKeyword, TriviaList(Space)), type, argumentList, null);
 
     internal static ArrayCreationExpressionSyntax ArrayCreationExpression(ArrayTypeSyntax type, InitializerExpressionSyntax? initializer = null) => SyntaxFactory.ArrayCreationExpression(Token(SyntaxKind.NewKeyword), type, initializer);
 

--- a/src/Microsoft.Windows.CsWin32/Generator.Features.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Features.cs
@@ -21,6 +21,7 @@ public partial class Generator
     private readonly bool overloadResolutionPriorityAttributePredefined;
     private readonly bool unscopedRefAttributePredefined;
     private readonly bool canUseComVariant;
+    private readonly bool canUseArgumentNullExceptionThrowIfNull;
     private readonly INamedTypeSymbol? runtimeFeatureClass;
     private readonly bool generateSupportedOSPlatformAttributes;
     private readonly bool generateSupportedOSPlatformAttributesOnInterfaces; // only supported on net6.0 (https://github.com/dotnet/runtime/pull/48838)

--- a/src/Microsoft.Windows.CsWin32/Generator.WhitespaceRewriter.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.WhitespaceRewriter.cs
@@ -97,7 +97,11 @@ public partial class Generator
         public override SyntaxNode? VisitBlock(BlockSyntax node)
         {
             SyntaxTriviaList leadingTrivia;
-            if (node.Parent is FixedStatementSyntax or AccessorDeclarationSyntax or TryStatementSyntax or FinallyClauseSyntax)
+            if (node.Parent is ElseClauseSyntax
+                            or FixedStatementSyntax
+                            or AccessorDeclarationSyntax
+                            or TryStatementSyntax
+                            or FinallyClauseSyntax)
             {
                 leadingTrivia = TriviaList(this.IndentTrivia);
             }
@@ -107,8 +111,8 @@ public partial class Generator
             }
 
             node = node
-                .WithOpenBraceToken(Token(leadingTrivia, SyntaxKind.OpenBraceToken, TriviaList(LineFeed)))
-                .WithCloseBraceToken(Token(TriviaList(this.IndentTrivia), SyntaxKind.CloseBraceToken, TriviaList(LineFeed)));
+                .WithOpenBraceToken(Token(leadingTrivia, SyntaxKind.OpenBraceToken, node.OpenBraceToken.TrailingTrivia))
+                .WithCloseBraceToken(Token(TriviaList(this.IndentTrivia), SyntaxKind.CloseBraceToken, node.CloseBraceToken.TrailingTrivia));
             using var indent = new Indent(this);
             return base.VisitBlock(node);
         }

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -125,6 +125,10 @@ public partial class Generator : IGenerator, IDisposable
         this.generateDefaultDllImportSearchPathsAttribute = this.compilation?.GetTypeByMetadataName(typeof(DefaultDllImportSearchPathsAttribute).FullName) is object;
         this.canUseIPropertyValue = this.compilation?.GetTypeByMetadataName("Windows.Foundation.IPropertyValue")?.DeclaredAccessibility == Accessibility.Public;
         this.canUseComVariant = this.compilation?.GetTypeByMetadataName("System.Runtime.InteropServices.Marshalling.ComVariant") is not null;
+
+        INamedTypeSymbol? argumentNullExceptionType = this.compilation?.GetTypeByMetadataName(typeof(ArgumentNullException).FullName);
+        this.canUseArgumentNullExceptionThrowIfNull = argumentNullExceptionType?.GetMembers("ThrowIfNull").Length > 0;
+
         if (this.FindTypeSymbolIfAlreadyAvailable("System.Runtime.Versioning.SupportedOSPlatformAttribute") is { } attribute)
         {
             this.generateSupportedOSPlatformAttributes = true;

--- a/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
@@ -78,6 +78,127 @@ public class FriendlyOverloadTests : GeneratorTestBase
         this.Generate(name);
     }
 
+    [Fact]
+    public void NullCheckOfSafeHandles_ModernOverload()
+    {
+        var expectedCodeGen = """
+            /// <inheritdoc cref="SignalObjectAndWait(winmdroot.Foundation.HANDLE, winmdroot.Foundation.HANDLE, uint, winmdroot.Foundation.BOOL)"/>
+            [SupportedOSPlatform("windows5.1.2600")]
+            internal static unsafe winmdroot.Foundation.WAIT_EVENT SignalObjectAndWait(SafeHandle hObjectToSignal, SafeHandle hObjectToWaitOn, uint dwMilliseconds, winmdroot.Foundation.BOOL bAlertable)
+            {
+                ArgumentNullException.ThrowIfNull(hObjectToSignal);
+                ArgumentNullException.ThrowIfNull(hObjectToWaitOn);
+
+                bool hObjectToSignalAddRef = false;
+                bool hObjectToWaitOnAddRef = false;
+                try
+                {
+                    hObjectToSignal.DangerousAddRef(ref hObjectToSignalAddRef);
+                    winmdroot.Foundation.HANDLE hObjectToSignalLocal = (winmdroot.Foundation.HANDLE)hObjectToSignal.DangerousGetHandle();
+                    hObjectToWaitOn.DangerousAddRef(ref hObjectToWaitOnAddRef);
+                    winmdroot.Foundation.HANDLE hObjectToWaitOnLocal = (winmdroot.Foundation.HANDLE)hObjectToWaitOn.DangerousGetHandle();
+                    winmdroot.Foundation.WAIT_EVENT __result = PInvoke.SignalObjectAndWait(hObjectToSignalLocal, hObjectToWaitOnLocal, dwMilliseconds, bAlertable);
+                    return __result;
+                }
+                finally
+                {
+                    if (hObjectToSignalAddRef)
+                        hObjectToSignal.DangerousRelease();
+                    if (hObjectToWaitOnAddRef)
+                        hObjectToWaitOn.DangerousRelease();
+                }
+            }
+            """;
+
+        this.compilation = this.starterCompilations["net8.0"];
+        this.AssertGeneratedApiFunction(
+            "SignalObjectAndWait",
+            m => m.ParameterList.Parameters is [{ Type: IdentifierNameSyntax { Identifier.ValueText: "SafeHandle" } }, ..],
+            expectedCodeGen);
+    }
+
+    [Fact]
+    public void NullCheckOfSafeHandles_ManualNullCheck()
+    {
+        var expectedCodeGen = """
+            /// <inheritdoc cref="SignalObjectAndWait(winmdroot.Foundation.HANDLE, winmdroot.Foundation.HANDLE, uint, winmdroot.Foundation.BOOL)"/>
+            internal static unsafe winmdroot.Foundation.WAIT_EVENT SignalObjectAndWait(SafeHandle hObjectToSignal, SafeHandle hObjectToWaitOn, uint dwMilliseconds, winmdroot.Foundation.BOOL bAlertable)
+            {
+                if (hObjectToSignal is null)
+                {
+                    throw new ArgumentNullException(nameof(hObjectToSignal));
+                }
+                if (hObjectToWaitOn is null)
+                {
+                    throw new ArgumentNullException(nameof(hObjectToWaitOn));
+                }
+            
+                bool hObjectToSignalAddRef = false;
+                bool hObjectToWaitOnAddRef = false;
+                try
+                {
+                    hObjectToSignal.DangerousAddRef(ref hObjectToSignalAddRef);
+                    winmdroot.Foundation.HANDLE hObjectToSignalLocal = (winmdroot.Foundation.HANDLE)hObjectToSignal.DangerousGetHandle();
+                    hObjectToWaitOn.DangerousAddRef(ref hObjectToWaitOnAddRef);
+                    winmdroot.Foundation.HANDLE hObjectToWaitOnLocal = (winmdroot.Foundation.HANDLE)hObjectToWaitOn.DangerousGetHandle();
+                    winmdroot.Foundation.WAIT_EVENT __result = PInvoke.SignalObjectAndWait(hObjectToSignalLocal, hObjectToWaitOnLocal, dwMilliseconds, bAlertable);
+                    return __result;
+                }
+                finally
+                {
+                    if (hObjectToSignalAddRef)
+                        hObjectToSignal.DangerousRelease();
+                    if (hObjectToWaitOnAddRef)
+                        hObjectToWaitOn.DangerousRelease();
+                }
+            }
+            """;
+
+        this.compilation = this.starterCompilations["net472"];
+        this.AssertGeneratedApiFunction(
+            "SignalObjectAndWait",
+            m => m.ParameterList.Parameters is [{ Type: IdentifierNameSyntax { Identifier.ValueText: "SafeHandle" } }, ..],
+            expectedCodeGen);
+    }
+
+    [Fact]
+    public void OptionalHandleParameter()
+    {
+        var expectedCodeGen = """
+            /// <inheritdoc cref="SetThreadToken(winmdroot.Foundation.HANDLE*, winmdroot.Foundation.HANDLE)"/>
+            internal static unsafe winmdroot.Foundation.BOOL SetThreadToken(winmdroot.Foundation.HANDLE? Thread, SafeHandle Token)
+            {
+                bool TokenAddRef = false;
+                try
+                {
+                    winmdroot.Foundation.HANDLE ThreadLocal = Thread ?? default(winmdroot.Foundation.HANDLE);
+                    winmdroot.Foundation.HANDLE TokenLocal;
+                    if (Token is object)
+                    {
+                        Token.DangerousAddRef(ref TokenAddRef);
+                        TokenLocal = (winmdroot.Foundation.HANDLE)Token.DangerousGetHandle();
+                    }
+                    else
+                    {
+                        TokenLocal = (winmdroot.Foundation.HANDLE )new IntPtr(0L);
+                    }
+                    winmdroot.Foundation.BOOL __result = PInvoke.SetThreadToken(Thread.HasValue ? &ThreadLocal : null, TokenLocal);
+                    return __result;
+                }
+                finally
+                {
+                    if (TokenAddRef)
+                        Token.DangerousRelease();
+                }
+            }
+            """;
+
+        this.AssertGeneratedApiFunction(
+            "SetThreadToken",
+            m => m.ParameterList.Parameters is [_, { Type: IdentifierNameSyntax { Identifier.ValueText: "SafeHandle" } }],
+            expectedCodeGen);
+    }
+
     private void Generate(string name)
     {
         this.compilation = this.compilation.WithOptions(this.compilation.Options.WithPlatform(Platform.X64));


### PR DESCRIPTION
Before this change null checking of safe handles inside friendly overloads was hapenning inside main method logic, e.g.:
```cs
internal static unsafe winmdroot.Foundation.WAIT_EVENT SignalObjectAndWait(SafeHandle hObjectToSignal, SafeHandle hObjectToWaitOn, uint dwMilliseconds, winmdroot.Foundation.BOOL bAlertable)
{
	bool hObjectToSignalAddRef = false;
	bool hObjectToWaitOnAddRef = false;
	try
	{
		winmdroot.Foundation.HANDLE hObjectToSignalLocal;
		if (hObjectToSignal is object)
		{
			hObjectToSignal.DangerousAddRef(ref hObjectToSignalAddRef);
			hObjectToSignalLocal = (winmdroot.Foundation.HANDLE)hObjectToSignal.DangerousGetHandle();
		}
		else
			throw new ArgumentNullException(nameof(hObjectToSignal));
		winmdroot.Foundation.HANDLE hObjectToWaitOnLocal;
		if (hObjectToWaitOn is object)
		{
			hObjectToWaitOn.DangerousAddRef(ref hObjectToWaitOnAddRef);
			hObjectToWaitOnLocal = (winmdroot.Foundation.HANDLE)hObjectToWaitOn.DangerousGetHandle();
		}
		else
			throw new ArgumentNullException(nameof(hObjectToWaitOn));
		winmdroot.Foundation.WAIT_EVENT __result = PInvoke.SignalObjectAndWait(hObjectToSignalLocal, hObjectToWaitOnLocal, dwMilliseconds, bAlertable);
		return __result;
	}
	finally
	{
		if (hObjectToSignalAddRef)
			hObjectToSignal.DangerousRelease();
		if (hObjectToWaitOnAddRef)
			hObjectToWaitOn.DangerousRelease();
	}
}
```
This meant that some logic could be executed before validating an incoming argument. Moved validation to the top of the method to avoid that. This also gives us an ability to use more idiomatic `ArgumentNullException.ThrowIfNull()` API on modern .NET versions