### PR TITLE
Promote handle pointer to an `out` reference if handle cannot be trivially represented as a `SafeHandle`

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -364,13 +364,13 @@ public partial class Generator
                 pointedElementInfo.Generator.TryGetHandleReleaseMethod(pointedElementInfo.Handle, paramAttributes, out string? outReleaseMethod) && !this.Reader.StringComparer.Equals(methodDefinition.Name, outReleaseMethod) &&
                 (memorySize is null) && !isArray)
             {
+                signatureChanged = true;
+
+                IdentifierNameSyntax localName = IdentifierName(externParam.Identifier.ValueText + "Local");
+
                 // NOTE: We don't handle scenarios where the parameter is [MemorySize] annotated (e.g. EnumProcessModules) or [NativeArrayInfo] (e.g. ITypeInfo.GetNames)
                 if (this.RequestSafeHandle(outReleaseMethod) is TypeSyntax safeHandleType)
                 {
-                    signatureChanged = true;
-
-                    IdentifierNameSyntax typeDefHandleName = IdentifierName(externParam.Identifier.ValueText + "Local");
-
                     // out SafeHandle
                     parameters[paramIndex] = externParam
                         .WithType(safeHandleType.WithTrailingTrivia(TriviaList(Space)))
@@ -381,7 +381,7 @@ public partial class Generator
                         LocalDeclarationStatement(
                             VariableDeclaration(
                                 pointedElementInfo.ToTypeSyntax(parameterTypeSyntaxSettings, GeneratingElement.FriendlyOverload, null).Type,
-                                [VariableDeclarator(typeDefHandleName.Identifier)])));
+                                [VariableDeclarator(localName.Identifier)])));
 
                     ArgumentSyntax ownsHandleArgument = Argument(
                         NameColon(IdentifierName("ownsHandle")),
@@ -408,7 +408,7 @@ public partial class Generator
                                         IdentifierName("InitHandle")),
                                     [
                                         Argument(origName),
-                                        Argument(this.GetIntPtrFromTypeDef(typeDefHandleName, pointedElementInfo)),
+                                        Argument(this.GetIntPtrFromTypeDef(localName, pointedElementInfo)),
                                     ])));
                     }
                     else
@@ -417,11 +417,32 @@ public partial class Generator
                         trailingStatements.Add(ExpressionStatement(AssignmentExpression(
                             SyntaxKind.SimpleAssignmentExpression,
                             origName,
-                            ObjectCreationExpression(safeHandleType, [Argument(this.GetIntPtrFromTypeDef(typeDefHandleName, pointedElementInfo)), ownsHandleArgument]))));
+                            ObjectCreationExpression(safeHandleType, [Argument(this.GetIntPtrFromTypeDef(localName, pointedElementInfo)), ownsHandleArgument]))));
                     }
 
                     // Argument: &SomeLocal
-                    arguments[paramIndex] = Argument(PrefixUnaryExpression(SyntaxKind.AddressOfExpression, typeDefHandleName));
+                    arguments[paramIndex] = Argument(PrefixUnaryExpression(SyntaxKind.AddressOfExpression, localName));
+                }
+                else
+                {
+                    // If we were not able to upgrade the handle to a SafeHandle, at least make it a managed out reference
+                    TypeSyntax underlyingType = ((PointerTypeSyntax)externParam.Type).ElementType;
+
+                    // out ORIGINAL_HANDLE_TYPE
+                    parameters[paramIndex] = externParam
+                        .WithType(underlyingType.WithTrailingTrivia(TriviaList(Space)))
+                        .WithModifiers([TokenWithSpace(SyntaxKind.OutKeyword)]);
+
+                    // fixed (ORIGINAL_HANDLE_TYPE* someHandleLocal = &someHandle)
+                    fixedBlocks.Add(
+                        VariableDeclaration(
+                            externParam.Type,
+                            [VariableDeclarator(
+                                localName.Identifier,
+                                EqualsValueClause(
+                                    PrefixUnaryExpression(SyntaxKind.AddressOfExpression, IdentifierName(externParam.Identifier))))]));
+
+                    arguments[paramIndex] = Argument(localName);
                 }
             }
             else if (this.options.UseSafeHandles && isIn && !isOut && !isReleaseMethod && parameterTypeInfo is HandleTypeHandleInfo parameterHandleTypeInfo && this.TryGetHandleReleaseMethod(parameterHandleTypeInfo.Handle, paramAttributes, out string? releaseMethod) && !this.Reader.StringComparer.Equals(methodDefinition.Name, releaseMethod)

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -223,6 +223,8 @@ public partial class CsWin32GeneratorTests : CsWin32GeneratorTestsBase
         ["Windows.Win32.NetworkManagement.WindowsFilteringPlatform.FwpmEngineOpen0", "FwpmEngineOpen0", "[Optional] winmdroot.Foundation.PCWSTR serverName, uint authnService, [Optional] winmdroot.System.Rpc.SEC_WINNT_AUTH_IDENTITY_W* authIdentity, [Optional] winmdroot.NetworkManagement.WindowsFilteringPlatform.FWPM_SESSION0* session, winmdroot.NetworkManagement.WindowsFilteringPlatform.FWPM_ENGINE_HANDLE* engineHandle"],
         // WlanCloseHandle accepts an additional reserved parameter. We can still generate safe hanlde for WlanOpenHandle then
         ["WlanOpenHandle", "WlanOpenHandle", "uint dwClientVersion, out uint pdwNegotiatedVersion, out global::Windows.Win32.WlanCloseHandleSafeHandle phClientHandle"],
+        // Has an out reference of a handle that cannot be trivially converted to a SafeHandle
+        ["Windows.Win32.NetworkManagement.WindowsFilteringPlatform.FwpmFilterCreateEnumHandle0", "FwpmFilterCreateEnumHandle0", "SafeHandle engineHandle, [Optional] winmdroot.NetworkManagement.WindowsFilteringPlatform.FWPM_FILTER_ENUM_TEMPLATE0? enumTemplate, out winmdroot.NetworkManagement.WindowsFilteringPlatform.FWPM_FILTER_ENUM_HANDLE enumHandle"]
     ];
 
     [Theory]


### PR DESCRIPTION
Complementary to https://github.com/microsoft/win32metadata/pull/2192, fixes the issue described in [this comment](https://github.com/microsoft/win32metadata/pull/2192#issuecomment-3727453418)