### PR TITLE
Minor modification to improve WinRT source generation

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -1082,7 +1082,7 @@ public partial class Generator : IGenerator, IDisposable
                     {
                         AssemblyReference assemblyRef = this.Reader.GetAssemblyReference((AssemblyReferenceHandle)typeRef.ResolutionScope);
                         string scope = this.Reader.GetString(assemblyRef.Name);
-                        if (scope != "Windows.Foundation.UniversalApiContract")
+                        if (scope != "Windows.Foundation.UniversalApiContract" && scope != "Windows.Foundation.FoundationContract")
                         {
                             throw new GenerationFailedException($"Input metadata file \"{scope}\" has not been provided, or is referenced at a version that is lacking the type \"{metadataName}\".");
                         }


### PR DESCRIPTION
Exceptions are no longer thrown when interop type metadata requests fail within the Windows.Foundation.FoundationContract scope.