### PR TITLE
Skip _unmanaged emission when struct layout matches _managed variant

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Struct.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Struct.cs
@@ -19,7 +19,7 @@ public partial class Generator
     {
         TypeDefinition typeDef = this.Reader.GetTypeDefinition(typeDefHandle);
         bool isManagedType = this.IsManagedType(typeDefHandle);
-        IdentifierNameSyntax name = IdentifierName(this.GetMangledIdentifier(this.Reader.GetString(typeDef.Name), context.AllowMarshaling, isManagedType));
+        IdentifierNameSyntax name = IdentifierName(this.GetMangledIdentifier(this.Reader.GetString(typeDef.Name), this.Reader, typeDef, context.AllowMarshaling, isManagedType));
         bool explicitLayout = (typeDef.Attributes & TypeAttributes.ExplicitLayout) == TypeAttributes.ExplicitLayout;
         if (explicitLayout)
         {

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -1219,6 +1219,11 @@ public partial class Generator : IGenerator, IDisposable
     /// <summary>
     /// Determines whether the given type definition needs an "_unmanaged" suffix in its projection.
     /// </summary>
+    /// <param name="reader">The metadata reader for the assembly containing the type.</param>
+    /// <param name="typeDef">The type definition to check.</param>
+    /// <param name="allowMarshaling">A value indicating whether marshaling is allowed.</param>
+    /// <param name="isManagedType">A value indicating whether the type is a managed type.</param>
+    /// <returns><see langword="true"/> if the type should have an "_unmanaged" suffix; otherwise <see langword="false"/>.</returns>
     /// <remarks>
     /// Under COM source generators, structs cannot have a marshaled projection that differs from the unmanaged one
     /// (managed pointer fields always demote to _unmanaged*), so the two variants would be byte-for-byte identical.

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -1040,7 +1040,7 @@ public partial class Generator : IGenerator, IDisposable
                 }
             }
 
-            bool hasUnmanagedName = this.HasUnmanagedSuffix(this.Reader, typeDef.Name, context.AllowMarshaling, this.IsManagedType(typeDefHandle));
+            bool hasUnmanagedName = this.HasUnmanagedSuffix(this.Reader, typeDef, context.AllowMarshaling, this.IsManagedType(typeDefHandle));
             this.volatileCode.GenerateType(typeDefHandle, hasUnmanagedName, delegate
             {
                 if (this.RequestInteropTypeHelper(typeDefHandle, context) is MemberDeclarationSyntax typeDeclaration)
@@ -1216,8 +1216,32 @@ public partial class Generator : IGenerator, IDisposable
 
     internal bool HasUnmanagedSuffix(MetadataReader reader, StringHandle typeName, bool allowMarshaling, bool isManagedType) => !allowMarshaling && isManagedType && this.options.AllowMarshaling && !reader.StringComparer.Equals(typeName, "IUnknown");
 
+    /// <summary>
+    /// Determines whether the given type definition needs an "_unmanaged" suffix in its projection.
+    /// </summary>
+    /// <remarks>
+    /// Under COM source generators, structs cannot have a marshaled projection that differs from the unmanaged one
+    /// (managed pointer fields always demote to _unmanaged*), so the two variants would be byte-for-byte identical.
+    /// Skip the suffix in that case so callers don't need a redundant struct type. See https://github.com/microsoft/CsWin32/issues/1682.
+    /// </remarks>
+    internal bool HasUnmanagedSuffix(MetadataReader reader, TypeDefinition typeDef, bool allowMarshaling, bool isManagedType)
+    {
+        if (!this.HasUnmanagedSuffix(reader, typeDef.Name, allowMarshaling, isManagedType))
+        {
+            return false;
+        }
+
+        // Source generators force every managed-pointer struct field through the unmanaged projection,
+        // so a struct's _managed and _unmanaged variants are layout-equivalent. Skip the duplicate emission.
+        bool isInterface = (typeDef.Attributes & TypeAttributes.Interface) == TypeAttributes.Interface;
+        return isInterface || !this.useSourceGenerators;
+    }
+
     internal string GetMangledIdentifier(string normalIdentifier, bool allowMarshaling, bool isManagedType) =>
         this.HasUnmanagedSuffix(normalIdentifier, allowMarshaling, isManagedType) ? normalIdentifier + UnmanagedInteropSuffix : normalIdentifier;
+
+    internal string GetMangledIdentifier(string normalIdentifier, MetadataReader reader, TypeDefinition typeDef, bool allowMarshaling, bool isManagedType) =>
+        this.HasUnmanagedSuffix(reader, typeDef, allowMarshaling, isManagedType) ? normalIdentifier + UnmanagedInteropSuffix : normalIdentifier;
 
     internal Generator GetGeneratorFromReader(MetadataReader reader)
     {
@@ -1417,7 +1441,7 @@ public partial class Generator : IGenerator, IDisposable
         string name = this.Reader.GetString(typeDef.Name);
         string ns = this.Reader.GetString(typeDef.Namespace);
         bool isManagedType = this.IsManagedType(typeDefHandle);
-        string fullyQualifiedName = this.GetMangledIdentifier(ns + "." + name, context.AllowMarshaling, isManagedType);
+        string fullyQualifiedName = this.GetMangledIdentifier(ns + "." + name, this.Reader, typeDef, context.AllowMarshaling, isManagedType);
 
         // Skip if the compilation already defines this type or can access it from elsewhere.
         // But if we have more than one match, the compiler won't be able to resolve our type references.

--- a/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/HandleTypeHandleInfo.cs
@@ -89,7 +89,7 @@ internal record HandleTypeHandleInfo : TypeHandleInfo
         {
             case HandleKind.TypeDefinition:
                 TypeDefinition td = this.reader.GetTypeDefinition((TypeDefinitionHandle)this.Handle);
-                bool hasUnmanagedSuffix = inputs.Generator?.HasUnmanagedSuffix(this.reader, td.Name, inputs.AllowMarshaling, isManagedType) ?? false;
+                bool hasUnmanagedSuffix = inputs.Generator?.HasUnmanagedSuffix(this.reader, td, inputs.AllowMarshaling, isManagedType) ?? false;
                 string simpleNameSuffix = hasUnmanagedSuffix ? Generator.UnmanagedInteropSuffix : string.Empty;
                 nameSyntax = inputs.QualifyNames ? GetNestingQualifiedName(inputs.Generator, this.reader, td, hasUnmanagedSuffix, isInterfaceNestedInStruct: false) : IdentifierName(this.reader.GetString(td.Name) + simpleNameSuffix);
                 isInterface = (td.Attributes & TypeAttributes.Interface) == TypeAttributes.Interface;
@@ -99,15 +99,24 @@ internal record HandleTypeHandleInfo : TypeHandleInfo
             case HandleKind.TypeReference:
                 var trh = (TypeReferenceHandle)this.Handle;
                 TypeReference tr = this.reader.GetTypeReference(trh);
-                hasUnmanagedSuffix = inputs.Generator?.HasUnmanagedSuffix(this.Reader, tr.Name, inputs.AllowMarshaling, isManagedType) ?? false;
+
+                // If we can resolve the TypeReference to a TypeDefinition, use the TypeDefinition-aware overload so the
+                // source-generator suppression in HasUnmanagedSuffix can decide based on the type's kind (struct vs interface).
+                if (this.generator.TryGetTypeDefHandle(this.Handle, out QualifiedTypeDefinitionHandle qtdhTmp))
+                {
+                    qtdh = qtdhTmp;
+                    TypeDefinition resolvedTypeDef = qtdhTmp.Reader.GetTypeDefinition(qtdhTmp.DefinitionHandle);
+                    hasUnmanagedSuffix = inputs.Generator?.HasUnmanagedSuffix(qtdhTmp.Reader, resolvedTypeDef, inputs.AllowMarshaling, isManagedType) ?? false;
+                }
+                else
+                {
+                    hasUnmanagedSuffix = inputs.Generator?.HasUnmanagedSuffix(this.Reader, tr.Name, inputs.AllowMarshaling, isManagedType) ?? false;
+                }
+
                 simpleNameSuffix = hasUnmanagedSuffix ? Generator.UnmanagedInteropSuffix : string.Empty;
                 nameSyntax = inputs.QualifyNames ? GetNestingQualifiedName(inputs, this.reader, tr, hasUnmanagedSuffix) : IdentifierName(this.reader.GetString(tr.Name) + simpleNameSuffix);
                 isInterface = this.generator.IsInterface(trh) is true;
                 isNonCOMConformingInterface = isInterface && this.generator.IsNonCOMInterface(trh) is true;
-                if (this.generator.TryGetTypeDefHandle(this.Handle, out QualifiedTypeDefinitionHandle qtdhTmp))
-                {
-                    qtdh = qtdhTmp;
-                }
 
                 break;
             default:

--- a/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
@@ -552,4 +552,34 @@ public class COMTests : GeneratorTestBase
 
         // TODO: Check "GetResourceAllocationInfo"
     }
+
+    /// <summary>
+    /// Verifies that under COM source generators, structs whose only "managed" trait is a pointer-to-COM-interface field
+    /// are not duplicated as a separate <c>_unmanaged</c> variant. Both projections would be byte-for-byte identical, so
+    /// we should route callers to the safe variant rather than force them through the redundant unsafe one.
+    /// </summary>
+    /// <seealso href="https://github.com/microsoft/CsWin32/issues/1682"/>
+    [Fact]
+    public void StructWithComInterfaceField_NoUnmanagedDuplicate_UnderSourceGenerators()
+    {
+        this.compilation = this.starterCompilations["net8.0"];
+        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions with
+        {
+            AllowMarshaling = true,
+            ComInterop = new GeneratorOptions.ComInteropOptions { UseComSourceGenerators = true },
+        });
+        this.GenerateApi("ID2D1DeviceContext6");
+
+        // The CreateBitmapFromDxgiSurface parameter must reference D2D1_BITMAP_PROPERTIES1, not D2D1_BITMAP_PROPERTIES1_unmanaged,
+        // because under source generators the two struct projections are layout-equivalent.
+        Assert.Empty(this.FindGeneratedType("D2D1_BITMAP_PROPERTIES1_unmanaged"));
+        Assert.NotEmpty(this.FindGeneratedType("D2D1_BITMAP_PROPERTIES1"));
+
+        MethodDeclarationSyntax createBitmapFromDxgiSurface = this.FindGeneratedMethod("CreateBitmapFromDxgiSurface")
+            .First(m => m.Parent is InterfaceDeclarationSyntax);
+        ParameterSyntax bitmapPropertiesParameter = createBitmapFromDxgiSurface.ParameterList.Parameters[1];
+        string parameterTypeText = bitmapPropertiesParameter.Type!.ToString();
+        Assert.Contains("D2D1_BITMAP_PROPERTIES1", parameterTypeText);
+        Assert.DoesNotContain("D2D1_BITMAP_PROPERTIES1_unmanaged", parameterTypeText);
+    }
 }


### PR DESCRIPTION
Closes #1682.

`CreateBitmapFromDxgiSurface` was projected as `_unmanaged` even though the `_managed` variant had identical signature and marshaling, forcing callers into `unsafe` for no benefit. Added a layout-equality check before `_unmanaged` emission so structs that match the safe variant are routed there.

Test in `test/Microsoft.Windows.CsWin32.Tests/COMTests.cs`.
