### PR TITLE
Add validate gate job for single required status check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,3 +181,23 @@ jobs:
         name: test-results-heavy-${{ matrix.name }}
         path: TestResults/
         retention-days: 5
+
+  validate:
+    name: ✅ Validate
+    if: always()
+    needs: [build, test-fast-windows, test-fast-linux, test-heavy]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check results
+      run: |
+        echo "Build: ${{ needs.build.result }}"
+        echo "Windows tests: ${{ needs.test-fast-windows.result }}"
+        echo "Linux tests: ${{ needs.test-fast-linux.result }}"
+        echo "Heavy tests: ${{ needs.test-heavy.result }}"
+        if [[ "${{ needs.build.result }}" != "success" ||
+              "${{ needs.test-fast-windows.result }}" != "success" ||
+              "${{ needs.test-fast-linux.result }}" != "success" ||
+              "${{ needs.test-heavy.result }}" != "success" ]]; then
+          echo "::error::One or more required jobs failed or were cancelled."
+          exit 1
+        fi


### PR DESCRIPTION
﻿## Summary

Adds a `✅ Validate` gate job to the GitHub Actions workflow that depends on all test jobs. This gives a single status check to require in the branch ruleset instead of listing 10+ individual jobs.

The gate job:
- Uses `if: always()` so it runs even if upstream jobs fail
- Checks all job results and fails if any are not `success`
- Runs on `ubuntu-latest` (just a shell script, no build needed)

## Usage

After merging, update the branch ruleset to require only `✅ Validate` instead of individual job names. Adding/removing shards in the future won't require ruleset changes.