### PR TITLE
Update win32metadata to latest (68.0.4-preview)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <MicroBuildVersion>2.0.201</MicroBuildVersion>
-    <MetadataVersion>65.0.8-preview</MetadataVersion>
+    <MetadataVersion>68.0.4-preview</MetadataVersion>
     <WDKMetadataVersion>0.13.25-experimental</WDKMetadataVersion>
     <!-- <DiaMetadataVersion>0.2.185-preview-g7e1e6a442c</DiaMetadataVersion> -->
     <ApiDocsVersion>0.1.42-alpha</ApiDocsVersion>

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -171,7 +171,7 @@ public partial class CsWin32GeneratorTests : CsWin32GeneratorTestsBase
 
     public static IList<object[]> TestSignatureData => [
         ["IMFMediaKeySession", "get_KeySystem", "winmdroot.Foundation.BSTR* keySystem"],
-        ["AddPrinterW", "AddPrinter", "winmdroot.Foundation.PWSTR pName, uint Level, Span<byte> pPrinter"],
+        ["AddPrinterW", "AddPrinter", "string pName, uint Level, Span<byte> pPrinter"],
         // MemorySized-struct param should have Span<byte> parameter.
         ["SHGetFileInfo", "SHGetFileInfo", "string pszPath, winmdroot.Storage.FileSystem.FILE_FLAGS_AND_ATTRIBUTES dwFileAttributes, Span<byte> psfi, winmdroot.UI.Shell.SHGFI_FLAGS uFlags"],
         // MemorySized-struct param should also have a version with `ref struct` parameter.

--- a/test/Microsoft.Windows.CsWin32.Tests/ExternMethodTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/ExternMethodTests.cs
@@ -126,8 +126,8 @@ public class ExternMethodTests : GeneratorTestBase
     {
         this.compilation = this.starterCompilations["net35"];
         this.GenerateApi("AddPrinter");
-        var methodSignatures = this.FindGeneratedMethod("AddPrinter_SafeHandle").Select(x => x.ParameterList.ToString());
-        Assert.Contains("(winmdroot.Foundation.PWSTR pName, uint Level, byte* pPrinter)", methodSignatures);
+        var methodSignatures = this.FindGeneratedMethod("AddPrinter").Select(x => x.ParameterList.ToString());
+        Assert.Contains("(string pName, uint Level, byte* pPrinter)", methodSignatures);
     }
 
     private static AttributeSyntax? FindDllImportAttribute(SyntaxList<AttributeListSyntax> attributeLists) => attributeLists.SelectMany(al => al.Attributes).FirstOrDefault(a => a.Name.ToString() == "DllImport");


### PR DESCRIPTION
Update win32metadata to latest. This aligns with the 10.0.26100.6584 SDK.

Minor test update as AddPrinter's first param is [Const] now which means it projects as string instead of PWSTR. Yay!