### PR TITLE
Bump metadata version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <MicroBuildVersion>2.0.201</MicroBuildVersion>
-    <MetadataVersion>69.0.7-preview</MetadataVersion>
+    <MetadataVersion>70.0.11-preview</MetadataVersion>
     <WDKMetadataVersion>0.13.25-experimental</WDKMetadataVersion>
     <!-- <DiaMetadataVersion>0.2.185-preview-g7e1e6a442c</DiaMetadataVersion> -->
     <ApiDocsVersion>0.1.42-alpha</ApiDocsVersion>

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTestsBase.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTestsBase.cs
@@ -247,11 +247,7 @@ using System.Runtime.CompilerServices;
                 }
             }
 
-            // Filter out SYSLIB1092 diagnostics (related to DisableRuntimeMarshalling) as they are expected
-            var filteredGeneratorDiagnostics = generatorDiagnostics.Where(d =>
-                !(d.Descriptor.Id == "SYSLIB1092" && d.Descriptor.Title.ToString().Contains("The return value in the managed definition will be converted to an additional 'out' parameter at the end of the parameter list when calling the unmanaged COM method.", StringComparison.OrdinalIgnoreCase)));
-
-            allDiagnostics.AddRange(filteredGeneratorDiagnostics);
+            allDiagnostics.AddRange(generatorDiagnostics.Where(d => !d.IsSuppressed));
         }
         else
         {


### PR DESCRIPTION
Bumps metadata version. It took ober an hour on my machine, but I swear I ran all the tests including the "full generation" ones, added a little test fix and all tests where green