### PR TITLE
Improve intellisense experience with CsWin32RunAsBuildTask mode

### DIFF
--- a/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.targets
+++ b/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.targets
@@ -93,5 +93,14 @@
       <FileWrites Include="@(CsWin32GeneratorOutputs)" />
       <FileWrites Include="$(CsWin32GeneratorGeneratedFilesList)" Condition="Exists('$(CsWin32GeneratorGeneratedFilesList)')" />
     </ItemGroup>
+
   </Target>
+
+  <!-- Add the items to AdditionalDesignTimeBuildInput as well so that DesignTimeBuilds re-run when NativeMethods.txt contents change.
+       VS seems to evaluate this directly (not looking at the DesignTimeBuild outputs) and so we can't do it in a Target.
+       And VS doesn't support conditions on FileName or things like that in a top-level ItemGroup so just include all AdditionalFiles 
+       as ContentSensitive. Worst case the DesignTimeBuild runs on files other than NativeMethods.txt. -->
+  <ItemGroup Condition="'$(CsWin32RunAsBuildTask)'=='true'">
+    <AdditionalDesignTimeBuildInput Include="@(AdditionalFiles)" ContentSensitive="true" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
We were seeing situations where DesignTimeBuild was not re-running when folks changed NativeMethods.txt and that caused the intellisense experience to get out of sync with the build. @davkean suggested I use AdditionalDesignTimeBuildInput and that seems to do the trick.

The downside is that this ItemGroup seems to need to be populated during project evaluation and can't be the output of an ItemGroup, and that limits our ability to use any kind of complex conditions. I ended up having to grab all AdditionalFiles instead of AdditionalFiles which end in NativeMethods.txt.