### PR TITLE
Add test for cross-winmd IInspectable derivation and fix a tiny bug

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Com.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Com.cs
@@ -134,7 +134,7 @@ public partial class Generator
                     foreach (QualifiedTypeDefinitionHandle baseType in baseTypes)
                     {
                         TypeDefinition baseTypeDef = baseType.Generator.Reader.GetTypeDefinition(baseType.DefinitionHandle);
-                        if (this.FindGuidAttribute(baseTypeDef.GetCustomAttributes()) is null)
+                        if (baseType.Generator.FindGuidAttribute(baseTypeDef.GetCustomAttributes()) is null)
                         {
                             canDeclareAsInterface = false;
                             break;

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -544,16 +544,19 @@ using global::System.Runtime.Versioning;
     }
 
     [Theory, CombinatorialData]
-    public void CrossWinMD_IInspectable(
+    public async Task CrossWinMD_IInspectable(
         [CombinatorialValues([false, true])] bool allowMarshaling,
         [CombinatorialValues([null, "TestPInvoke"])] string pinvokeClassName,
         [CombinatorialValues(["net8.0", "net9.0"])] string tfm)
     {
         this.compilation = this.starterCompilations[tfm];
-        this.win32winmdPaths = [.. this.win32winmdPaths, CustomIInspectableMetadataPath];
-        this.nativeMethodsJsonOptions = new(AllowMarshaling = allowMarshaling, ClassName = pinvokeClassName);
+        this.win32winmdPaths = [.. this.win32winmdPaths!, CustomIInspectableMetadataPath];
+        this.nativeMethodsJsonOptions = new NativeMethodsJsonOptions
+        {
+            AllowMarshaling = allowMarshaling,
+            ClassName = pinvokeClassName,
+        };
         this.nativeMethods.Add("ITestDerivedFromInspectable");
         await this.InvokeGeneratorAndCompile($"{nameof(this.CrossWinMD_IInspectable)}_{tfm}_{allowMarshaling}_{pinvokeClassName ?? "null"}");
     }
-
 }

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTestsBase.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTestsBase.cs
@@ -43,8 +43,6 @@ public partial class CsWin32GeneratorTestsBase : GeneratorTestBase
     protected string[]? win32winmdPaths;
     protected NativeMethodsJsonOptions? nativeMethodsJsonOptions;
 
-    protected static readonly string CustomIInspectableMetadataPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location!)!, "ExternalMetadata", "CustomIInspectable.winmd");
-
     public CsWin32GeneratorTestsBase(ITestOutputHelper logger)
         : base(logger)
     {
@@ -108,11 +106,12 @@ public partial class CsWin32GeneratorTestsBase : GeneratorTestBase
             File.WriteAllLines(nativeMethodsTxtPath, this.nativeMethods);
         }
 
-        if (this.nativeMethodsJsonOptions is NativeMethodsJsonOptions options)
+        if (this.nativeMethodsJsonOptions is NativeMethodsJsonOptions generatorOptions)
         {
             string nativeMethodsJsonPath = Path.Combine(this.GetTestCaseOutputDirectory(testCase), "NativeMethods.json");
             var jsonOptions = new System.Text.Json.JsonSerializerOptions { WriteIndented = true };
-            string jsonContent = System.Text.Json.JsonSerializer.Serialize(options, jsonOptions);
+            jsonOptions.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault;
+            string jsonContent = System.Text.Json.JsonSerializer.Serialize(generatorOptions, jsonOptions);
             File.WriteAllText(nativeMethodsJsonPath, jsonContent);
             this.nativeMethodsJson = Path.GetFileName(nativeMethodsJsonPath);
         }


### PR DESCRIPTION
We were trying to use the new source generators mode with a custom winmd and ran into a "read out of bounds" crash. I realized I hadn't written a test case for this in the source generators environment. Once I did it repro'd the bug and I fixed it: Some new code was using the wrong Generator for reading a typeDef.