### PR TITLE
Fix hardcoded PInvoke class name in ICCloseSafeHandle generation

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Handle.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Handle.cs
@@ -243,7 +243,7 @@ public partial class Generator
                                 break;
                             case "LRESULT" when releaseMethod == "ICClose":
                                 this.TryGenerateConstantOrThrow("ICERR_OK");
-                                noerror = CastExpression(ParseName("global::Windows.Win32.Foundation.LRESULT"), MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName("PInvoke"), IdentifierName("ICERR_OK")));
+                                noerror = CastExpression(ParseName("global::Windows.Win32.Foundation.LRESULT"), MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, this.methodsAndConstantsClassName, IdentifierName("ICERR_OK")));
                                 releaseInvocation = BinaryExpression(SyntaxKind.EqualsExpression, releaseInvocation, noerror);
                                 break;
                             case "HGLOBAL":

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -606,6 +606,18 @@ using global::System.Runtime.Versioning;
         await this.InvokeGeneratorAndCompile($"{nameof(this.CrossWinMD_IInspectable)}_{tfm}_{allowMarshaling}_{pinvokeClassName ?? "null"}");
     }
 
+    [Theory, CombinatorialData]
+    public async Task ICCloseSafeHandle_CustomClassName(
+        [CombinatorialValues([null, "MyPInvoke"])] string? pinvokeClassName)
+    {
+        this.nativeMethodsJsonOptions = new NativeMethodsJsonOptions
+        {
+            ClassName = pinvokeClassName,
+        };
+        this.nativeMethods.Add("ICOpen");
+        await this.InvokeGeneratorAndCompile($"{nameof(this.ICCloseSafeHandle_CustomClassName)}_{pinvokeClassName ?? "null"}");
+    }
+
     [Fact]
     public async Task CrossWinMD_NTSTATUSSafeHandleConstant()
     {


### PR DESCRIPTION
﻿## Summary

Fixes #1696 — When a custom `className` is configured in `NativeMethods.json`, the generated `ICCloseSafeHandle.ReleaseHandle()` method incorrectly referenced `PInvoke.ICERR_OK` instead of using the configured class name (e.g., `MyPInvoke.ICERR_OK`).

## Changes

- **`src/Microsoft.Windows.CsWin32/Generator.Handle.cs`**: Replaced hardcoded `IdentifierName("PInvoke")` with `this.methodsAndConstantsClassName` which correctly reflects the configured `className` option.
- **`test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs`**: Added `ICCloseSafeHandle_CustomClassName` test that verifies `ICOpen` generation (which produces `ICCloseSafeHandle`) compiles successfully with both default and custom class names.