### PR TITLE
Update components to fix CVEs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- We have to use the MessagePack version used by win32metadata (https://github.com/microsoft/CsWin32/issues/371) -->
-    <PackageVersion Include="MessagePack" Version="2.2.85" />
+    <PackageVersion Include="MessagePack" Version="2.5.187" />
     <PackageVersion Include="MessagePackAnalyzer" Version="2.5.192" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.11.6" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.106",
     "rollForward": "patch",
     "allowPrerelease": false
   },


### PR DESCRIPTION
DotNet SDK update for [multiple CVEs](https://github.com/dotnet/core/blob/main/release-notes/10.0/10.0.6/10.0.6.md?WT.mc_id=dotnet-35129-website)
MessagePack update for CVE-2024-48924 . 

According to #371, this update also requires a simultaneous update in win32metadata, but [win32metadata seems to be already on this version](https://github.com/microsoft/win32metadata/blob/278d01c46c731ee672c04f773e24356f4999e570/apidocs/Microsoft.Windows.SDK.Win32Docs/Microsoft.Windows.SDK.Win32Docs.csproj#L23).