### PR TITLE
Add GitHub Actions workflow to run all tests in PR

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@
 
 * There should generally be one test project (under the `test` directory) per shipping project (under the `src` directory). Test projects are named after the project being tested with a `.Test` suffix.
 * Tests should use the Xunit testing framework.
-* Some tests are known to be unstable. When running tests, you should skip the unstable ones by running `dotnet test --filter "TestCategory!=FailsInCloudTest"`.
+* Some tests are known to be unstable or require special hardware. When running tests locally, you can skip hardware-dependent tests by running `dotnet test --filter "TestCategory!=RequiresHardware"`. To also skip high-memory tests (which each consume ~4GB), add `&TestCategory!=HighMemory` to the filter.
 
 ## Coding style
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ env:
   BuildConfiguration: Release
 
 jobs:
-  build:
-    name: 🛠️ Build
-    runs-on: ubuntu-latest
+  test-fast-windows:
+    name: 🧪 Tests (Windows)
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -32,29 +32,6 @@ jobs:
       shell: pwsh
     - name: 🛠️ Build
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
-    - name: 📦 Upload build output
-      uses: actions/upload-artifact@v4
-      with:
-        name: build-output
-        path: bin/
-        retention-days: 1
-
-  test-fast-windows:
-    name: 🧪 Tests (Windows)
-    needs: build
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: ⚙️ Install prerequisites
-      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
-      shell: pwsh
-    - name: 📦 Download build
-      uses: actions/download-artifact@v4
-      with:
-        name: build-output
-        path: bin/
     - name: 🧪 Run tests
       run: |
         dotnet test --no-build -c ${{ env.BuildConfiguration }} `
@@ -74,7 +51,6 @@ jobs:
 
   test-fast-linux:
     name: 🧪 Tests (Linux)
-    needs: build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -83,11 +59,8 @@ jobs:
     - name: ⚙️ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
       shell: pwsh
-    - name: 📦 Download build
-      uses: actions/download-artifact@v4
-      with:
-        name: build-output
-        path: bin/
+    - name: 🛠️ Build
+      run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
     - name: 🧪 Run tests
       run: |
         dotnet test --no-build -c ${{ env.BuildConfiguration }} `
@@ -107,7 +80,6 @@ jobs:
 
   test-heavy:
     name: 🧪 Heavy tests (Windows)
-    needs: build
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
@@ -116,14 +88,10 @@ jobs:
     - name: ⚙️ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
       shell: pwsh
-    - name: 📦 Download build
-      uses: actions/download-artifact@v4
-      with:
-        name: build-output
-        path: bin/
+    - name: 🛠️ Build
+      run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
     - name: 🧪 Run heavy tests (parallelism limited to fit in 16GB)
       run: |
-        # Run each heavy test project separately with limited parallelism.
         # Each test uses ~4GB peak memory; with maxParallelThreads=2, peak is ~8GB which fits in 16GB.
         dotnet test --no-build -c ${{ env.BuildConfiguration }} `
           --filter "TestCategory=HighMemory" `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ on:
     - azure-pipelines/release.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NBGV_GitEngine: Disabled
@@ -88,9 +91,25 @@ jobs:
         retention-days: 5
 
   test-heavy:
-    name: 🧪 Heavy tests (Windows)
+    name: 🧪 Heavy (${{ matrix.name }})
     runs-on: windows-latest
-    timeout-minutes: 240
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ExternMethods
+            project: test/Microsoft.Windows.CsWin32.Tests
+            filter: "TestCategory=HighMemory&FullyQualifiedName~ExternMethods"
+          - name: Everything
+            project: test/Microsoft.Windows.CsWin32.Tests
+            filter: "TestCategory=HighMemory&FullyQualifiedName~Everything"
+          - name: InteropTypes
+            project: test/Microsoft.Windows.CsWin32.Tests
+            filter: "TestCategory=HighMemory&FullyQualifiedName~InteropTypes"
+          - name: FullGeneration
+            project: test/CsWin32Generator.Tests
+            filter: "TestCategory=HighMemory"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -100,19 +119,10 @@ jobs:
       shell: pwsh
     - name: 🛠️ Build
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
-    - name: 🧪 Run heavy tests (parallelism limited to fit in 16GB)
+    - name: 🧪 Run heavy tests
       run: |
-        # Each test uses ~4GB peak memory; with maxParallelThreads=2, peak is ~8GB which fits in 16GB.
-        # Target only the projects that have HighMemory tests to avoid "no tests matched" failures.
-        # Use a long hang timeout — individual FullGeneration tests can take 30-60 minutes each.
-        dotnet test test/Microsoft.Windows.CsWin32.Tests --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "TestCategory=HighMemory" `
-          --blame-hang-timeout 7200s `
-          --blame-crash `
-          --logger trx `
-          --results-directory TestResults
-        dotnet test test/CsWin32Generator.Tests --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "TestCategory=HighMemory" `
+        dotnet test ${{ matrix.project }} --no-build -c ${{ env.BuildConfiguration }} `
+          --filter "${{ matrix.filter }}" `
           --blame-hang-timeout 7200s `
           --blame-crash `
           --logger trx `
@@ -124,6 +134,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: test-results-heavy
+        name: test-results-heavy-${{ matrix.name }}
         path: TestResults/
         retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,17 @@ jobs:
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
     - name: 🧪 Run tests
       run: |
-        dotnet test --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware&WindowsOnly!=true" `
+        # Only run cross-platform test projects. Windows-specific projects
+        # (GenerationSandbox.*, SpellChecker, WinRTInteropTest) use Windows TFMs
+        # and produce app hosts that cannot execute on Linux.
+        dotnet test test/CsWin32Generator.Tests --no-build -c ${{ env.BuildConfiguration }} `
+          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
+          --blame-hang-timeout 600s `
+          --blame-crash `
+          --logger trx `
+          --results-directory TestResults
+        dotnet test test/Microsoft.Windows.CsWin32.Tests --no-build -c ${{ env.BuildConfiguration }} `
+          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
           --blame-hang-timeout 600s `
           --blame-crash `
           --logger trx `
@@ -93,7 +102,14 @@ jobs:
     - name: 🧪 Run heavy tests (parallelism limited to fit in 16GB)
       run: |
         # Each test uses ~4GB peak memory; with maxParallelThreads=2, peak is ~8GB which fits in 16GB.
-        dotnet test --no-build -c ${{ env.BuildConfiguration }} `
+        # Target only the projects that have HighMemory tests to avoid "no tests matched" failures.
+        dotnet test test/Microsoft.Windows.CsWin32.Tests --no-build -c ${{ env.BuildConfiguration }} `
+          --filter "TestCategory=HighMemory" `
+          --blame-hang-timeout 1800s `
+          --blame-crash `
+          --logger trx `
+          --results-directory TestResults
+        dotnet test test/CsWin32Generator.Tests --no-build -c ${{ env.BuildConfiguration }} `
           --filter "TestCategory=HighMemory" `
           --blame-hang-timeout 1800s `
           --blame-crash `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,143 @@
+name: 🏗️ Build & Test
+
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+    - 'v*.*'
+    - 'validate/*'
+    paths-ignore:
+    - doc/
+    - '*.md'
+    - .vscode/
+    - azure-pipelines/release.yml
+  workflow_dispatch:
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  NBGV_GitEngine: Disabled
+  BuildConfiguration: Release
+
+jobs:
+  build:
+    name: 🛠️ Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: ⚙️ Install prerequisites
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      shell: pwsh
+    - name: 🛠️ Build
+      run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
+    - name: 📦 Upload build output
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-output
+        path: bin/
+        retention-days: 1
+
+  test-fast-windows:
+    name: 🧪 Tests (Windows)
+    needs: build
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: ⚙️ Install prerequisites
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      shell: pwsh
+    - name: 📦 Download build
+      uses: actions/download-artifact@v4
+      with:
+        name: build-output
+        path: bin/
+    - name: 🧪 Run tests
+      run: |
+        dotnet test --no-build -c ${{ env.BuildConfiguration }} `
+          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
+          --blame-hang-timeout 600s `
+          --blame-crash `
+          --logger trx `
+          --results-directory TestResults
+      shell: pwsh
+    - name: 📢 Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results-windows
+        path: TestResults/
+        retention-days: 5
+
+  test-fast-linux:
+    name: 🧪 Tests (Linux)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: ⚙️ Install prerequisites
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      shell: pwsh
+    - name: 📦 Download build
+      uses: actions/download-artifact@v4
+      with:
+        name: build-output
+        path: bin/
+    - name: 🧪 Run tests
+      run: |
+        dotnet test --no-build -c ${{ env.BuildConfiguration }} `
+          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware&WindowsOnly!=true" `
+          --blame-hang-timeout 600s `
+          --blame-crash `
+          --logger trx `
+          --results-directory TestResults
+      shell: pwsh
+    - name: 📢 Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results-linux
+        path: TestResults/
+        retention-days: 5
+
+  test-heavy:
+    name: 🧪 Heavy tests (Windows)
+    needs: build
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: ⚙️ Install prerequisites
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      shell: pwsh
+    - name: 📦 Download build
+      uses: actions/download-artifact@v4
+      with:
+        name: build-output
+        path: bin/
+    - name: 🧪 Run heavy tests (parallelism limited to fit in 16GB)
+      run: |
+        # Run each heavy test project separately with limited parallelism.
+        # Each test uses ~4GB peak memory; with maxParallelThreads=2, peak is ~8GB which fits in 16GB.
+        dotnet test --no-build -c ${{ env.BuildConfiguration }} `
+          --filter "TestCategory=HighMemory" `
+          --blame-hang-timeout 1800s `
+          --blame-crash `
+          --logger trx `
+          --results-directory TestResults
+      shell: pwsh
+      env:
+        XUNIT_MAX_PARALLEL_THREADS: 2
+    - name: 📢 Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results-heavy
+        path: TestResults/
+        retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ env:
   BuildConfiguration: Release
 
 jobs:
-  test-fast-windows:
-    name: 🧪 Tests (Windows)
+  build:
+    name: 🛠️ Build
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
@@ -35,6 +35,29 @@ jobs:
       shell: pwsh
     - name: 🛠️ Build
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
+    - name: 📦 Upload build output
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-windows
+        path: bin/
+        retention-days: 1
+
+  test-fast-windows:
+    name: 🧪 Tests (Windows)
+    needs: build
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: ⚙️ Install prerequisites
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      shell: pwsh
+    - name: 📦 Download build
+      uses: actions/download-artifact@v4
+      with:
+        name: build-windows
+        path: bin/
     - name: 🧪 Run tests
       run: |
         dotnet test --no-build -c ${{ env.BuildConfiguration }} `
@@ -92,20 +115,34 @@ jobs:
 
   test-heavy:
     name: 🧪 Heavy (${{ matrix.name }})
+    needs: build
     runs-on: windows-latest
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: Shard1
-            filter: "TestCategory=HighMemory&TestShard=1"
-          - name: Shard2
-            filter: "TestCategory=HighMemory&TestShard=2"
-          - name: Shard3
-            filter: "TestCategory=HighMemory&TestShard=3"
+          - name: FastMethods
+            filter: "TestCategory=HighMemory&TestShard=FastMethods"
+            threads: "2"
+          - name: EverythingModern
+            filter: "TestCategory=HighMemory&TestShard=EverythingModern"
+            threads: "2"
+          - name: EverythingLegacy
+            filter: "TestCategory=HighMemory&TestShard=EverythingLegacy"
+            threads: "2"
+          - name: FullGen-Net8
+            filter: "TestCategory=HighMemory&TestShard=FullGen-Net8"
+            threads: "1"
+          - name: FullGen-Net9
+            filter: "TestCategory=HighMemory&TestShard=FullGen-Net9"
+            threads: "1"
+          - name: FullGen-Net9-Ptrs
+            filter: "TestCategory=HighMemory&TestShard=FullGen-Net9-Ptrs"
+            threads: "1"
           - name: Default
-            filter: "TestCategory=HighMemory&TestShard!=1&TestShard!=2&TestShard!=3"
+            filter: "TestCategory=HighMemory&TestShard!=FastMethods&TestShard!=EverythingModern&TestShard!=EverythingLegacy&TestShard!=FullGen-Net8&TestShard!=FullGen-Net9&TestShard!=FullGen-Net9-Ptrs"
+            threads: "1"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -113,8 +150,11 @@ jobs:
     - name: ⚙️ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
       shell: pwsh
-    - name: 🛠️ Build
-      run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
+    - name: 📦 Download build
+      uses: actions/download-artifact@v4
+      with:
+        name: build-windows
+        path: bin/
     - name: 🧪 Run heavy tests
       run: |
         dotnet test test/Microsoft.Windows.CsWin32.Tests --no-build -c ${{ env.BuildConfiguration }} `
@@ -133,7 +173,7 @@ jobs:
           -- RunConfiguration.TreatNoTestsAsError=false
       shell: pwsh
       env:
-        XUNIT_MAX_PARALLEL_THREADS: 2
+        XUNIT_MAX_PARALLEL_THREADS: ${{ matrix.threads }}
     - name: 📢 Upload test results
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,18 +98,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ExternMethods
-            project: test/Microsoft.Windows.CsWin32.Tests
-            filter: "TestCategory=HighMemory&FullyQualifiedName~ExternMethods"
-          - name: Everything
-            project: test/Microsoft.Windows.CsWin32.Tests
-            filter: "TestCategory=HighMemory&FullyQualifiedName~Everything"
-          - name: InteropTypes
-            project: test/Microsoft.Windows.CsWin32.Tests
-            filter: "TestCategory=HighMemory&FullyQualifiedName~InteropTypes"
-          - name: FullGeneration
-            project: test/CsWin32Generator.Tests
-            filter: "TestCategory=HighMemory"
+          - name: Shard1
+            filter: "TestCategory=HighMemory&TestShard=1"
+          - name: Shard2
+            filter: "TestCategory=HighMemory&TestShard=2"
+          - name: Shard3
+            filter: "TestCategory=HighMemory&TestShard=3"
+          - name: Default
+            filter: "TestCategory=HighMemory&TestShard!=1&TestShard!=2&TestShard!=3"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -121,12 +117,20 @@ jobs:
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
     - name: 🧪 Run heavy tests
       run: |
-        dotnet test ${{ matrix.project }} --no-build -c ${{ env.BuildConfiguration }} `
+        dotnet test test/Microsoft.Windows.CsWin32.Tests --no-build -c ${{ env.BuildConfiguration }} `
           --filter "${{ matrix.filter }}" `
           --blame-hang-timeout 7200s `
           --blame-crash `
           --logger trx `
-          --results-directory TestResults
+          --results-directory TestResults `
+          -- RunConfiguration.TreatNoTestsAsError=false
+        dotnet test test/CsWin32Generator.Tests --no-build -c ${{ env.BuildConfiguration }} `
+          --filter "${{ matrix.filter }}" `
+          --blame-hang-timeout 7200s `
+          --blame-crash `
+          --logger trx `
+          --results-directory TestResults `
+          -- RunConfiguration.TreatNoTestsAsError=false
       shell: pwsh
       env:
         XUNIT_MAX_PARALLEL_THREADS: 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
   test-heavy:
     name: 🧪 Heavy tests (Windows)
     runs-on: windows-latest
+    timeout-minutes: 240
     steps:
     - uses: actions/checkout@v4
       with:
@@ -103,15 +104,16 @@ jobs:
       run: |
         # Each test uses ~4GB peak memory; with maxParallelThreads=2, peak is ~8GB which fits in 16GB.
         # Target only the projects that have HighMemory tests to avoid "no tests matched" failures.
+        # Use a long hang timeout — individual FullGeneration tests can take 30-60 minutes each.
         dotnet test test/Microsoft.Windows.CsWin32.Tests --no-build -c ${{ env.BuildConfiguration }} `
           --filter "TestCategory=HighMemory" `
-          --blame-hang-timeout 1800s `
+          --blame-hang-timeout 7200s `
           --blame-crash `
           --logger trx `
           --results-directory TestResults
         dotnet test test/CsWin32Generator.Tests --no-build -c ${{ env.BuildConfiguration }} `
           --filter "TestCategory=HighMemory" `
-          --blame-hang-timeout 1800s `
+          --blame-hang-timeout 7200s `
           --blame-crash `
           --logger trx `
           --results-directory TestResults

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
@@ -13,18 +13,39 @@ public partial class CsWin32GeneratorFullTests : CsWin32GeneratorTestsBase
     {
     }
 
-    [Theory]
-    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
-    [Trait("TestShard", "3")]
-    [InlineData("net8.0", LanguageVersion.CSharp12)]
-    [InlineData("net9.0", LanguageVersion.CSharp13)]
-    [InlineData("net9.0", LanguageVersion.CSharp13, true)]
-    public async Task FullGeneration(string tfm, LanguageVersion langVersion, bool includePointerOverloads = false)
+    [Fact]
+    [Trait("TestCategory", "HighMemory")]
+    [Trait("TestShard", "FullGen-Net8")]
+    public async Task FullGeneration_Net8()
     {
         this.fullGeneration = true;
-        this.compilation = this.starterCompilations[tfm];
-        this.parseOptions = this.parseOptions.WithLanguageVersion(langVersion);
-        this.nativeMethodsJson = includePointerOverloads ? "NativeMethods.IncludePointerOverloads.json" : "NativeMethods.EmitSingleFile.json";
-        await this.InvokeGeneratorAndCompile($"FullGeneration_{tfm}_{langVersion}{(includePointerOverloads ? "_pointers" : string.Empty)}", TestOptions.None);
+        this.compilation = this.starterCompilations["net8.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(LanguageVersion.CSharp12);
+        this.nativeMethodsJson = "NativeMethods.EmitSingleFile.json";
+        await this.InvokeGeneratorAndCompile("FullGeneration_net8.0_CSharp12", TestOptions.None);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "HighMemory")]
+    [Trait("TestShard", "FullGen-Net9")]
+    public async Task FullGeneration_Net9()
+    {
+        this.fullGeneration = true;
+        this.compilation = this.starterCompilations["net9.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(LanguageVersion.CSharp13);
+        this.nativeMethodsJson = "NativeMethods.EmitSingleFile.json";
+        await this.InvokeGeneratorAndCompile("FullGeneration_net9.0_CSharp13", TestOptions.None);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "HighMemory")]
+    [Trait("TestShard", "FullGen-Net9-Ptrs")]
+    public async Task FullGeneration_Net9_Pointers()
+    {
+        this.fullGeneration = true;
+        this.compilation = this.starterCompilations["net9.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(LanguageVersion.CSharp13);
+        this.nativeMethodsJson = "NativeMethods.IncludePointerOverloads.json";
+        await this.InvokeGeneratorAndCompile("FullGeneration_net9.0_CSharp13_pointers", TestOptions.None);
     }
 }

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
@@ -14,7 +14,7 @@ public partial class CsWin32GeneratorFullTests : CsWin32GeneratorTestsBase
     }
 
     [Theory]
-    [Trait("TestCategory", "FailsInCloudTest")] // these take ~4GB of memory to run.
+    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
     [InlineData("net8.0", LanguageVersion.CSharp12)]
     [InlineData("net9.0", LanguageVersion.CSharp13)]
     [InlineData("net9.0", LanguageVersion.CSharp13, true)]

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
@@ -15,6 +15,7 @@ public partial class CsWin32GeneratorFullTests : CsWin32GeneratorTestsBase
 
     [Theory]
     [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
+    [Trait("TestShard", "3")]
     [InlineData("net8.0", LanguageVersion.CSharp12)]
     [InlineData("net9.0", LanguageVersion.CSharp13)]
     [InlineData("net9.0", LanguageVersion.CSharp13, true)]

--- a/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
@@ -110,7 +110,7 @@ public partial class COMTests(ITestOutputHelper outputHelper)
 
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")] // D3D APIs fail in cloud VMs
+    [Trait("TestCategory", "RequiresHardware")] // D3D APIs fail in cloud VMs
     public void ReturnValueMarshalsCorrectly()
     {
         // Create an ID2D1HwndRenderTarget and verify GetHwnd returns the original HWND.
@@ -202,7 +202,7 @@ public partial class COMTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")] // WMI APIs don't work in cloud VMs.
+    [Trait("TestCategory", "RequiresHardware")] // WMI APIs don't work in cloud VMs.
     public void IWbemServices_GetObject_Works()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
@@ -237,7 +237,7 @@ public partial class COMTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")]
+    [Trait("TestCategory", "RequiresHardware")]
     public void CanCallINetFwMgrApis()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
@@ -267,7 +267,7 @@ public partial class COMTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")]
+    [Trait("TestCategory", "RequiresHardware")]
     public unsafe void CanCallPnPAPIs()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");

--- a/test/GenerationSandbox.Tests/ComRuntimeTests.cs
+++ b/test/GenerationSandbox.Tests/ComRuntimeTests.cs
@@ -22,7 +22,7 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
     private ITestOutputHelper outputHelper = outputHelper;
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")]
+    [Trait("TestCategory", "RequiresHardware")]
     public void RemotableInterface()
     {
         IShellWindows shellWindows = (IShellWindows)new ShellWindows();
@@ -35,7 +35,7 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")] // D3D APIs fail in cloud VMs
+    [Trait("TestCategory", "RequiresHardware")] // D3D APIs fail in cloud VMs
     public void ReturnValueMarshalsCorrectly()
     {
         // Create an ID2D1HwndRenderTarget and verify GetHwnd returns the original HWND.
@@ -126,7 +126,7 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")] // WMI APIs don't work in cloud VMs.
+    [Trait("TestCategory", "RequiresHardware")] // WMI APIs don't work in cloud VMs.
     public void IWbemServices_GetObject_Works()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
@@ -161,7 +161,7 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")] // WMI APIs don't work in cloud VMs.
+    [Trait("TestCategory", "RequiresHardware")] // WMI APIs don't work in cloud VMs.
     public void CanCallIDispatchOnlyMethods()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
@@ -188,7 +188,7 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")]
+    [Trait("TestCategory", "RequiresHardware")]
     public void CanCallINetFwMgrApis()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");

--- a/test/GenerationSandbox.Unmarshalled.Tests/COMTests.cs
+++ b/test/GenerationSandbox.Unmarshalled.Tests/COMTests.cs
@@ -44,7 +44,7 @@ public class COMTests
 #endif
 
     [Fact]
-    [Trait("TestCategory", "FailsInCloudTest")] // D3D APIs fail in cloud VMs
+    [Trait("TestCategory", "RequiresHardware")] // D3D APIs fail in cloud VMs
     public unsafe void ReturnValueMarshalsCorrectly()
     {
         // Create an ID2D1HwndRenderTarget and verify GetHwnd returns the original HWND.

--- a/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
@@ -7,9 +7,17 @@ using System.Diagnostics;
 /// Tests that generate everything possible, or subsets of everything.
 /// </summary>
 /// <remarks>
+/// <para>
 /// These tests tend to be slow and require ~4GB of memory each. They are tagged with
 /// <c>[Trait("TestCategory", "HighMemory")]</c> and run in a dedicated CI job with
 /// limited parallelism to avoid OOM on memory-constrained agents.
+/// </para>
+/// <para>
+/// Each test is assigned to a <c>TestShard</c> that determines which CI agent runs it.
+/// The shard names are: <c>FastMethods</c>, <c>EverythingModern</c>, <c>EverythingLegacy</c>.
+/// Tests without a shard assignment run in a <c>Default</c> catch-all shard.
+/// When adding new HighMemory tests, assign them to an appropriate shard.
+/// </para>
 /// </remarks>
 public class FullGenerationTests : GeneratorTestBase
 {
@@ -18,28 +26,50 @@ public class FullGenerationTests : GeneratorTestBase
     {
     }
 
-    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
-    [Trait("TestShard", "3")]
+    /// <summary>
+    /// Gets the modern target frameworks (net8.0+). Used to split <c>Everything</c> across shards.
+    /// </summary>
+    public static string[] ModernTfms => new[] { "net8.0", "net9.0", "net10.0" };
+
+    /// <summary>
+    /// Gets the legacy target frameworks (pre-.NET Core). Used to split <c>Everything</c> across shards.
+    /// </summary>
+    public static string[] LegacyTfms => new[] { "net472", "netstandard2.0" };
+
+    [Trait("TestCategory", "HighMemory")]
+    [Trait("TestShard", "FastMethods")]
     [Fact]
     public void Everything_NoFriendlyOverloads()
     {
         this.TestHelper(new GeneratorOptions { FriendlyOverloads = new() { Enabled = false } }, Platform.X64, "net8.0", generator => generator.GenerateAll(CancellationToken.None));
     }
 
-    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
-    [Trait("TestShard", "2")]
+    [Trait("TestCategory", "HighMemory")]
+    [Trait("TestShard", "EverythingModern")]
     [Theory, PairwiseData]
-    public void Everything(
+    public void Everything_ModernTfms(
         MarshalingOptions marshaling,
         bool useIntPtrForComOutPtr,
         [CombinatorialMemberData(nameof(AnyCpuArchitectures))] Platform platform,
-        [CombinatorialMemberData(nameof(TFMDataNoNetFx35))] string tfm)
+        [CombinatorialMemberData(nameof(ModernTfms))] string tfm)
     {
         this.TestHelper(OptionsForMarshaling(marshaling, useIntPtrForComOutPtr), platform, tfm, generator => generator.GenerateAll(CancellationToken.None));
     }
 
-    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
-    [Trait("TestShard", "3")]
+    [Trait("TestCategory", "HighMemory")]
+    [Trait("TestShard", "EverythingLegacy")]
+    [Theory, PairwiseData]
+    public void Everything_LegacyTfms(
+        MarshalingOptions marshaling,
+        bool useIntPtrForComOutPtr,
+        [CombinatorialMemberData(nameof(AnyCpuArchitectures))] Platform platform,
+        [CombinatorialMemberData(nameof(LegacyTfms))] string tfm)
+    {
+        this.TestHelper(OptionsForMarshaling(marshaling, useIntPtrForComOutPtr), platform, tfm, generator => generator.GenerateAll(CancellationToken.None));
+    }
+
+    [Trait("TestCategory", "HighMemory")]
+    [Trait("TestShard", "FastMethods")]
     [Theory, PairwiseData]
     public void InteropTypes(
         MarshalingOptions marshaling,
@@ -56,8 +86,8 @@ public class FullGenerationTests : GeneratorTestBase
     }
 
     [Theory, PairwiseData]
-    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
-    [Trait("TestShard", "1")]
+    [Trait("TestCategory", "HighMemory")]
+    [Trait("TestShard", "FastMethods")]
     public void ExternMethods(
         MarshalingOptions marshaling,
         bool useIntPtrForComOutPtr,

--- a/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
@@ -19,6 +19,7 @@ public class FullGenerationTests : GeneratorTestBase
     }
 
     [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
+    [Trait("TestShard", "3")]
     [Fact]
     public void Everything_NoFriendlyOverloads()
     {
@@ -26,6 +27,7 @@ public class FullGenerationTests : GeneratorTestBase
     }
 
     [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
+    [Trait("TestShard", "2")]
     [Theory, PairwiseData]
     public void Everything(
         MarshalingOptions marshaling,
@@ -37,6 +39,7 @@ public class FullGenerationTests : GeneratorTestBase
     }
 
     [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
+    [Trait("TestShard", "3")]
     [Theory, PairwiseData]
     public void InteropTypes(
         MarshalingOptions marshaling,
@@ -54,6 +57,7 @@ public class FullGenerationTests : GeneratorTestBase
 
     [Theory, PairwiseData]
     [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
+    [Trait("TestShard", "1")]
     public void ExternMethods(
         MarshalingOptions marshaling,
         bool useIntPtrForComOutPtr,

--- a/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FullGenerationTests.cs
@@ -7,9 +7,9 @@ using System.Diagnostics;
 /// Tests that generate everything possible, or subsets of everything.
 /// </summary>
 /// <remarks>
-/// These tests tend to be slow, and some require 4GB of memory, and thus some cannot be run on Azure Pipelines
-/// as the test host process gets too large and gets terminated.
-/// The <see cref="Everything"/> test should be run in all its combinations manually prior to sending a pull request.
+/// These tests tend to be slow and require ~4GB of memory each. They are tagged with
+/// <c>[Trait("TestCategory", "HighMemory")]</c> and run in a dedicated CI job with
+/// limited parallelism to avoid OOM on memory-constrained agents.
 /// </remarks>
 public class FullGenerationTests : GeneratorTestBase
 {
@@ -18,14 +18,14 @@ public class FullGenerationTests : GeneratorTestBase
     {
     }
 
-    [Trait("TestCategory", "FailsInCloudTest")] // these take ~4GB of memory to run.
+    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
     [Fact]
     public void Everything_NoFriendlyOverloads()
     {
         this.TestHelper(new GeneratorOptions { FriendlyOverloads = new() { Enabled = false } }, Platform.X64, "net8.0", generator => generator.GenerateAll(CancellationToken.None));
     }
 
-    [Trait("TestCategory", "FailsInCloudTest")] // these take ~4GB of memory to run.
+    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
     [Theory, PairwiseData]
     public void Everything(
         MarshalingOptions marshaling,
@@ -36,7 +36,7 @@ public class FullGenerationTests : GeneratorTestBase
         this.TestHelper(OptionsForMarshaling(marshaling, useIntPtrForComOutPtr), platform, tfm, generator => generator.GenerateAll(CancellationToken.None));
     }
 
-    [Trait("TestCategory", "FailsInCloudTest")] // these take ~4GB of memory to run.
+    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
     [Theory, PairwiseData]
     public void InteropTypes(
         MarshalingOptions marshaling,
@@ -53,7 +53,7 @@ public class FullGenerationTests : GeneratorTestBase
     }
 
     [Theory, PairwiseData]
-    [Trait("TestCategory", "FailsInCloudTest")] // these take ~4GB of memory to run.
+    [Trait("TestCategory", "HighMemory")] // these take ~4GB of memory to run.
     public void ExternMethods(
         MarshalingOptions marshaling,
         bool useIntPtrForComOutPtr,

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -50,7 +50,7 @@ $testDiagLog = Join-Path $ArtifactStagingFolder (Join-Path test_logs diag.log)
 & $dotnet test $RepoRoot `
     --no-build `
     -c $Configuration `
-    --filter "TestCategory!=FailsInCloudTest$env:TESTFILTER" `
+    --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware$env:TESTFILTER" `
     --collect "Code Coverage;Format=cobertura" `
     --settings "$PSScriptRoot/test.runsettings" `
     --blame-hang-timeout 1500s `


### PR DESCRIPTION
﻿## Summary

Adds a GitHub Actions workflow that runs **all** unit tests (including the ~4GB memory "heavy" tests) on every PR. Previously these tests were excluded from CI entirely because they OOM'd the Azure Pipelines agents.

## What changed

### New GitHub Actions workflow (`.github/workflows/build.yml`)
- **Build-once, test-many**: A single Windows build job produces artifacts shared by all Windows test jobs
- **Fast tests**: Run on both Windows and Linux (Linux builds its own due to platform-specific app hosts)
- **Heavy tests**: Fan out across 7 parallel shards on separate 16GB agents, each with appropriate thread limits

### Test trait refactoring
- Replaced `FailsInCloudTest` with two orthogonal traits:
  - `HighMemory` — tests needing ~4GB RAM (run in dedicated heavy shards)
  - `RequiresHardware` — tests needing GPU/WMI/COM (skipped in all CI)
- Added `TestShard` trait for deterministic shard assignment with a Default catch-all

### Heavy test sharding strategy

| Shard | Contents | Time |
|-------|----------|------|
| FastMethods | ExternMethods + InteropTypes + NoFriendlyOverloads | ~60 min |
| EverythingModern | Everything (net8.0, net9.0, net10.0) | ~52 min |
| EverythingLegacy | Everything (net472, netstandard2.0) | ~47 min |
| FullGen-Net8 | FullGeneration net8.0/C#12 | ~40 min |
| FullGen-Net9 | FullGeneration net9.0/C#13 | ~49 min |
| FullGen-Net9-Ptrs | FullGeneration net9.0/C#13 + pointers | ~48 min |
| Default | Any unassigned HighMemory tests | catches new tests |

### Key design decisions
- Each FullGeneration test runs **alone** on its own agent (1 thread) to avoid OOM
- `Everything` pairwise tests split by TFM family (Modern vs Legacy) for balanced sharding
- `XUNIT_MAX_PARALLEL_THREADS` set per-shard via matrix config
- `--blame-hang-timeout 7200s` for heavy tests (individual tests can take 30-60 min)
- Default shard ensures new HighMemory tests are never silently skipped

## Results

Total wall-clock time: **~69 minutes** (build 9min + longest shard 60min)

Previously these tests could only be run manually on a developer machine.

## Backward compatibility

- Azure Pipelines `dotnet-test-cloud.ps1` updated to use new trait names (`HighMemory`/`RequiresHardware` instead of `FailsInCloudTest`)
- Existing CI pipelines continue to skip heavy tests as before