### PR TITLE
Add extensionReceiver option for layered PInvoke composition (#1477)

### DIFF
--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -36,6 +36,6 @@
     <PackageVersion Update="System.Memory" Version="4.5.5" />
     <PackageVersion Update="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Update="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -13,10 +13,29 @@
     <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="System.Collections.Immutable" Version="9.0.0" />
-    <PackageVersion Update="System.Memory" Version="4.6.0" />
+
+    <!--
+      ANALYZER SUPPORT-ASSEMBLY VERSION BINDINGS — DO NOT BUMP HERE.
+
+      The following System.* versions are the support assemblies that get copied next to
+      the analyzer (CopyLocalLockFileAssemblies=true) and shipped inside the NuGet package.
+      They are intentionally pinned to the FLOOR (Roslyn 4.11 / VS 2022 Update 14 / .NET 8)
+      versions because the analyzer must load inside older Visual Studio and `dotnet build`
+      hosts that ship exactly these assembly versions in the compiler's load context.
+      Shipping a NEWER version than the host provides risks an assembly-load/version
+      mismatch at analysis time (the root cause behind issue #1555).
+
+      These are the central defaults consumed by the Roslyn 4.11 floor leg
+      (Microsoft.Windows.CsWin32.Roslyn4). The Roslyn 5.0 leg
+      (Microsoft.Windows.CsWin32) runs in a newer host whose compiler genuinely ships
+      newer System.* assemblies, so that leg — and ONLY that leg — overrides these
+      versions locally via <VersionOverride> in its .csproj. Keep the floor numbers here
+      and add per-leg overrides there; never raise the floor to satisfy the newer leg.
+    -->
+    <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Update="System.Memory" Version="4.5.5" />
     <PackageVersion Update="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Update="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -1,14 +1,20 @@
 <Project>
   <PropertyGroup>
-    <CodeAnalysisVersionForAnalyzers>4.11.0</CodeAnalysisVersionForAnalyzers>
+    <!--
+      Default analyzer Roslyn version. The analyzer is multi-targeted so it ships an assembly
+      built against Roslyn 4.11 (the floor that supports VS 2022 Update 14 / .NET 8 SDK) AND
+      an assembly built against Roslyn 5.0 (required for C# 14 ExtensionBlockDeclarationSyntax).
+      Projects override $(CodeAnalysisVersionForAnalyzers) per Roslyn leg.
+    -->
+    <CodeAnalysisVersionForAnalyzers Condition="'$(CodeAnalysisVersionForAnalyzers)'==''">4.11.0</CodeAnalysisVersionForAnalyzers>
   </PropertyGroup>
   <ItemGroup>
     <!-- These versions carefully chosen to support VS 2022 Update 14 and also run down to .NET 8. -->
     <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Update="System.Memory" Version="4.5.5" />
+    <PackageVersion Update="System.Collections.Immutable" Version="9.0.0" />
+    <PackageVersion Update="System.Memory" Version="4.6.0" />
     <PackageVersion Update="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageVersion Update="System.Text.Json" Version="8.0.5" />

--- a/Microsoft.Windows.CsWin32.sln
+++ b/Microsoft.Windows.CsWin32.sln
@@ -34,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{36CCE840-6
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Windows.CsWin32", "src\Microsoft.Windows.CsWin32\Microsoft.Windows.CsWin32.csproj", "{E3E96466-44B6-41AF-BBC8-9D30183ED8A9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Windows.CsWin32.Roslyn4", "src\Microsoft.Windows.CsWin32.Roslyn4\Microsoft.Windows.CsWin32.Roslyn4.csproj", "{93A6CCA2-5A52-46B9-8A91-928AFA67429D}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Windows.CsWin32.Tests", "test\Microsoft.Windows.CsWin32.Tests\Microsoft.Windows.CsWin32.Tests.csproj", "{0129FE6E-3480-408A-BF40-9E6343CDB06C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerationSandbox.Tests", "test\GenerationSandbox.Tests\GenerationSandbox.Tests.csproj", "{7E8A5179-F94C-410F-8BBE-FDAAA95A19C3}"
@@ -74,6 +76,14 @@ Global
 		{E3E96466-44B6-41AF-BBC8-9D30183ED8A9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E3E96466-44B6-41AF-BBC8-9D30183ED8A9}.Release|NonWindows.ActiveCfg = Release|Any CPU
 		{E3E96466-44B6-41AF-BBC8-9D30183ED8A9}.Release|NonWindows.Build.0 = Release|Any CPU
+		{93A6CCA2-5A52-46B9-8A91-928AFA67429D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93A6CCA2-5A52-46B9-8A91-928AFA67429D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93A6CCA2-5A52-46B9-8A91-928AFA67429D}.Debug|NonWindows.ActiveCfg = Debug|Any CPU
+		{93A6CCA2-5A52-46B9-8A91-928AFA67429D}.Debug|NonWindows.Build.0 = Debug|Any CPU
+		{93A6CCA2-5A52-46B9-8A91-928AFA67429D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93A6CCA2-5A52-46B9-8A91-928AFA67429D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93A6CCA2-5A52-46B9-8A91-928AFA67429D}.Release|NonWindows.ActiveCfg = Release|Any CPU
+		{93A6CCA2-5A52-46B9-8A91-928AFA67429D}.Release|NonWindows.Build.0 = Release|Any CPU
 		{0129FE6E-3480-408A-BF40-9E6343CDB06C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0129FE6E-3480-408A-BF40-9E6343CDB06C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0129FE6E-3480-408A-BF40-9E6343CDB06C}.Debug|NonWindows.ActiveCfg = Debug|Any CPU

--- a/docfx/docs/composition.md
+++ b/docfx/docs/composition.md
@@ -1,0 +1,438 @@
+# Layered composition with `extensionReceiver`
+
+CsWin32 lets multiple assemblies contribute to a single, unified static class for native API
+discovery. One assembly hosts the canonical `PInvoke` symbol; every other assembly that uses
+CsWin32 extends it. Callers reach every native API through `PInvoke.X()` regardless of which
+assembly emitted it.
+
+This is built on C# 14 [extension members][csharp14-extensions] and is configured via the
+`extensionReceiver` setting in `NativeMethods.json`.
+
+## When to use it
+
+Use `extensionReceiver` if your codebase is layered — a low-level library, a UI/runtime helper
+library on top, and an application on top of that — and you want callers to use a single
+`PInvoke.X()` discovery surface regardless of which layer happens to declare `X`.
+
+Don't use it for single-assembly projects. The default `partial class PInvoke` already gives you
+everything you need without C# 14.
+
+## Requirements
+
+C# 14 or later in every project that consumes the generated extension members. This is the
+default when targeting .NET 10 or later; otherwise set `<LangVersion>14</LangVersion>` (or
+`Preview` / `Latest` / `LatestMajor`) in the project file.
+
+## Two roles
+
+Every assembly that runs CsWin32 plays exactly one role:
+
+| Role | `NativeMethods.json` shape | What the generator emits |
+|---|---|---|
+| **Owner** | `extensionReceiver` *not* set | A plain `partial class <className>` with members declared directly on it. |
+| **Extender** | `extensionReceiver: "<OwnerClassName>"` set | A `partial class <className>` whose members live inside an `extension(<OwnerClassName>) { … }` block. |
+
+In a layered stack, the lowest assembly is the owner; every higher assembly is an extender. Each
+extender must use a `className` that differs from the owner's and from every other extender's.
+
+## A worked example
+
+Three projects in dependency order: `MyApp.Core` (lowest), `MyApp.Helpers`, `MyApp.App` (highest).
+
+### Owner — `MyApp.Core`
+
+```jsonc
+// NativeMethods.json
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "PInvoke",
+  "public": true
+}
+```
+
+```text
+// NativeMethods.txt
+GetTickCount
+```
+
+Generates:
+
+```csharp
+namespace Windows.Win32
+{
+    public static partial class PInvoke
+    {
+        [DllImport("KERNEL32.dll", ExactSpelling = true)]
+        public static extern uint GetTickCount();
+    }
+}
+```
+
+### Extender — `MyApp.Helpers` (references `MyApp.Core`)
+
+```jsonc
+// NativeMethods.json
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "PInvokeHelpers",
+  "extensionReceiver": "PInvoke",
+  "public": true
+}
+```
+
+```text
+// NativeMethods.txt
+GetForegroundWindow
+```
+
+Generates:
+
+```csharp
+namespace Windows.Win32
+{
+    public static partial class PInvokeHelpers
+    {
+        extension (global::Windows.Win32.PInvoke)
+        {
+            [DllImport("USER32.dll", ExactSpelling = true)]
+            public static extern global::Windows.Win32.Foundation.HWND GetForegroundWindow();
+        }
+    }
+}
+```
+
+### Extender — `MyApp.App` (references both)
+
+```jsonc
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "PInvokeApp",
+  "extensionReceiver": "PInvoke"
+}
+```
+
+```text
+IsWindow
+```
+
+### Consuming code
+
+Application code reaches every API through the single `PInvoke` symbol:
+
+```csharp
+using Windows.Win32;
+
+uint   ticks = PInvoke.GetTickCount();        // declared in MyApp.Core
+HWND   hwnd  = PInvoke.GetForegroundWindow(); // declared in MyApp.Helpers
+bool   alive = PInvoke.IsWindow(hwnd);        // declared in MyApp.App
+```
+
+The `using Windows.Win32;` directive at the top of the file is what makes the extension members
+discoverable. See [Dispatch rules](#dispatch-rules) below.
+
+## Dispatch rules
+
+C# 14 extension members participate in member lookup only when the static class that declares the
+`extension(T) { … }` block is in scope at the call site. Three practical rules cover almost every
+case.
+
+### Rule 1 — Bring the extender's namespace into scope
+
+To call `PInvoke.X()` and have the compiler find `X` in an extender, the call site must either be
+inside `namespace Windows.Win32 { … }` or contain a **file-scoped** `using Windows.Win32;`.
+
+> [!IMPORTANT]
+> `global using Windows.Win32;` in a `GlobalUsings.cs` file works for most lookups, but it does
+> **not** contribute to type-name resolution inside user-authored `extension(T)` blocks. If you
+> author your own extension blocks, add the file-scoped `using` in those files even if the same
+> namespace is declared as a global using.
+
+### Rule 2 — When you can't use the extension path, use the host class directly
+
+Some C# contexts cannot resolve through an extension property. Specifically:
+
+- `enum` initializers
+- attribute arguments
+- `fixed`-array sizes
+- `case` labels of `switch`
+
+For these contexts, reach the value through the host class:
+
+```csharp
+// Works in any context, including const contexts.
+const uint Sentinel = PInvoke.WM_NULL;       // host class on the owner
+enum MyFlags { Default = (int)PInvokeHelpers.SomeFlag }  // host class on an extender
+```
+
+(See [Constants](#constants) below for why this is necessary.)
+
+### Rule 3 — Inside an extension block, qualify every call
+
+When you author your own `extension(T) { … }` block, calls to sibling extension members are *not*
+discovered through unqualified names. Always write `T.X(…)`:
+
+```csharp
+using Windows.Win32;
+
+namespace Windows.Win32;
+
+internal static class MyExtraHelpers
+{
+    extension (PInvoke)
+    {
+        public static int RunWithCleanup()
+        {
+            // ✅ Qualify with the receiver. Anything else is wrong.
+            uint t = PInvoke.GetTickCount();
+            return (int)t;
+        }
+    }
+}
+```
+
+Forgetting the qualifier produces `CS0103` in the simple case — or, if the surrounding method
+happens to have the same name as the API it wraps, *silent infinite recursion at runtime*. Qualify
+always.
+
+## Constants
+
+C# 14 extension blocks cannot contain `const` fields or `static readonly` fields. CsWin32 therefore
+emits a constant in two forms:
+
+```csharp
+public static partial class PInvoke
+{
+    // 1. The real const lives on the host class. Reachable as `PInvoke.WM_NULL` in any context,
+    //    including enum initializers, attribute arguments, `fixed`-array sizes, and case labels.
+    public const uint WM_NULL = 0u;
+
+    extension (global::Windows.Win32.PInvoke)
+    {
+        // 2. A forwarder property surfaces the same value through the receiver type for runtime
+        //    contexts. `PInvoke.WM_NULL` resolves to this when not in a const context.
+        public static uint WM_NULL => global::Windows.Win32.PInvoke.WM_NULL;
+    }
+}
+```
+
+For an extender (e.g. `PInvokeHelpers`), the const lives on the extender's host class
+(`PInvokeHelpers.X`) and the forwarder lives on the receiver (`PInvoke.X`). You can always reach
+the const via the host class.
+
+## How duplicates are handled across layers
+
+When an extender's `NativeMethods.txt` requests something the owner (or any other referenced
+extender) already exposes on the receiver, CsWin32 detects the duplicate and does not re-emit it.
+
+The match is signature-based: same simple name, same parameter count, same parameter type names
+(after normalization that strips `global::` and leading namespace segments). A user-authored
+wrapper of the same name but a different signature is treated as a distinct overload and does *not*
+cause the metadata extern to be skipped.
+
+| Already on receiver | This layer wants | Result |
+|---|---|---|
+| `uint GetTickCount()` | `uint GetTickCount()` | Skipped — full signature match. |
+| `string Lookup(string, string)` (user wrapper) | `int Lookup(HKEY, PCWSTR, …)` | Emitted — parameter counts/types differ. |
+| `int WM_NULL` field or property | `uint WM_NULL` constant | Skipped — name + arity 0 match. |
+
+For most multi-layer setups this is automatic. The cases where you need to think about it are
+listed in the [migration section](#migration-from-a-multi-layer-project) below.
+
+## Diagnostics
+
+The generator emits these diagnostics for misconfigurations:
+
+| Diagnostic | When | Resolution |
+|---|---|---|
+| `PInvoke011` | The configured `extensionReceiver` could not be resolved in any namespace served by your CsWin32 generators, or it resolves to something other than a static class, or it equals `className`. | Verify the receiver type exists, is `static class`, is accessible (`public` from another assembly or `[InternalsVisibleTo]`), and is not the same as `className`. |
+| `PInvoke012` | The consuming project's `LangVersion` is less than C# 14. | Set `<LangVersion>14</LangVersion>` (or `Preview` / `Latest` / `LatestMajor`) in the project that uses the extension members. Targeting .NET 10 or later picks this up automatically. |
+| `PInvoke013` | The host's analyzer doesn't support C# 14 extension members. | Upgrade to a newer SDK or Visual Studio, or remove the `extensionReceiver` setting. |
+
+## Migration from a multi-layer project
+
+The following steps mirror the work most existing multi-layer codebases need to go through to
+adopt the feature. Each step is independently reversible if you change your mind partway through.
+
+### Step 1 — Inventory
+
+For every project that already runs CsWin32, record:
+
+- Its `className` value (or `PInvoke` if unset).
+- Its `public` flag.
+- Whether it ships any hand-authored `partial` of a type that CsWin32 also emits (e.g. a
+  `Foundation/HRESULT.cs`, a `PInvoke.SomeWrapper.cs`).
+
+### Step 2 — Choose the owner
+
+Pick the project that sits at the bottom of your dependency graph — the one referenced by every
+other CsWin32-consuming project, that doesn't itself reference any of them. Usually this is the
+"core" or "primitives" project.
+
+If the owner's existing `className` is not `"PInvoke"`, rename it now. Every extender will reach
+the owner through that name; making it the unsurprising default reduces friction for consumers.
+
+### Step 3 — Make the receiver visible to extenders
+
+The receiver type must be reachable from every extending project. The simplest pattern:
+
+```jsonc
+// Owner's NativeMethods.json
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "PInvoke",
+  "public": true
+}
+```
+
+Setting `public: true` on the owner makes the receiver visible to any consumer. If your owner
+intends to keep all its API surface internal, you can instead apply
+`[InternalsVisibleTo("<each extender>")]` from the owner — but be aware that final application code
+won't be able to use `PInvoke.X()` to reach extender members unless it, too, can see the owner's
+receiver type.
+
+> [!NOTE]
+> Setting `public: true` on the owner publishes **every** type CsWin32 emits in that assembly,
+> including foundation types like `HRESULT`, `BSTR`, `PWSTR`, `BOOL`. If higher layers already
+> ship their own `partial` of those types, you'll need to consolidate them (Step 6).
+
+### Step 4 — Flip extenders
+
+In every extending project's `NativeMethods.json`:
+
+```jsonc
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "PInvokeMyLibrary",
+  "extensionReceiver": "PInvoke",
+  "public": true
+}
+```
+
+Rename `className` to something unique per assembly (a common convention is
+`PInvoke<AssemblyShortName>`) and add `extensionReceiver: "<OwnerClassName>"`.
+
+### Step 5 — Bump `LangVersion` to 14 in every consuming project
+
+Targeting .NET 10 or later already implies C# 14. For other target frameworks, set
+`<LangVersion>14</LangVersion>` (or `Preview`/`Latest`/`LatestMajor`) in `Directory.Build.props`
+or in each `.csproj`. Make sure it applies to every TargetFramework you build, including `net472`
+/ `net48` legs if you multi-target. The generated `extension(T) { … }` blocks won't parse with an
+older language version.
+
+### Step 6 — Consolidate hand-authored partials
+
+If a higher layer ships its own `partial` of a type that the owner now emits publicly (commonly
+`HRESULT`, `BSTR`, `PWSTR`, custom handle types), the higher layer's partial will collide with the
+owner's now-imported type and the compiler will emit `CS0436`.
+
+Apply the following rule, in order, to each conflicting partial:
+
+1. If the partial's members already exist on the owner's CsWin32-generated version (typical for
+   well-known helpers), **delete** the duplicate.
+2. If the partial adds methods, properties, or indexers that the owner doesn't have, **move them
+   into an `extension(<Type>) { … }` block** in a sibling static class within the higher layer.
+3. If the partial adds constants, `static readonly` fields, nested types, or operators (none of
+   which can live in a C# 14 extension block), **add them to the owner's `NativeMethods.txt`** so
+   the owner emits them, or, if that isn't possible, declare them in a non-conflicting sibling
+   type in the higher layer.
+
+The general principle:
+
+> When there are partial-definition collisions between layers, move the additions to an extension
+> on the type as defined lower in the stack — unless the equivalent functionality is already there.
+> When something cannot be lifted into an extension, decide explicitly where it lives instead.
+
+### Step 7 — Rewrite call sites
+
+Sweep your code for `<OldClassName>.<member>` references in extenders and rewrite them to
+`<OwnerClassName>.<member>` — for the typical owner-named-`PInvoke`, this is just `PInvoke.<member>`.
+
+For every file that now reaches a native API:
+
+- If the file is already inside `namespace Windows.Win32 { … }`, no change needed.
+- Otherwise, add a file-scoped `using Windows.Win32;` at the top.
+
+For any constant referenced in a C# const context (enum initializer, attribute argument,
+`fixed`-array size, `case` label), keep the host-class-qualified form (`<HostClass>.X`) — the
+extension forwarder is a property, not a const.
+
+### Step 8 — Fix XML doc cref references
+
+XML doc tooling cannot resolve `<see cref="PInvoke.X(…)"/>` when `X` is an extension member.
+With `TreatWarningsAsErrors` on, this surfaces as `CS1574` and fails the build.
+
+Rewrite affected crefs to inline code:
+
+```diff
+- /// <see cref="PInvoke.GetTickCount"/>
++ /// <c>PInvoke.GetTickCount</c>
+```
+
+Where the cref pointed at a direct member on the host class that still exists post-migration,
+leave it alone.
+
+### Step 9 — Build, test, ship
+
+Build every TargetFramework. Tests should pass unchanged — the feature is a discovery-surface
+change, not a runtime behavior change.
+
+## Common issues
+
+### `'PInvoke' does not contain a definition for 'X'` (`CS0117`)
+
+The call site can't see the extender that declares `X`.
+
+- Add `using Windows.Win32;` (file-scoped) in the file.
+- Confirm the extender's host class (and its containing assembly) are reachable: `public`, or
+  `internal` plus `[InternalsVisibleTo]`.
+- If you author your own `extension(T) { … }` and rely on a `global using` to bring another
+  namespace into scope, switch to a file-scoped `using`.
+
+### Constant in a const context fails to compile (`CS0133`)
+
+You wrote `PInvoke.X` in a context that requires a `const`. The extension path is a property and
+properties are not constants. Use `<HostClass>.X` — the const lives there.
+
+### Self-recursion in a user-authored wrapper
+
+Inside an `extension(T)` block, unqualified calls do not find sibling extension members of the
+same name. Always qualify as `T.X(…)`. Without the qualifier, the wrapper either fails to compile
+(`CS0103`) or, if its own name matches, recurses into itself at runtime.
+
+### Type conflicts with the owner after promoting it to `public` (`CS0436`)
+
+A higher layer ships a partial of a type that the owner now exports. See [Step 6](#step-6--consolidate-hand-authored-partials).
+
+### `extension` keyword unrecognized on a legacy TFM leg
+
+The consuming project's `LangVersion` is < 14 on at least one TargetFramework. Set
+`<LangVersion>14</LangVersion>` for every leg that isn't already on .NET 10+ (typically in
+`Directory.Build.props`).
+
+### Argument ambiguity on `null` (`CS1503` / `CS1620`)
+
+CsWin32 adds `out T` friendly overloads alongside the raw `T*` parameter. Existing call sites that
+pass `null` to the raw pointer may become ambiguous. Replace `null` with `out _` (use the
+overload) or with a typed `(T*)null` cast (force the raw-pointer overload).
+
+## What can and can't live in an `extension(T)` block
+
+The C# 14 language defines what extension blocks can contain. Helpful to consult when deciding how
+to migrate a hand-authored partial.
+
+| Construct | Allowed in `extension(T)`? |
+|---|---|
+| Static methods | ✅ |
+| Instance methods (on the receiver value) | ✅ |
+| Static / instance properties | ✅ |
+| Indexers | ✅ (some shapes) |
+| Static constructors | ❌ |
+| Fields (any) | ❌ |
+| `const` | ❌ |
+| Nested types | ❌ |
+| Operators | Partial — only specific shapes |
+
+For members that can't be expressed as extension members, the migration playbook in
+[Step 6](#step-6--consolidate-hand-authored-partials) covers where they belong instead.
+
+[csharp14-extensions]: https://learn.microsoft.com/dotnet/csharp/whats-new/csharp-14#extension-members

--- a/docfx/docs/features.md
+++ b/docfx/docs/features.md
@@ -4,5 +4,6 @@
 - Generates friendly overloads/extensions (including `SafeHandle`-types support).
 - Generates xml documentation based on and links back to learn.microsoft.com
 - Ships no bulky assemblies alongside your application.
+- [Layered composition](composition.md): multiple assemblies can extend a single shared `PInvoke` static class so callers reach every native API through one symbol.
 
 ![Animation demonstrating p/invoke code generation](../images/demo.gif)

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -37,25 +37,25 @@ dotnet add package System.Memory
 dotnet add package System.Runtime.CompilerServices.Unsafe
 ```
 
-Projects targeting .NET do *not* need to add these package references, although it is harmless to do so.
+Projects targeting .NET do _not_ need to add these package references, although it is harmless to do so.
 
 Note that while the `System.Memory` package depends on the `System.Runtime.CompilerServices.Unsafe` package,
 referencing the latter directly is still important to get the latest version of the APIs it provides.
 
 Your project must allow unsafe code to support the generated code that will likely use pointers.
-This does *not* automatically make all your code *unsafe*.
+This does _not_ automatically make all your code _unsafe_.
 Use of the `unsafe` keyword is required anywhere you use pointers.
 The source generator NuGet package sets the default value of the `AllowUnsafeBlocks` property for your project to `true`,
 but if you explicitly set it to `false` in your project file, generated code may produce compiler errors.
 
 Create a `NativeMethods.txt` file in your project directory that lists the APIs to generate code for.
-Each line may consist of *one* of the following:
+Each line may consist of _one_ of the following:
 
-* Exported method name (e.g. `CreateFile`). This *may* include the `A` or `W` suffix, where applicable. This *may* be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
+* Exported method name (e.g. `CreateFile`). This _may_ include the `A` or `W` suffix, where applicable. This _may_ be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
 * A macro name (e.g. `HRESULT_FROM_WIN32`). These are generated into the same class with extern methods. Macros must be hand-authored into CsWin32, so let us know if you want to see a macro added.
 * A namespace to generate all APIs from (e.g. `Windows.Win32.Storage.FileSystem` would search the metadata for all APIs within that namespace and generate them).
 * Module name followed by `.*` to generate all methods exported from that module (e.g. `Kernel32.*`).
-* The name of a struct, enum, constant or interface to generate. This *may* be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
+* The name of a struct, enum, constant or interface to generate. This _may_ be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
 * A prefix shared by many constants, followed by `*`, to generate all constants that share that prefix (e.g. `ALG_SID_MD*`).
 * A comment (i.e. any line starting with `//`) or white space line, which will be ignored.
 * A prefix `-` to indicate a name that should not be generated. The rest of the line can be a name (e.g. `BSTR`), fully namespaced name (e.g. `Windows.Win32.Foundation.BSTR`), or name ending in wildcard (e.g. `Windows.Win32.Foundation..*`)
@@ -99,6 +99,7 @@ Several aspects of the generated code can be customized, including:
 * Whether to emit ANSI functions as well where Wide character functions also exist
 * Set `PreserveSig` for COM interfaces or individual members
 * Force generation of blittable structs, COM structs instead of interfaces (for super high performance with 0 GC pressure), etc.
+* Layered composition: have multiple assemblies contribute to a single shared `PInvoke` symbol so callers reach every API through one discovery point. See [Layered composition](composition.md) for the design, dispatch rules, and a migration playbook for existing multi-layer projects.
 
 To configure these settings, create a `NativeMethods.json` file in your project directory.
 Specifying the `$schema` property that points to [the schema](https://github.com/microsoft/CsWin32/blob/main/src/Microsoft.Windows.CsWin32/settings.schema.json) adds completions, descriptions and validation in many JSON editors, and in fact is where all the documentation for the available settings is found.
@@ -112,7 +113,7 @@ Specifying the `$schema` property that points to [the schema](https://github.com
 
 Most generated types include the `partial` modifier so you can add your own members to that type within your code.
 
-When you need to *replace* a generated type, simply copy and paste it from generated code into your own source files
+When you need to _replace_ a generated type, simply copy and paste it from generated code into your own source files
 and remove the `partial` modifier.
 Be sure to keep the name and namespace exactly the same.
 CsWin32 will notice that your project already declares the type and skip generating it, but generate everything else.
@@ -144,8 +145,8 @@ To make this chaining work, you have to request CsWin32 to run as a build task t
 ```
 
 It is also strongly recommended to set DisableRuntimeMarshalling=true as shown here to ensure that the COM source generators handle
-all the marshalling correctly. See https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke-source-generation and
-https://learn.microsoft.com/en-us/dotnet/standard/native-interop/comwrappers-source-generation for more information on these .NET source
+all the marshalling correctly. See <https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke-source-generation> and
+<https://learn.microsoft.com/en-us/dotnet/standard/native-interop/comwrappers-source-generation> for more information on these .NET source
 generators.
 
 #### Disable runtime marshalling
@@ -196,6 +197,7 @@ static BOOL InitializeAcl(Span<byte> pAcl, ACE_REVISION dwAclRevision) { ... }
 ```
 
 And you would call this by creating a buffer to receive the ACL. Then, after the call you can reinterpret the buffer as an ACL:
+
 ```c#
 // Make a buffer
 Span<byte> buffer = new byte[CalculateAclSize(...)];

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -9,7 +9,7 @@ WPF projects have [additional requirements](https://github.com/microsoft/CsWin32
 This source generator generates code compatible with .NET Framework, .NET Standard 2.0, and .NET, as applicable to the project that uses it.
 .NET Framework 4.7.2 is the oldest target framework that is officially supported, but community contributions have made a subset of the generated code work in .NET Framework 3.5 projects.
 
-When targeting .NET Standard or .NET Framework, it is necessary to explicitly update the C# language version to at _least_ C# 9+ (`<LangVersion>9</LangVersion>` in your project file).
+When targeting .NET Standard or .NET Framework, it is necessary to explicitly update the C# language version to at least C# 9+ (`<LangVersion>9</LangVersion>` in your project file).
 C# 11 is sometimes required depending on the code being generated.
 See [issue #4](https://github.com/microsoft/CsWin32/issues/4) for more on this.
 Newer is generally better.
@@ -37,25 +37,25 @@ dotnet add package System.Memory
 dotnet add package System.Runtime.CompilerServices.Unsafe
 ```
 
-Projects targeting .NET do _not_ need to add these package references, although it is harmless to do so.
+Projects targeting .NET do not need to add these package references, although it is harmless to do so.
 
 Note that while the `System.Memory` package depends on the `System.Runtime.CompilerServices.Unsafe` package,
 referencing the latter directly is still important to get the latest version of the APIs it provides.
 
 Your project must allow unsafe code to support the generated code that will likely use pointers.
-This does _not_ automatically make all your code _unsafe_.
+This does not automatically make all your code unsafe.
 Use of the `unsafe` keyword is required anywhere you use pointers.
 The source generator NuGet package sets the default value of the `AllowUnsafeBlocks` property for your project to `true`,
 but if you explicitly set it to `false` in your project file, generated code may produce compiler errors.
 
 Create a `NativeMethods.txt` file in your project directory that lists the APIs to generate code for.
-Each line may consist of _one_ of the following:
+Each line may consist of one of the following:
 
-* Exported method name (e.g. `CreateFile`). This _may_ include the `A` or `W` suffix, where applicable. This _may_ be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
+* Exported method name (e.g. `CreateFile`). This may include the `A` or `W` suffix, where applicable. This may be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
 * A macro name (e.g. `HRESULT_FROM_WIN32`). These are generated into the same class with extern methods. Macros must be hand-authored into CsWin32, so let us know if you want to see a macro added.
 * A namespace to generate all APIs from (e.g. `Windows.Win32.Storage.FileSystem` would search the metadata for all APIs within that namespace and generate them).
 * Module name followed by `.*` to generate all methods exported from that module (e.g. `Kernel32.*`).
-* The name of a struct, enum, constant or interface to generate. This _may_ be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
+* The name of a struct, enum, constant or interface to generate. This may be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
 * A prefix shared by many constants, followed by `*`, to generate all constants that share that prefix (e.g. `ALG_SID_MD*`).
 * A comment (i.e. any line starting with `//`) or white space line, which will be ignored.
 * A prefix `-` to indicate a name that should not be generated. The rest of the line can be a name (e.g. `BSTR`), fully namespaced name (e.g. `Windows.Win32.Foundation.BSTR`), or name ending in wildcard (e.g. `Windows.Win32.Foundation..*`)
@@ -113,7 +113,7 @@ Specifying the `$schema` property that points to [the schema](https://github.com
 
 Most generated types include the `partial` modifier so you can add your own members to that type within your code.
 
-When you need to _replace_ a generated type, simply copy and paste it from generated code into your own source files
+When you need to replace a generated type, simply copy and paste it from generated code into your own source files
 and remove the `partial` modifier.
 Be sure to keep the name and namespace exactly the same.
 CsWin32 will notice that your project already declares the type and skip generating it, but generate everything else.
@@ -137,7 +137,7 @@ Then you have two options:
 #### Enable CsWin32RunAsBuildTask
 
 CsWin32 now supports AOT by generating code which relies on `GeneratedComInterface` and `LibraryImport`, which are source generators.
-To make this chaining work, you have to request CsWin32 to run as a build task to generate the source code _before_ compile. Do this by adding this to your csproj:
+To make this chaining work, you have to request CsWin32 to run as a build task to generate the source code before compile. Do this by adding this to your csproj:
 
 ```xml
 <CsWin32RunAsBuildTask>true</CsWin32RunAsBuildTask>

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -9,7 +9,7 @@ WPF projects have [additional requirements](https://github.com/microsoft/CsWin32
 This source generator generates code compatible with .NET Framework, .NET Standard 2.0, and .NET, as applicable to the project that uses it.
 .NET Framework 4.7.2 is the oldest target framework that is officially supported, but community contributions have made a subset of the generated code work in .NET Framework 3.5 projects.
 
-When targeting .NET Standard or .NET Framework, it is necessary to explicitly update the C# language version to at least C# 9+ (`<LangVersion>9</LangVersion>` in your project file).
+When targeting .NET Standard or .NET Framework, it is necessary to explicitly update the C# language version to at _least_ C# 9+ (`<LangVersion>9</LangVersion>` in your project file).
 C# 11 is sometimes required depending on the code being generated.
 See [issue #4](https://github.com/microsoft/CsWin32/issues/4) for more on this.
 Newer is generally better.
@@ -37,25 +37,25 @@ dotnet add package System.Memory
 dotnet add package System.Runtime.CompilerServices.Unsafe
 ```
 
-Projects targeting .NET do not need to add these package references, although it is harmless to do so.
+Projects targeting .NET do _not_ need to add these package references, although it is harmless to do so.
 
 Note that while the `System.Memory` package depends on the `System.Runtime.CompilerServices.Unsafe` package,
 referencing the latter directly is still important to get the latest version of the APIs it provides.
 
 Your project must allow unsafe code to support the generated code that will likely use pointers.
-This does not automatically make all your code unsafe.
+This does _not_ automatically make all your code _unsafe_.
 Use of the `unsafe` keyword is required anywhere you use pointers.
 The source generator NuGet package sets the default value of the `AllowUnsafeBlocks` property for your project to `true`,
 but if you explicitly set it to `false` in your project file, generated code may produce compiler errors.
 
 Create a `NativeMethods.txt` file in your project directory that lists the APIs to generate code for.
-Each line may consist of one of the following:
+Each line may consist of _one_ of the following:
 
-* Exported method name (e.g. `CreateFile`). This may include the `A` or `W` suffix, where applicable. This may be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
+* Exported method name (e.g. `CreateFile`). This _may_ include the `A` or `W` suffix, where applicable. This _may_ be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
 * A macro name (e.g. `HRESULT_FROM_WIN32`). These are generated into the same class with extern methods. Macros must be hand-authored into CsWin32, so let us know if you want to see a macro added.
 * A namespace to generate all APIs from (e.g. `Windows.Win32.Storage.FileSystem` would search the metadata for all APIs within that namespace and generate them).
 * Module name followed by `.*` to generate all methods exported from that module (e.g. `Kernel32.*`).
-* The name of a struct, enum, constant or interface to generate. This may be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
+* The name of a struct, enum, constant or interface to generate. This _may_ be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
 * A prefix shared by many constants, followed by `*`, to generate all constants that share that prefix (e.g. `ALG_SID_MD*`).
 * A comment (i.e. any line starting with `//`) or white space line, which will be ignored.
 * A prefix `-` to indicate a name that should not be generated. The rest of the line can be a name (e.g. `BSTR`), fully namespaced name (e.g. `Windows.Win32.Foundation.BSTR`), or name ending in wildcard (e.g. `Windows.Win32.Foundation..*`)
@@ -113,7 +113,7 @@ Specifying the `$schema` property that points to [the schema](https://github.com
 
 Most generated types include the `partial` modifier so you can add your own members to that type within your code.
 
-When you need to replace a generated type, simply copy and paste it from generated code into your own source files
+When you need to _replace_ a generated type, simply copy and paste it from generated code into your own source files
 and remove the `partial` modifier.
 Be sure to keep the name and namespace exactly the same.
 CsWin32 will notice that your project already declares the type and skip generating it, but generate everything else.
@@ -137,7 +137,7 @@ Then you have two options:
 #### Enable CsWin32RunAsBuildTask
 
 CsWin32 now supports AOT by generating code which relies on `GeneratedComInterface` and `LibraryImport`, which are source generators.
-To make this chaining work, you have to request CsWin32 to run as a build task to generate the source code before compile. Do this by adding this to your csproj:
+To make this chaining work, you have to request CsWin32 to run as a build task to generate the source code _before_ compile. Do this by adding this to your csproj:
 
 ```xml
 <CsWin32RunAsBuildTask>true</CsWin32RunAsBuildTask>

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -37,25 +37,25 @@ dotnet add package System.Memory
 dotnet add package System.Runtime.CompilerServices.Unsafe
 ```
 
-Projects targeting .NET do _not_ need to add these package references, although it is harmless to do so.
+Projects targeting .NET do *not* need to add these package references, although it is harmless to do so.
 
 Note that while the `System.Memory` package depends on the `System.Runtime.CompilerServices.Unsafe` package,
 referencing the latter directly is still important to get the latest version of the APIs it provides.
 
 Your project must allow unsafe code to support the generated code that will likely use pointers.
-This does _not_ automatically make all your code _unsafe_.
+This does *not* automatically make all your code *unsafe*.
 Use of the `unsafe` keyword is required anywhere you use pointers.
 The source generator NuGet package sets the default value of the `AllowUnsafeBlocks` property for your project to `true`,
 but if you explicitly set it to `false` in your project file, generated code may produce compiler errors.
 
 Create a `NativeMethods.txt` file in your project directory that lists the APIs to generate code for.
-Each line may consist of _one_ of the following:
+Each line may consist of *one* of the following:
 
-* Exported method name (e.g. `CreateFile`). This _may_ include the `A` or `W` suffix, where applicable. This _may_ be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
+* Exported method name (e.g. `CreateFile`). This *may* include the `A` or `W` suffix, where applicable. This *may* be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
 * A macro name (e.g. `HRESULT_FROM_WIN32`). These are generated into the same class with extern methods. Macros must be hand-authored into CsWin32, so let us know if you want to see a macro added.
 * A namespace to generate all APIs from (e.g. `Windows.Win32.Storage.FileSystem` would search the metadata for all APIs within that namespace and generate them).
 * Module name followed by `.*` to generate all methods exported from that module (e.g. `Kernel32.*`).
-* The name of a struct, enum, constant or interface to generate. This _may_ be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
+* The name of a struct, enum, constant or interface to generate. This *may* be qualified with a namespace but is only recommended in cases of ambiguity, which CsWin32 will prompt where appropriate.
 * A prefix shared by many constants, followed by `*`, to generate all constants that share that prefix (e.g. `ALG_SID_MD*`).
 * A comment (i.e. any line starting with `//`) or white space line, which will be ignored.
 * A prefix `-` to indicate a name that should not be generated. The rest of the line can be a name (e.g. `BSTR`), fully namespaced name (e.g. `Windows.Win32.Foundation.BSTR`), or name ending in wildcard (e.g. `Windows.Win32.Foundation..*`)
@@ -113,7 +113,7 @@ Specifying the `$schema` property that points to [the schema](https://github.com
 
 Most generated types include the `partial` modifier so you can add your own members to that type within your code.
 
-When you need to _replace_ a generated type, simply copy and paste it from generated code into your own source files
+When you need to *replace* a generated type, simply copy and paste it from generated code into your own source files
 and remove the `partial` modifier.
 Be sure to keep the name and namespace exactly the same.
 CsWin32 will notice that your project already declares the type and skip generating it, but generate everything else.
@@ -145,8 +145,8 @@ To make this chaining work, you have to request CsWin32 to run as a build task t
 ```
 
 It is also strongly recommended to set DisableRuntimeMarshalling=true as shown here to ensure that the COM source generators handle
-all the marshalling correctly. See <https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke-source-generation> and
-<https://learn.microsoft.com/en-us/dotnet/standard/native-interop/comwrappers-source-generation> for more information on these .NET source
+all the marshalling correctly. See https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke-source-generation and
+https://learn.microsoft.com/en-us/dotnet/standard/native-interop/comwrappers-source-generation for more information on these .NET source
 generators.
 
 #### Disable runtime marshalling
@@ -197,7 +197,6 @@ static BOOL InitializeAcl(Span<byte> pAcl, ACE_REVISION dwAclRevision) { ... }
 ```
 
 And you would call this by creating a buffer to receive the ACL. Then, after the call you can reinterpret the buffer as an ACL:
-
 ```c#
 // Make a buffer
 Span<byte> buffer = new byte[CalculateAclSize(...)];

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -2,5 +2,6 @@ items:
 - href: features.md
 - href: getting-started.md
 - href: Examples.md
+- href: composition.md
 - href: ArchSpecificAPIs.md
 - href: 3rdPartyMetadata.md

--- a/src/Microsoft.Windows.CsWin32.Roslyn4/Microsoft.Windows.CsWin32.Roslyn4.csproj
+++ b/src/Microsoft.Windows.CsWin32.Roslyn4/Microsoft.Windows.CsWin32.Roslyn4.csproj
@@ -1,0 +1,79 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Microsoft.Windows.CsWin32.Roslyn4 — the Roslyn 4.11 (floor) leg of the analyzer.
+
+    Builds the same source as the sibling Microsoft.Windows.CsWin32 project, against the
+    floor Roslyn package version, with the ROSLYN5 symbol omitted. The Roslyn 4 leg
+    refuses the ExtensionReceiver feature with diagnostic PInvoke013 and otherwise behaves
+    identically to the original CsWin32 analyzer.
+
+    The DLL produced here is consumed by the original project's nuspec to pack a second
+    analyzer assembly under `analyzers/dotnet/roslyn4.11/cs/`. NuGet's analyzer loader
+    picks the appropriate folder based on the host's Roslyn version.
+
+    This project is NOT independently packable; it is a sibling that contributes its
+    output to the parent package.
+  -->
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Platforms>AnyCPU</Platforms>
+    <Nullable>enable</Nullable>
+
+    <!-- Force the Roslyn 4 floor version for this leg. -->
+    <CodeAnalysisVersionForAnalyzers>4.11.0</CodeAnalysisVersionForAnalyzers>
+
+    <!-- Produce the same DLL filename + assembly identity as the Roslyn 5 leg. -->
+    <AssemblyName>Microsoft.Windows.CsWin32</AssemblyName>
+    <RootNamespace>Microsoft.Windows.CsWin32</RootNamespace>
+
+    <!-- Source comes from the sibling project (single source of truth). -->
+    <CsWin32SharedSourceRoot>$(MSBuildThisFileDirectory)..\Microsoft.Windows.CsWin32\</CsWin32SharedSourceRoot>
+
+    <!-- Special properties for analyzer packages (mirror the Roslyn 5 csproj). -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <NoWarn>$(NoWarn);NU5128;NU5127;NU5104</NoWarn>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+
+    <!-- Do NOT define ROSLYN5. Wave A/B feature code is conditionally compiled on this symbol;
+         on this leg the ExtensionReceiver feature is rejected via PInvoke013. -->
+  </PropertyGroup>
+
+  <!-- Pull in all source from the Roslyn 5 leg via a wildcard, mirroring its file layout. -->
+  <ItemGroup>
+    <Compile Remove="**\*.cs" />
+    <Compile Include="$(CsWin32SharedSourceRoot)**\*.cs" Exclude="$(CsWin32SharedSourceRoot)bin\**\*.cs;$(CsWin32SharedSourceRoot)obj\**\*.cs;$(CsWin32SharedSourceRoot)templates\**\*.cs" />
+    <EmbeddedResource Include="$(CsWin32SharedSourceRoot)templates\**\*.cs" />
+    <AdditionalFiles Include="$(CsWin32SharedSourceRoot)BannedSymbols.txt" />
+    <AdditionalFiles Include="$(CsWin32SharedSourceRoot)AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="$(CsWin32SharedSourceRoot)AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+  <ItemDefinitionGroup>
+    <PackageReference>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MessagePack" />
+    <PackageReference Include="MessagePackAnalyzer" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" GeneratePathProperty="true" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.Windows.SDK.Win32Docs" GeneratePathProperty="true" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.Windows.WDK.Win32Metadata" GeneratePathProperty="true" PrivateAssets="none" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
+    <PackageReference Include="System.Memory" PrivateAssets="none" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Windows.CsWin32/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.Windows.CsWin32/AnalyzerReleases.Unshipped.md
@@ -1,7 +1,8 @@
 ﻿; Unshipped analyzer release
-; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+; <https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md>
 
 ### New Rules
+
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 PInvoke000 | Functionality | Error | SourceGenerator
@@ -15,3 +16,6 @@ PInvoke007 | Functionality | Error | SourceGenerator
 PInvoke008 | Configuration | Error | SourceGenerator
 PInvoke009 | Configuration | Warning | SourceGenerator
 PInvoke010 | Configuration | Error | SourceGenerator
+PInvoke011 | Configuration | Error | SourceGenerator
+PInvoke012 | Configuration | Error | SourceGenerator
+PInvoke013 | Configuration | Error | SourceGenerator

--- a/src/Microsoft.Windows.CsWin32/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.Windows.CsWin32/AnalyzerReleases.Unshipped.md
@@ -1,8 +1,7 @@
 ﻿; Unshipped analyzer release
-; <https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md>
+; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
 ### New Rules
-
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 PInvoke000 | Functionality | Error | SourceGenerator

--- a/src/Microsoft.Windows.CsWin32/FastSyntaxFactory.cs
+++ b/src/Microsoft.Windows.CsWin32/FastSyntaxFactory.cs
@@ -158,6 +158,35 @@ internal static class FastSyntaxFactory
 
     internal static StructDeclarationSyntax StructDeclaration(SyntaxToken identifier, SyntaxList<MemberDeclarationSyntax> members = default) => SyntaxFactory.StructDeclaration(default, default, TokenWithSpace(SyntaxKind.StructKeyword), identifier.WithTrailingTrivia(TriviaList(LineFeed)), null, null, default, OpenBrace, members, CloseBrace, default);
 
+#if ROSLYN5
+    /// <summary>
+    /// Creates a C# 14 <c>extension (Receiver) { ... }</c> block declaration suitable for inclusion in a static class. Only available in the Roslyn 5 leg of the analyzer.
+    /// </summary>
+    /// <param name="receiverType">The type that is being extended (the receiver).</param>
+    /// <param name="members">The members of the extension block.</param>
+    /// <returns>An <see cref="ExtensionBlockDeclarationSyntax"/>.</returns>
+    internal static ExtensionBlockDeclarationSyntax ExtensionBlock(TypeSyntax receiverType, SyntaxList<MemberDeclarationSyntax> members)
+    {
+        ParameterSyntax receiverParameter = SyntaxFactory.Parameter(default, default, receiverType, default(SyntaxToken), null);
+        ParameterListSyntax parameterList = SyntaxFactory.ParameterList(
+            Token(SyntaxKind.OpenParenToken),
+            SyntaxFactory.SeparatedList<ParameterSyntax>([receiverParameter]),
+            Token(SyntaxKind.CloseParenToken).WithTrailingTrivia(TriviaList(LineFeed)));
+
+        return SyntaxFactory.ExtensionBlockDeclaration(
+            attributeLists: default,
+            modifiers: default,
+            keyword: TokenWithSpace(SyntaxKind.ExtensionKeyword),
+            typeParameterList: null,
+            parameterList: parameterList,
+            constraintClauses: default,
+            openBraceToken: OpenBrace,
+            members: members,
+            closeBraceToken: CloseBrace,
+            semicolonToken: default);
+    }
+#endif
+
     internal static ConstructorInitializerSyntax ConstructorInitializer(SyntaxKind kind, SeparatedSyntaxList<ArgumentSyntax> arguments = default) => SyntaxFactory.ConstructorInitializer(kind, Token(SyntaxKind.ColonToken), Token(GetConstructorInitializerThisOrBaseKeywordKind(kind)), ArgumentList(arguments));
 
     internal static PropertyDeclarationSyntax PropertyDeclaration(TypeSyntax type, string identifier) => PropertyDeclaration(type, Identifier(identifier));

--- a/src/Microsoft.Windows.CsWin32/Generator.Constant.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Constant.cs
@@ -149,7 +149,7 @@ public partial class Generator
             if (this.options.ExtensionReceiver is not null)
             {
                 string constantName = this.Reader.GetString(fieldDef.Name);
-                if (this.IsExtensionMemberAlreadyOnReceiver(constantName, Array.Empty<string>()))
+                if (this.IsExtensionMemberAlreadyOnReceiver(constantName, Array.Empty<string>(), ReceiverMemberKind.Value))
                 {
                     return;
                 }

--- a/src/Microsoft.Windows.CsWin32/Generator.Constant.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Constant.cs
@@ -140,6 +140,21 @@ public partial class Generator
         this.volatileCode.GenerateConstant(fieldDefHandle, delegate
         {
             FieldDefinition fieldDef = this.Reader.GetFieldDefinition(fieldDefHandle);
+
+            // Multi-assembly composition: if another assembly already exposes this constant as an extension
+            // property (or as a plain field/property on the receiver type), skip regeneration so layered
+            // CsWin32 outputs compose without duplicates. Constants are name-unique per type (no
+            // overloading), so we look for any member of the same name with zero parameters
+            // (field / property / parameterless accessor) by passing an empty parameter-types list.
+            if (this.options.ExtensionReceiver is not null)
+            {
+                string constantName = this.Reader.GetString(fieldDef.Name);
+                if (this.IsExtensionMemberAlreadyOnReceiver(constantName, Array.Empty<string>()))
+                {
+                    return;
+                }
+            }
+
             FieldDeclarationSyntax constantDeclaration = this.DeclareConstant(fieldDef);
 
             TypeHandleInfo fieldTypeInfo = fieldDef.DecodeSignature<TypeHandleInfo, SignatureHandleProvider.IGenericContext?>(this.SignatureHandleProvider, null) with { IsConstantField = true };
@@ -420,7 +435,68 @@ public partial class Generator
 
     private ClassDeclarationSyntax DeclareConstantDefiningClass()
     {
+#if ROSLYN5
+        // Skip the field-split when no receiver is configured OR when THIS generator's namespace can't
+        // resolve the configured receiver (multi-namespace pipeline edge case — see Generator.WrapAsExtensionMembers).
+        if (this.options.ExtensionReceiver is null || this.GetExtensionReceiverSymbol() is null)
+        {
+            return ClassDeclaration(this.methodsAndConstantsClassName.Identifier, [.. this.committedCode.TopLevelFields])
+                .WithModifiers([TokenWithSpace(this.Visibility), TokenWithSpace(SyntaxKind.StaticKeyword), TokenWithSpace(SyntaxKind.PartialKeyword)]);
+        }
+
+        // When an extension receiver is configured, constants must remain on the host class because
+        // fields are not legal members of a C# 14 extension block. To still expose them through the
+        // receiver, we emit a forwarding static property inside the extension block that returns the
+        // underlying field. The backing field keeps its original visibility (typically <c>public</c>
+        // because const fields need to be reachable from C# constant contexts such as enum initializers,
+        // attribute arguments, and `fixed` array sizes — none of which can flow through a property).
+        // Consumers reach the constant either as `<HostClass>.X` (works in const contexts) or as
+        // `<Receiver>.X` via the extension property (works in any runtime context).
+        SyntaxToken publicVisibility = TokenWithSpace(this.Visibility);
+
+        var backingFields = new System.Collections.Generic.List<MemberDeclarationSyntax>(this.committedCode.TopLevelFields.Count());
+        var forwarderProperties = new System.Collections.Generic.List<MemberDeclarationSyntax>(this.committedCode.TopLevelFields.Count());
+
+        // Use a global-qualified host expression so the forwarder body is unambiguous even when the extension
+        // block's own scope shadows the host class name.
+        ExpressionSyntax qualifiedHost = ParseName($"global::{this.Namespace}.{this.options.ClassName}");
+
+        foreach (FieldDeclarationSyntax originalField in this.committedCode.TopLevelFields)
+        {
+            // Keep the field as-is on the host class (original visibility preserved) so consumers can use
+            // `<HostClass>.<Name>` in const contexts. The forwarder property below adds the receiver-qualified
+            // discovery path for runtime contexts.
+            backingFields.Add(originalField);
+
+            // Build the forwarder property: <visibility> static <Type> <Name> => <Host>.<Name>;
+            TypeSyntax fieldType = originalField.Declaration.Type;
+            foreach (VariableDeclaratorSyntax declarator in originalField.Declaration.Variables)
+            {
+                SyntaxToken nameIdent = declarator.Identifier;
+                ExpressionSyntax forwardExpr = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    qualifiedHost,
+                    IdentifierName(nameIdent.WithoutTrivia()));
+                PropertyDeclarationSyntax property = SyntaxFactory.PropertyDeclaration(fieldType.WithTrailingTrivia(TriviaList(Space)), nameIdent.WithoutTrivia())
+                    .WithModifiers(SyntaxFactory.TokenList(publicVisibility, TokenWithSpace(SyntaxKind.StaticKeyword)))
+                    .WithExpressionBody(ArrowExpressionClause(forwardExpr))
+                    .WithSemicolonToken(SemicolonWithLineFeed);
+                forwarderProperties.Add(property);
+            }
+        }
+
+        var classMembers = new System.Collections.Generic.List<MemberDeclarationSyntax>(backingFields);
+        if (forwarderProperties.Count > 0)
+        {
+            classMembers.Add(ExtensionBlock(ParseName($"global::{this.Namespace}.{this.options.ExtensionReceiver}"), SyntaxFactory.List(forwarderProperties)));
+        }
+
+        return ClassDeclaration(this.methodsAndConstantsClassName.Identifier, SyntaxFactory.List(classMembers))
+            .WithModifiers([TokenWithSpace(this.Visibility), TokenWithSpace(SyntaxKind.StaticKeyword), TokenWithSpace(SyntaxKind.PartialKeyword)]);
+#else
+        // The Roslyn 4 leg ignores ExtensionReceiver (rejected at validation time via PInvoke013).
         return ClassDeclaration(this.methodsAndConstantsClassName.Identifier, [.. this.committedCode.TopLevelFields])
             .WithModifiers([TokenWithSpace(this.Visibility), TokenWithSpace(SyntaxKind.StaticKeyword), TokenWithSpace(SyntaxKind.PartialKeyword)]);
+#endif
     }
 }

--- a/src/Microsoft.Windows.CsWin32/Generator.Extern.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Extern.cs
@@ -148,6 +148,32 @@ public partial class Generator
             }
         }
 
+        // Multi-assembly composition: if another CsWin32-emitted assembly already exposes a method with
+        // a matching signature (name AND parameter count AND parameter type names) as an extension member
+        // on the configured receiver, skip regeneration. Matching by name alone is unsafe: a user-authored
+        // helper wrapper (e.g. `extension(PInvoke) { string GetThemeDocumentationProperty(string, string) {...} }`)
+        // would falsely match the raw P/Invoke (`GetThemeDocumentationProperty(HTHEME, PCWSTR, PWSTR, int)`),
+        // causing the wrapper to silently recurse into itself at runtime. We require a full signature match.
+        if (this.options.ExtensionReceiver is not null)
+        {
+            MethodSignature<TypeHandleInfo> sig = methodDefinition.DecodeSignature(this.SignatureHandleProvider, null);
+            string[] parameterTypeNames = new string[sig.ParameterTypes.Length];
+            for (int i = 0; i < sig.ParameterTypes.Length; i++)
+            {
+                // Use the same projection settings the extern emission uses, so the textual form of each
+                // parameter type matches what a CsWin32-emitted extension member in another assembly would
+                // also produce (subject to the normalization in IsExtensionMemberAlreadyOnReceiver).
+                parameterTypeNames[i] = sig.ParameterTypes[i]
+                    .ToTypeSyntax(this.externSignatureTypeSettings, GeneratingElement.ExternMethod, null)
+                    .Type.ToString();
+            }
+
+            if (this.IsExtensionMemberAlreadyOnReceiver(this.Reader.GetString(methodDefinition.Name), parameterTypeNames))
+            {
+                return;
+            }
+        }
+
         this.volatileCode.GenerateMethod(methodDefinitionHandle, () => this.DeclareExternMethod(methodDefinitionHandle));
     }
 

--- a/src/Microsoft.Windows.CsWin32/Generator.Extern.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Extern.cs
@@ -168,7 +168,7 @@ public partial class Generator
                     .Type.ToString();
             }
 
-            if (this.IsExtensionMemberAlreadyOnReceiver(this.Reader.GetString(methodDefinition.Name), parameterTypeNames))
+            if (this.IsExtensionMemberAlreadyOnReceiver(this.Reader.GetString(methodDefinition.Name), parameterTypeNames, ReceiverMemberKind.Method))
             {
                 return;
             }

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -52,6 +52,8 @@ public partial class Generator : IGenerator, IDisposable
     private readonly Dictionary<TypeDefinitionHandle, bool> managedTypesCheck = new();
     private readonly Dictionary<TypeDefinitionHandle, bool> structTypesCheck = new();
     private MethodDeclarationSyntax? sliceAtNullMethodDecl;
+    private INamedTypeSymbol? extensionReceiverSymbolCache;
+    private bool extensionReceiverSymbolResolved;
 
     static Generator()
     {
@@ -334,7 +336,7 @@ public partial class Generator : IGenerator, IDisposable
             int i = 0;
             foreach (IGrouping<string, MemberDeclarationSyntax> entry in members)
             {
-                ClassDeclarationSyntax partialClass = DeclarePInvokeClass(entry.Key, [.. entry])
+                ClassDeclarationSyntax partialClass = DeclarePInvokeClass(entry.Key, this.WrapAsExtensionMembers([.. entry]))
                     .WithLeadingTrivia(ParseLeadingTrivia(string.Format(CultureInfo.InvariantCulture, PartialPInvokeContentComment, entry.Key)));
                 if (i == 0)
                 {
@@ -348,7 +350,7 @@ public partial class Generator : IGenerator, IDisposable
                 i++;
             }
 
-            ClassDeclarationSyntax macrosPartialClass = DeclarePInvokeClass("Macros", [.. this.committedCode.Macros])
+            ClassDeclarationSyntax macrosPartialClass = DeclarePInvokeClass("Macros", this.WrapAsExtensionMembers([.. this.committedCode.Macros]))
                 .WithLeadingTrivia(ParseLeadingTrivia(PartialPInvokeMacrosContentComment));
             if (macrosPartialClass.Members.Count > 0)
             {
@@ -1403,6 +1405,355 @@ public partial class Generator : IGenerator, IDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Wraps a list of members in an <c>extension (Receiver) { ... }</c> block when <see cref="GeneratorOptions.ExtensionReceiver"/> is configured; otherwise returns the input unchanged. Under the Roslyn 4 leg the wrap is a no-op (the feature is gated to Roslyn 5 + C# 14).
+    /// </summary>
+    /// <param name="members">The members that would otherwise be added directly to the host static class.</param>
+    /// <returns>A new member list (length 1) containing an extension block, or the original list when no extension receiver is configured, the input is empty, or the analyzer is the Roslyn 4 leg.</returns>
+    private SyntaxList<MemberDeclarationSyntax> WrapAsExtensionMembers(SyntaxList<MemberDeclarationSyntax> members)
+    {
+#if ROSLYN5
+        if (this.options.ExtensionReceiver is null || members.Count == 0)
+        {
+            return members;
+        }
+
+        // Per-generator gate: if THIS generator's namespace doesn't contain the receiver type (common when
+        // multiple metadata pipelines run, e.g. Windows.Win32 + Windows.Wdk and the receiver only exists
+        // in one), skip the wrap for this generator instead of failing the whole compilation.
+        if (this.GetExtensionReceiverSymbol() is null)
+        {
+            return members;
+        }
+
+        // Use a global-qualified name so the receiver is unambiguous regardless of `using`s in the consuming file.
+        TypeSyntax receiverType = ParseName($"global::{this.Namespace}.{this.options.ExtensionReceiver}");
+        ExtensionBlockDeclarationSyntax extensionBlock = ExtensionBlock(receiverType, members);
+        return SyntaxFactory.SingletonList<MemberDeclarationSyntax>(extensionBlock);
+#else
+        return members;
+#endif
+    }
+
+    /// <summary>
+    /// Resolves <see cref="GeneratorOptions.ExtensionReceiver"/> against this generator's <see cref="Namespace"/> and verifies it names a usable static class.
+    /// </summary>
+    /// <param name="symbol">Receives the resolved receiver symbol on success.</param>
+    /// <param name="errorReason">Receives a human-readable explanation on failure, suitable for use as a diagnostic message argument.</param>
+    /// <returns><see langword="true"/> if the receiver resolves and is valid; <see langword="false"/> otherwise. Also returns <see langword="false"/> with both out parameters <see langword="null"/> when no extension receiver is configured.</returns>
+#pragma warning disable SA1202 // Element ordering: keep validation helper near other Find* helpers it depends on.
+    public bool TryResolveExtensionReceiver(out INamedTypeSymbol? symbol, out string? errorReason)
+#pragma warning restore SA1202
+    {
+        symbol = null;
+        errorReason = null;
+
+        if (this.options.ExtensionReceiver is not string receiverName)
+        {
+            return false;
+        }
+
+        if (string.Equals(receiverName, this.options.ClassName, StringComparison.Ordinal))
+        {
+            errorReason = "it equals ClassName (self-reference is not allowed)";
+            return false;
+        }
+
+        if (this.compilation is null)
+        {
+            errorReason = "no compilation context is available to resolve the receiver type";
+            return false;
+        }
+
+        string fullyQualifiedName = $"{this.Namespace}.{receiverName}";
+        IReadOnlyList<ISymbol> matches = this.FindTypeSymbolsIfAlreadyAvailable(fullyQualifiedName);
+        if (matches.Count == 0)
+        {
+            errorReason = $"the type \"{fullyQualifiedName}\" was not found in the compilation or any referenced assembly (or it is not accessible)";
+            return false;
+        }
+
+        if (matches.Count > 1)
+        {
+            errorReason = $"the type \"{fullyQualifiedName}\" is declared in multiple places, which makes the receiver ambiguous";
+            return false;
+        }
+
+        if (matches[0] is not INamedTypeSymbol named)
+        {
+            errorReason = $"\"{fullyQualifiedName}\" did not resolve to a named type";
+            return false;
+        }
+
+        if (named.TypeKind != TypeKind.Class || !named.IsStatic)
+        {
+            errorReason = $"\"{fullyQualifiedName}\" must be a static class";
+            return false;
+        }
+
+        symbol = named;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the cached, resolved extension receiver symbol or <see langword="null"/> when the option is unset or invalid.
+    /// </summary>
+    /// <returns>The receiver named type symbol, or <see langword="null"/>.</returns>
+    private INamedTypeSymbol? GetExtensionReceiverSymbol()
+    {
+        if (!this.extensionReceiverSymbolResolved)
+        {
+            this.extensionReceiverSymbolResolved = true;
+            this.TryResolveExtensionReceiver(out this.extensionReceiverSymbolCache, out _);
+        }
+
+        return this.extensionReceiverSymbolCache;
+    }
+
+    /// <summary>
+    /// Tests whether the configured extension receiver type already exposes an accessible member with a matching signature (name + parameter count + per-parameter type name) as an extension member, across the compilation and any referenced assemblies. Supports multi-assembly composition of CsWin32 outputs. Always returns <see langword="false"/> on the Roslyn 4 leg of the analyzer (which lacks the extension-symbol API).
+    /// </summary>
+    /// <param name="memberName">The simple member name to look for.</param>
+    /// <param name="parameterTypeNames">The CsWin32-projected textual form of each parameter type, in declaration order. Pass an empty array when probing for a field/property/parameterless member (e.g. a constant). The strings are compared after a normalization that strips <c>global::</c> prefixes and leading namespace segments, so callers may pass fully-qualified names produced by <c>ToTypeSyntax(...)</c>.</param>
+    /// <returns><see langword="true"/> if a matching extension member is already declared on the receiver in scope; <see langword="false"/> otherwise (including when no extension receiver is configured or running on the Roslyn 4 leg).</returns>
+#pragma warning disable SA1202 // Keep dedup helper next to TryResolveExtensionReceiver / receiver-related code.
+    internal bool IsExtensionMemberAlreadyOnReceiver(string memberName, IReadOnlyList<string> parameterTypeNames)
+#pragma warning restore SA1202
+    {
+#if ROSLYN5
+        if (this.options.ExtensionReceiver is null)
+        {
+            return false;
+        }
+
+        if (this.compilation is null)
+        {
+            return false;
+        }
+
+        INamedTypeSymbol? receiver = this.GetExtensionReceiverSymbol();
+        if (receiver is null)
+        {
+            return false;
+        }
+
+        INamespaceSymbol? targetNamespace = receiver.ContainingNamespace;
+        if (targetNamespace is null)
+        {
+            return false;
+        }
+
+        // Pre-normalize the metadata-side parameter names once.
+        string[] normalizedMetadataParams = new string[parameterTypeNames.Count];
+        for (int i = 0; i < parameterTypeNames.Count; i++)
+        {
+            normalizedMetadataParams[i] = NormalizeParameterTypeName(parameterTypeNames[i]);
+        }
+
+        foreach (IAssemblySymbol assembly in this.EnumerateAccessibleAssemblies())
+        {
+            INamespaceSymbol? ns = ResolveNamespaceIn(assembly, targetNamespace);
+            if (ns is null)
+            {
+                continue;
+            }
+
+            foreach (INamedTypeSymbol hostCandidate in ns.GetTypeMembers())
+            {
+                if (hostCandidate.TypeKind != TypeKind.Class || !hostCandidate.IsStatic)
+                {
+                    continue;
+                }
+
+                foreach (INamedTypeSymbol nested in hostCandidate.GetTypeMembers())
+                {
+                    if (!nested.IsExtension)
+                    {
+                        continue;
+                    }
+
+                    ITypeSymbol? receiverParameterType = nested.ExtensionParameter?.Type;
+                    if (receiverParameterType is null || !SymbolEqualityComparer.Default.Equals(receiverParameterType, receiver))
+                    {
+                        continue;
+                    }
+
+                    foreach (ISymbol member in nested.GetMembers(memberName))
+                    {
+                        if (!this.compilation.IsSymbolAccessibleWithin(member, this.compilation.Assembly))
+                        {
+                            continue;
+                        }
+
+                        if (SignatureMatches(member, normalizedMetadataParams))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+#else
+        // The Roslyn 4 symbol model has no IsExtension / ExtensionParameter API. The feature is gated to
+        // Roslyn 5; on this leg the option itself is rejected via PInvoke013 in SourceGenerator.Execute.
+        _ = memberName;
+        _ = parameterTypeNames;
+        return false;
+#endif
+    }
+
+#if ROSLYN5
+#pragma warning disable SA1201 // Keep dedup helpers (display format + signature/name normalization) co-located.
+    private static readonly SymbolDisplayFormat ParameterTypeDisplayFormat = new SymbolDisplayFormat(
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes | SymbolDisplayMiscellaneousOptions.ExpandNullable);
+#pragma warning restore SA1201
+
+    /// <summary>
+    /// Tests whether the given Roslyn member's signature matches the metadata-side parameter type names.
+    /// For fields / properties / parameterless accessors, expects an empty <paramref name="normalizedMetadataParams"/> array.
+    /// </summary>
+    private static bool SignatureMatches(ISymbol member, string[] normalizedMetadataParams)
+    {
+        ImmutableArray<IParameterSymbol> parameters;
+        switch (member)
+        {
+            case IMethodSymbol method:
+                parameters = method.Parameters;
+                break;
+            case IPropertySymbol property:
+                parameters = property.Parameters;
+                break;
+            case IFieldSymbol:
+                return normalizedMetadataParams.Length == 0;
+            default:
+                return false;
+        }
+
+        if (parameters.Length != normalizedMetadataParams.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            string symbolTypeName = NormalizeParameterTypeName(parameters[i].Type.ToDisplayString(ParameterTypeDisplayFormat));
+            if (!string.Equals(symbolTypeName, normalizedMetadataParams[i], StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Normalizes a parameter type's textual form for cross-source comparison: strips a <c>global::</c>
+    /// prefix, drops leading namespace segments (so <c>Windows.Win32.Foundation.HANDLE</c> and <c>HANDLE</c>
+    /// compare equal), and removes whitespace from any trailing pointer/array shape.
+    /// </summary>
+    /// <remarks>
+    /// This is a textual heuristic, not a semantic comparison. It deliberately does not attempt to handle
+    /// generics, alias projections (e.g. <c>BYTE</c> ↔ <c>byte</c>) where the two sides project to different
+    /// names, or differences in <c>ref</c>/<c>out</c>/<c>in</c> modifiers. The CsWin32 projection that drives
+    /// the metadata side already normalizes primitive types to their C# keyword form, which the
+    /// <see cref="ParameterTypeDisplayFormat"/> also produces for the symbol side, so this textual match is
+    /// sufficient for the common multi-assembly-composition case.
+    /// </remarks>
+    private static string NormalizeParameterTypeName(string text)
+    {
+        // Strip a leading global:: prefix.
+        const string GlobalPrefix = "global::";
+        if (text.StartsWith(GlobalPrefix, StringComparison.Ordinal))
+        {
+            text = text.Substring(GlobalPrefix.Length);
+        }
+
+        // Separate the trailing pointer/array shape (and any whitespace) from the named type portion.
+        int suffixStart = text.Length;
+        while (suffixStart > 0 && (text[suffixStart - 1] == '*' || text[suffixStart - 1] == ']' || text[suffixStart - 1] == '[' || char.IsWhiteSpace(text[suffixStart - 1])))
+        {
+            suffixStart--;
+        }
+
+        string namePath = text.Substring(0, suffixStart);
+        string suffix = text.Substring(suffixStart);
+
+        // Drop all leading namespace segments — keep only the last dot-separated identifier.
+        int lastDot = namePath.LastIndexOf('.');
+        if (lastDot >= 0)
+        {
+            namePath = namePath.Substring(lastDot + 1);
+        }
+
+        // Strip whitespace inside the suffix so `byte *` and `byte*` compare equal.
+        if (suffix.Length > 0)
+        {
+            System.Text.StringBuilder sb = new(suffix.Length);
+            foreach (char c in suffix)
+            {
+                if (!char.IsWhiteSpace(c))
+                {
+                    sb.Append(c);
+                }
+            }
+
+            suffix = sb.ToString();
+        }
+
+        return namePath + suffix;
+    }
+#endif
+
+    private static INamespaceSymbol? ResolveNamespaceIn(IAssemblySymbol assembly, INamespaceSymbol templateNamespace)
+    {
+        // Walk the namespace chain from the template (e.g. Windows.Win32) and look up each segment in the target assembly.
+        var segments = new Stack<string>();
+        for (INamespaceSymbol? n = templateNamespace; n is not null && !n.IsGlobalNamespace; n = n.ContainingNamespace)
+        {
+            segments.Push(n.Name);
+        }
+
+        INamespaceSymbol current = assembly.GlobalNamespace;
+        foreach (string segment in segments)
+        {
+            INamespaceSymbol? next = current.GetNamespaceMembers().FirstOrDefault(n => string.Equals(n.Name, segment, StringComparison.Ordinal));
+            if (next is null)
+            {
+                return null;
+            }
+
+            current = next;
+        }
+
+        return current;
+    }
+
+    private IEnumerable<IAssemblySymbol> EnumerateAccessibleAssemblies()
+    {
+        if (this.compilation is null)
+        {
+            yield break;
+        }
+
+        yield return this.compilation.Assembly;
+        foreach (MetadataReference reference in this.compilation.References)
+        {
+            if (!reference.Properties.Aliases.IsEmpty)
+            {
+                continue;
+            }
+
+            if (this.compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol referenced)
+            {
+                yield return referenced;
+            }
+        }
     }
 
     private MemberDeclarationSyntax? RequestInteropTypeHelper(TypeDefinitionHandle typeDefHandle, Context context)

--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -1506,6 +1506,13 @@ public partial class Generator : IGenerator, IDisposable
         if (!this.extensionReceiverSymbolResolved)
         {
             this.extensionReceiverSymbolResolved = true;
+
+            // The error reason is intentionally discarded here. This accessor feeds the per-generator
+            // no-op paths (WrapAsExtensionMembers / IsExtensionMemberAlreadyOnReceiver) where an
+            // unresolved receiver simply means "this generator doesn't own the receiver" (common when
+            // SuperGenerator runs several generators side by side). The user-facing PInvoke011 diagnostic
+            // is raised once in SourceGenerator.Execute, and only when NO generator can resolve the
+            // receiver, so reporting the reason here would produce duplicate or false diagnostics.
             this.TryResolveExtensionReceiver(out this.extensionReceiverSymbolCache, out _);
         }
 
@@ -1513,13 +1520,28 @@ public partial class Generator : IGenerator, IDisposable
     }
 
     /// <summary>
-    /// Tests whether the configured extension receiver type already exposes an accessible member with a matching signature (name + parameter count + per-parameter type name) as an extension member, across the compilation and any referenced assemblies. Supports multi-assembly composition of CsWin32 outputs. Always returns <see langword="false"/> on the Roslyn 4 leg of the analyzer (which lacks the extension-symbol API).
+    /// Identifies the kind of member being probed for by <see cref="IsExtensionMemberAlreadyOnReceiver"/>, so a constant and a same-named parameterless method cannot falsely suppress one another across composed assemblies.
+    /// </summary>
+#pragma warning disable SA1201 // Keep the discriminator next to the dedup helper that consumes it.
+    internal enum ReceiverMemberKind
+#pragma warning restore SA1201
+    {
+        /// <summary>A method member (a generated extern P/Invoke). Matches only methods on the receiver.</summary>
+        Method,
+
+        /// <summary>A value member (a generated constant). Matches only fields and parameterless properties on the receiver.</summary>
+        Value,
+    }
+
+    /// <summary>
+    /// Tests whether the configured extension receiver type already exposes an accessible member with a matching signature (name + member kind + parameter count + per-parameter type name) as an extension member, across the compilation and any referenced assemblies. Supports multi-assembly composition of CsWin32 outputs. Always returns <see langword="false"/> on the Roslyn 4 leg of the analyzer (which lacks the extension-symbol API).
     /// </summary>
     /// <param name="memberName">The simple member name to look for.</param>
-    /// <param name="parameterTypeNames">The CsWin32-projected textual form of each parameter type, in declaration order. Pass an empty array when probing for a field/property/parameterless member (e.g. a constant). The strings are compared after a normalization that strips <c>global::</c> prefixes and leading namespace segments, so callers may pass fully-qualified names produced by <c>ToTypeSyntax(...)</c>.</param>
+    /// <param name="parameterTypeNames">The CsWin32-projected textual form of each parameter type, in declaration order. Pass an empty array when probing for a value member (e.g. a constant). The strings are compared after a normalization that strips <c>global::</c> prefixes and leading namespace segments, so callers may pass fully-qualified names produced by <c>ToTypeSyntax(...)</c>.</param>
+    /// <param name="memberKind">The kind of member being probed for. A constant probes as <see cref="ReceiverMemberKind.Value"/> (matches fields and parameterless properties); an extern method probes as <see cref="ReceiverMemberKind.Method"/> (matches methods only). This prevents a constant in one assembly from being falsely suppressed by a parameterless method of the same name in another, and vice versa.</param>
     /// <returns><see langword="true"/> if a matching extension member is already declared on the receiver in scope; <see langword="false"/> otherwise (including when no extension receiver is configured or running on the Roslyn 4 leg).</returns>
 #pragma warning disable SA1202 // Keep dedup helper next to TryResolveExtensionReceiver / receiver-related code.
-    internal bool IsExtensionMemberAlreadyOnReceiver(string memberName, IReadOnlyList<string> parameterTypeNames)
+    internal bool IsExtensionMemberAlreadyOnReceiver(string memberName, IReadOnlyList<string> parameterTypeNames, ReceiverMemberKind memberKind)
 #pragma warning restore SA1202
     {
 #if ROSLYN5
@@ -1587,7 +1609,7 @@ public partial class Generator : IGenerator, IDisposable
                             continue;
                         }
 
-                        if (SignatureMatches(member, normalizedMetadataParams))
+                        if (SignatureMatches(member, normalizedMetadataParams, memberKind))
                         {
                             return true;
                         }
@@ -1602,6 +1624,7 @@ public partial class Generator : IGenerator, IDisposable
         // Roslyn 5; on this leg the option itself is rejected via PInvoke013 in SourceGenerator.Execute.
         _ = memberName;
         _ = parameterTypeNames;
+        _ = memberKind;
         return false;
 #endif
     }
@@ -1615,22 +1638,35 @@ public partial class Generator : IGenerator, IDisposable
 #pragma warning restore SA1201
 
     /// <summary>
-    /// Tests whether the given Roslyn member's signature matches the metadata-side parameter type names.
-    /// For fields / properties / parameterless accessors, expects an empty <paramref name="normalizedMetadataParams"/> array.
+    /// Tests whether the given Roslyn member's signature matches the metadata-side parameter type names and the requested member kind.
+    /// For a <see cref="ReceiverMemberKind.Value"/> probe (a constant), matches a field or a parameterless property and expects an empty <paramref name="normalizedMetadataParams"/> array.
+    /// For a <see cref="ReceiverMemberKind.Method"/> probe, matches a method whose parameter types line up with <paramref name="normalizedMetadataParams"/>.
     /// </summary>
-    private static bool SignatureMatches(ISymbol member, string[] normalizedMetadataParams)
+    private static bool SignatureMatches(ISymbol member, string[] normalizedMetadataParams, ReceiverMemberKind memberKind)
     {
         ImmutableArray<IParameterSymbol> parameters;
         switch (member)
         {
             case IMethodSymbol method:
+                if (memberKind != ReceiverMemberKind.Method)
+                {
+                    // A constant must not be suppressed by a (parameterless) method of the same name.
+                    return false;
+                }
+
                 parameters = method.Parameters;
                 break;
             case IPropertySymbol property:
+                if (memberKind != ReceiverMemberKind.Value)
+                {
+                    // A method must not be suppressed by a property of the same name.
+                    return false;
+                }
+
                 parameters = property.Parameters;
                 break;
             case IFieldSymbol:
-                return normalizedMetadataParams.Length == 0;
+                return memberKind == ReceiverMemberKind.Value && normalizedMetadataParams.Length == 0;
             default:
                 return false;
         }

--- a/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
+++ b/src/Microsoft.Windows.CsWin32/GeneratorOptions.cs
@@ -20,6 +20,20 @@ public record GeneratorOptions
     public string ClassName { get; set; } = "PInvoke";
 
     /// <summary>
+    /// Gets or sets the simple (unqualified) name of a CsWin32-generated static class in the same namespace whose members the generated APIs should appear as C# 14 extension members of.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set, the generated <see cref="ClassName"/> class wraps its p/invoke methods, friendly overloads, macros and helper methods in an <c>extension (Receiver) { ... }</c> block so callers may discover them through the receiver type. Constants remain on the host class as <see langword="private"/> fields and are surfaced through generated <see langword="static"/> properties inside the extension block.
+    /// </para>
+    /// <para>
+    /// The receiver type must be another CsWin32-generated static class in the same namespace, visible to the consuming compilation (either <see langword="public"/> or via <c>[InternalsVisibleTo]</c>). Requires C# 14 (<c>LangVersion</c> 14 or later) and the Roslyn 5 leg of the analyzer; otherwise a diagnostic is reported.
+    /// </para>
+    /// </remarks>
+    /// <value>The default value is <see langword="null"/>, which means no extension block is generated.</value>
+    public string? ExtensionReceiver { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to emit a single source file as opposed to types spread across many files, 'null' indicates to use the recommended default for the environment.
     /// </summary>
     /// <value>The default value is <see langword="null" />.</value>
@@ -68,6 +82,14 @@ public record GeneratorOptions
         {
             throw new InvalidOperationException("The ClassName property must not be null or empty.");
         }
+
+        if (this.ExtensionReceiver is { } receiver && string.IsNullOrWhiteSpace(receiver))
+        {
+            throw new InvalidOperationException("The ExtensionReceiver property must not be empty or whitespace when set.");
+        }
+
+        // Note: ExtensionReceiver == ClassName (self-reference) is detected at generation time and surfaces as the
+        // PInvoke011 diagnostic, allowing the rest of generation to continue without the extension wrap.
     }
 
     /// <summary>

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
@@ -78,6 +78,29 @@
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
+  <!--
+    PER-LEG SUPPORT-ASSEMBLY VERSION OVERRIDES (Roslyn 5.0 leg ONLY).
+
+    The shared central versions in Directory.Packages.Analyzers.props are intentionally
+    pinned to the Roslyn 4.11 FLOOR values (System.Collections.Immutable 8.0.0,
+    System.Memory 4.5.5) so the floor leg ships assemblies that load cleanly in older
+    VS 2022 Update 14 / .NET 8 hosts (see issue #1555).
+
+    This Roslyn 5.0 leg, however, references Microsoft.CodeAnalysis.CSharp 5.0.0, which
+    transitively requires System.Collections.Immutable >= 9.0.0 and System.Memory >= 4.6.0.
+    Keeping the floor versions here produces NU1109 package-downgrade errors. Because the
+    Roslyn 5.0 leg only ever loads inside a newer host whose compiler already ships these
+    higher assembly versions, bumping them HERE (and only here) is safe.
+
+    Override locally via VersionOverride instead of raising the shared floor. If you add a
+    newer Roslyn version that pulls in additional higher support assemblies, add the
+    corresponding override below rather than editing the central props.
+  -->
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="9.0.0" />
+    <PackageReference Include="System.Memory" VersionOverride="4.6.0" PrivateAssets="none" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <PackageReference Include="System.Memory" PrivateAssets="none" />
   </ItemGroup>

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
@@ -4,7 +4,16 @@
     <IsPackable>true</IsPackable>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    
+
+    <!--
+      This project builds the Roslyn 5.0 leg of the analyzer (required to use C# 14
+      ExtensionBlockDeclarationSyntax for the `extensionReceiver` feature). A sibling
+      project Microsoft.Windows.CsWin32.Roslyn4 builds the Roslyn 4.11 floor leg that
+      omits the C# 14 feature and emits a diagnostic if requested.
+    -->
+    <CodeAnalysisVersionForAnalyzers>5.0.0</CodeAnalysisVersionForAnalyzers>
+    <DefineConstants>$(DefineConstants);ROSLYN5</DefineConstants>
+
     <!-- Special properties for analyzer packages. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
@@ -28,6 +37,22 @@
 
   <ItemGroup>
     <AdditionalFiles Include="BannedSymbols.txt" />
+  </ItemGroup>
+
+  <!--
+    Force the Roslyn 4 sibling leg to build (and restore) whenever this project builds so that the
+    nuspec can pack its output under `analyzers/dotnet/roslyn4.11/cs/`. We do NOT consume its
+    assembly as a reference (ReferenceOutputAssembly=false) — only the build trigger and the
+    output paths surfaced via $(Roslyn4BaseOutputPath) in the nuspec properties.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Windows.CsWin32.Roslyn4\Microsoft.Windows.CsWin32.Roslyn4.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      SetPlatform="Platform=AnyCPU"
+                      Private="false"
+                      IncludeAssets="none"
+                      ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -54,7 +79,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net472'">
-    <PackageReference Include="System.Memory" PrivateAssets="none" />    
+    <PackageReference Include="System.Memory" PrivateAssets="none" />
   </ItemGroup>
 
   <Import Project="$(MSBuildProjectName).targets" />

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.nuspec
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.nuspec
@@ -43,13 +43,32 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="$BaseOutputPath$Microsoft.Windows.SDK.Win32Docs.dll" target="analyzers\cs\Microsoft.Windows.SDK.Win32Docs.dll" />
-    <file src="$BaseOutputPath$Microsoft.Windows.CsWin32.dll" target="analyzers\cs\Microsoft.Windows.CsWin32.dll" />
-    <file src="$SignedOutputPath$MessagePack.dll" target="analyzers\cs\MessagePack.dll" />
-    <file src="$SignedOutputPath$MessagePack.Annotations.dll" target="analyzers\cs\MessagePack.Annotations.dll" />
-    <file src="$BaseOutputPath$Microsoft.Bcl.AsyncInterfaces.dll" target="analyzers\cs\Microsoft.Bcl.AsyncInterfaces.dll" />
-    <file src="$BaseOutputPath$System.Text.Json.dll" target="analyzers\cs\System.Text.Json.dll" />
-    <file src="$BaseOutputPath$System.Text.Encodings.Web.dll" target="analyzers\cs\System.Text.Encodings.Web.dll" />
+    <!-- ============================================================ -->
+    <!-- Roslyn 5.0 leg (built against Microsoft.CodeAnalysis.CSharp 5.0). -->
+    <!-- Loaded by hosts running Roslyn 5.0 or later (.NET 10 SDK / VS 17.next). -->
+    <!-- This leg enables the C# 14 `extensionReceiver` feature. -->
+    <!-- ============================================================ -->
+    <file src="$BaseOutputPath$Microsoft.Windows.SDK.Win32Docs.dll" target="analyzers\dotnet\roslyn5.0\cs\Microsoft.Windows.SDK.Win32Docs.dll" />
+    <file src="$BaseOutputPath$Microsoft.Windows.CsWin32.dll" target="analyzers\dotnet\roslyn5.0\cs\Microsoft.Windows.CsWin32.dll" />
+    <file src="$SignedOutputPath$MessagePack.dll" target="analyzers\dotnet\roslyn5.0\cs\MessagePack.dll" />
+    <file src="$SignedOutputPath$MessagePack.Annotations.dll" target="analyzers\dotnet\roslyn5.0\cs\MessagePack.Annotations.dll" />
+    <file src="$BaseOutputPath$Microsoft.Bcl.AsyncInterfaces.dll" target="analyzers\dotnet\roslyn5.0\cs\Microsoft.Bcl.AsyncInterfaces.dll" />
+    <file src="$BaseOutputPath$System.Text.Json.dll" target="analyzers\dotnet\roslyn5.0\cs\System.Text.Json.dll" />
+    <file src="$BaseOutputPath$System.Text.Encodings.Web.dll" target="analyzers\dotnet\roslyn5.0\cs\System.Text.Encodings.Web.dll" />
+
+    <!-- ============================================================ -->
+    <!-- Roslyn 4.11 leg (the floor — built against Microsoft.CodeAnalysis.CSharp 4.11.0). -->
+    <!-- Loaded by hosts on the Roslyn 4.11..&lt;5.0 range (VS 2022 Update 14 / .NET 8 SDK). -->
+    <!-- The `extensionReceiver` feature is rejected on this leg via diagnostic PInvoke013. -->
+    <!-- ============================================================ -->
+    <file src="$Roslyn4BaseOutputPath$Microsoft.Windows.SDK.Win32Docs.dll" target="analyzers\dotnet\roslyn4.11\cs\Microsoft.Windows.SDK.Win32Docs.dll" />
+    <file src="$Roslyn4BaseOutputPath$Microsoft.Windows.CsWin32.dll" target="analyzers\dotnet\roslyn4.11\cs\Microsoft.Windows.CsWin32.dll" />
+    <file src="$SignedOutputPath$MessagePack.dll" target="analyzers\dotnet\roslyn4.11\cs\MessagePack.dll" />
+    <file src="$SignedOutputPath$MessagePack.Annotations.dll" target="analyzers\dotnet\roslyn4.11\cs\MessagePack.Annotations.dll" />
+    <file src="$Roslyn4BaseOutputPath$Microsoft.Bcl.AsyncInterfaces.dll" target="analyzers\dotnet\roslyn4.11\cs\Microsoft.Bcl.AsyncInterfaces.dll" />
+    <file src="$Roslyn4BaseOutputPath$System.Text.Json.dll" target="analyzers\dotnet\roslyn4.11\cs\System.Text.Json.dll" />
+    <file src="$Roslyn4BaseOutputPath$System.Text.Encodings.Web.dll" target="analyzers\dotnet\roslyn4.11\cs\System.Text.Encodings.Web.dll" />
+
     <file src="$CsWin32GeneratorBasePath$**" target="build\tools\" exclude="**\*.exe;**\MessagePack*.dll" />
     <file src="$SignedOutputPath$MessagePack.dll" target="build\tools\" />
     <file src="$SignedOutputPath$MessagePack.Annotations.dll" target="build\tools\" />

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.targets
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.targets
@@ -10,10 +10,12 @@
     <PropertyGroup>
       <CsWin32GeneratorBasePath>$([MSBuild]::NormalizePath('$(BaseOutputPath)..\CsWin32Generator\$(Configuration)\$(CsWin32GeneratorTargetFramework)\'))</CsWin32GeneratorBasePath>
       <CsWin32GeneratorBuildTasksPath>$([MSBuild]::NormalizePath('$(BaseOutputPath)..\Microsoft.Windows.CsWin32.BuildTasks\$(Configuration)\netstandard2.0\'))</CsWin32GeneratorBuildTasksPath>
+      <Roslyn4BaseOutputPath>$([MSBuild]::NormalizePath('$(BaseOutputPath)..\Microsoft.Windows.CsWin32.Roslyn4\$(Configuration)\netstandard2.0'))\</Roslyn4BaseOutputPath>
       <NuspecProperties>
         $(NuspecProperties);
         Version=$(Version);
         BaseOutputPath=$(OutputPath);
+        Roslyn4BaseOutputPath=$(Roslyn4BaseOutputPath);
         MetadataVersion=$(MetadataVersion);
         WDKMetadataVersion=$(WDKMetadataVersion);
         ApiDocsVersion=$(ApiDocsVersion);
@@ -29,19 +31,19 @@
   <Target Name="PackBuildOutputs" DependsOnTargets="ResolveProjectReferences;SatelliteDllsProjectOutputGroup;SatelliteDllsProjectOutputGroupDependencies" Condition="$(TargetFramework)=='netstandard2.0'">
     <ItemGroup>
       <!-- Analysis of C# projects -->
-      <TfmSpecificPackageFile Include="$(TargetPath)" PackagePath="analyzers\cs\" />
-      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\cs\" Condition=" '%(FileName)%(Extension)' == 'MessagePack.dll' " Authenticode="3PartySHA2" />
-      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\cs\" Condition=" '%(FileName)%(Extension)' == 'MessagePack.Annotations.dll' " Authenticode="3PartySHA2" />
-      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\cs\" Condition=" '%(FileName)%(Extension)' == 'Microsoft.Bcl.AsyncInterfaces.dll' " />
-      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Text.Json.dll' " />
-      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Text.Encodings.Web.dll' " />
-      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Numerics.Vectors.dll' " />
-      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Threading.Tasks.Extensions.dll' " />
-      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Memory.dll' " />
-      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Buffers.dll' " />
-      <TfmSpecificPackageFile Include="@(SatelliteDllsProjectOutputGroupDependency)" PackagePath="analyzers\cs\%(SatelliteDllsProjectOutputGroupDependency.DestinationSubDirectory)" Condition=" '%(SatelliteDllsProjectOutputGroupDependency.DestinationSubDirectory)' != '' " />
-      <TfmSpecificPackageFile Include="@(SatelliteDllsProjectOutputGroupOutput->'%(FinalOutputPath)')" PackagePath="analyzers\cs\%(SatelliteDllsProjectOutputGroupOutput.Culture)\" />
-      <TfmSpecificPackageFile Include="%(_ResolvedProjectReferencePaths.Identity)" PackagePath="analyzers\cs\" />
+      <TfmSpecificPackageFile Include="$(TargetPath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" />
+      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" Condition=" '%(FileName)%(Extension)' == 'MessagePack.dll' " Authenticode="3PartySHA2" />
+      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" Condition=" '%(FileName)%(Extension)' == 'MessagePack.Annotations.dll' " Authenticode="3PartySHA2" />
+      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" Condition=" '%(FileName)%(Extension)' == 'Microsoft.Bcl.AsyncInterfaces.dll' " />
+      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Text.Json.dll' " />
+      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Text.Encodings.Web.dll' " />
+      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Numerics.Vectors.dll' " />
+      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Threading.Tasks.Extensions.dll' " />
+      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Memory.dll' " />
+      <TfmSpecificPackageFile Include="@(ReferencePath)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" Condition=" '%(FileName)%(Extension)' == 'System.Buffers.dll' " />
+      <TfmSpecificPackageFile Include="@(SatelliteDllsProjectOutputGroupDependency)" PackagePath="analyzers\dotnet\roslyn5.0\cs\%(SatelliteDllsProjectOutputGroupDependency.DestinationSubDirectory)" Condition=" '%(SatelliteDllsProjectOutputGroupDependency.DestinationSubDirectory)' != '' " />
+      <TfmSpecificPackageFile Include="@(SatelliteDllsProjectOutputGroupOutput->'%(FinalOutputPath)')" PackagePath="analyzers\dotnet\roslyn5.0\cs\%(SatelliteDllsProjectOutputGroupOutput.Culture)\" />
+      <TfmSpecificPackageFile Include="%(_ResolvedProjectReferencePaths.Identity)" PackagePath="analyzers\dotnet\roslyn5.0\cs\" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
+++ b/src/Microsoft.Windows.CsWin32/SourceGenerator.cs
@@ -143,6 +143,31 @@ public partial class SourceGenerator : ISourceGenerator
         "Configuration",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor ExtensionReceiverInvalid = new(
+        "PInvoke011",
+        "Invalid ExtensionReceiver",
+        "The configured ExtensionReceiver \"{0}\" is invalid: {1}",
+        "Configuration",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "ExtensionReceiver must name a static class in the same namespace as the generated host class, must not equal ClassName, and must be accessible to the consuming compilation.");
+
+    public static readonly DiagnosticDescriptor ExtensionReceiverRequiresCSharp14 = new(
+        "PInvoke012",
+        "ExtensionReceiver requires C# 14",
+        "ExtensionReceiver was set to \"{0}\" but the consuming compilation is using C# {1}. C# 14 (LangVersion 14 or later) is required.",
+        "Configuration",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor ExtensionReceiverRequiresRoslyn5 = new(
+        "PInvoke013",
+        "ExtensionReceiver requires Roslyn 5 analyzer",
+        "ExtensionReceiver was set to \"{0}\" but the loaded CsWin32 analyzer was built against Roslyn 4 which does not support extension blocks. Upgrade the host (e.g. VS / .NET SDK) so a Roslyn 5+ analyzer is loaded.",
+        "Configuration",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     private const string InputProjectionErrorId = "PInvoke010";
@@ -230,6 +255,66 @@ public partial class SourceGenerator : ISourceGenerator
         {
             context.ReportDiagnostic(Diagnostic.Create(NonUniqueMetadataInputs, null, nonUniqueGenerator.Value));
             return;
+        }
+
+        // Validate the ExtensionReceiver option (if set). On the Roslyn 5 leg, validation runs per-Generator:
+        // if a generator's namespace doesn't contain the receiver type, the wrap is silently disabled for
+        // *that* generator only (each generator caches its own resolution and gates WrapAsExtensionMembers
+        // accordingly) — but a diagnostic still surfaces if NO generator can resolve the receiver. This
+        // supports multi-namespace pipelines (e.g. Windows.Win32 + Windows.Wdk) where the receiver only
+        // exists in one of them. Per the "refuse, don't fall back silently" decision, the diagnostic is
+        // emitted in error cases; the option is cleared only on global failures (LangVersion / Roslyn 4 leg).
+        if (options.ExtensionReceiver is string requestedReceiver)
+        {
+#if !ROSLYN5
+            // The Roslyn 4 leg lacks the API surface needed to emit C# 14 extension blocks. Tell the
+            // user to upgrade the host (VS / SDK) so that the Roslyn 5 leg of the analyzer loads instead.
+            context.ReportDiagnostic(Diagnostic.Create(ExtensionReceiverRequiresRoslyn5, location: null, requestedReceiver));
+            options.ExtensionReceiver = null;
+#else
+            LanguageVersion langVersion = parseOptions.LanguageVersion == LanguageVersion.Default
+                ? LanguageVersion.Default.MapSpecifiedToEffectiveVersion()
+                : parseOptions.LanguageVersion;
+            if (langVersion < LanguageVersion.CSharp14 && langVersion != LanguageVersion.Preview && langVersion != LanguageVersion.Latest && langVersion != LanguageVersion.LatestMajor)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(ExtensionReceiverRequiresCSharp14, location: null, requestedReceiver, langVersion.ToDisplayString()));
+                options.ExtensionReceiver = null;
+            }
+            else
+            {
+                int resolvedCount = 0;
+                List<string> failureReasons = new();
+                foreach (Generator generator in generators)
+                {
+                    if (generator.TryResolveExtensionReceiver(out _, out string? errorReason))
+                    {
+                        resolvedCount++;
+                    }
+                    else if (errorReason is not null)
+                    {
+                        failureReasons.Add(errorReason);
+                    }
+                }
+
+                // Multi-namespace pipelines (e.g. Windows.Win32 + Windows.Wdk) commonly resolve the receiver
+                // in only one namespace. Suppress per-generator failure diagnostics when at least one
+                // generator was able to wrap — the user has a working setup and shouldn't be pestered.
+                // Each unresolved generator's WrapAsExtensionMembers is already a no-op for its own emit.
+                if (resolvedCount == 0 && failureReasons.Count > 0)
+                {
+                    HashSet<string> reported = new(StringComparer.Ordinal);
+                    foreach (string reason in failureReasons)
+                    {
+                        if (reported.Add(reason))
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(ExtensionReceiverInvalid, location: null, requestedReceiver, reason));
+                        }
+                    }
+
+                    options.ExtensionReceiver = null;
+                }
+            }
+#endif
         }
 
         using SuperGenerator superGenerator = SuperGenerator.Combine(generators);

--- a/src/Microsoft.Windows.CsWin32/settings.schema.json
+++ b/src/Microsoft.Windows.CsWin32/settings.schema.json
@@ -84,6 +84,11 @@
       "default": "PInvoke",
       "pattern": "^\\w+$"
     },
+    "extensionReceiver": {
+      "description": "The simple (unqualified) name of a CsWin32-generated static class in the same namespace whose members the generated APIs should appear as C# 14 extension members of. When set, the host className class wraps its p/invoke methods, friendly overloads, macros and helper methods in an `extension (Receiver) { ... }` block; constants are stored as private fields on the host class and surfaced through static properties inside the extension block. Requires C# 14 (LangVersion 14+).",
+      "type": "string",
+      "pattern": "^\\w+$"
+    },
     "public": {
       "description": "A value indicating whether to expose the generated APIs publicly (as opposed to internally).",
       "type": "boolean",

--- a/test/Microsoft.Windows.CsWin32.Tests/ExtensionReceiverTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/ExtensionReceiverTests.cs
@@ -1,0 +1,539 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/// <summary>
+/// Tests for <see cref="GeneratorOptions.ExtensionReceiver"/> — wraps the generated host static class members
+/// in a C# 14 <c>extension (Receiver) { ... }</c> block and routes constants through a private backing field
+/// plus a public forwarder property inside the extension block.
+/// </summary>
+public class ExtensionReceiverTests : GeneratorTestBase
+{
+    private const string ReceiverName = "PInvoke";
+    private const string HostClassName = "WinFormsPInvokes";
+    private const string Win32MetadataAssemblyName = "Windows.Win32";
+
+    public ExtensionReceiverTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        // C# 14 is required to recognize the `extension (T) { ... }` block syntax that the generator emits.
+        // The base test harness re-parses generated source through `this.parseOptions`, so without this bump
+        // the emitted ExtensionBlockDeclarationSyntax nodes would be lost during re-parsing.
+        this.parseOptions = this.parseOptions.WithLanguageVersion(LanguageVersion.CSharp14);
+    }
+
+    /// <summary>
+    /// Baseline: when the option is not set, generated output is unchanged — no <c>extension (</c> appears anywhere,
+    /// and constants remain as plain public/internal fields directly on the host class.
+    /// </summary>
+    [Fact]
+    public void OptionUnset_NoExtensionBlockAndConstantsRemainAsPublicFields()
+    {
+        this.generator = this.CreateGenerator(new GeneratorOptions { EmitSingleFile = true });
+        Assert.True(this.generator.TryGenerate("GetTickCount", TestContext.Current.CancellationToken));
+        Assert.True(this.generator.TryGenerate("WM_NULL", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        foreach (SyntaxTree tree in this.compilation.SyntaxTrees)
+        {
+            string text = tree.GetText(TestContext.Current.CancellationToken).ToString();
+            Assert.DoesNotContain("extension (", text);
+        }
+
+        // The constant should be a directly-declared field on PInvoke (the default host class name).
+        FieldDeclarationSyntax wmNull = Assert.Single(this.FindGeneratedConstant("WM_NULL"));
+        Assert.DoesNotContain(wmNull.Modifiers, m => m.IsKind(SyntaxKind.PrivateKeyword));
+    }
+
+    /// <summary>
+    /// When set, per-module extern members and friendly overloads are wrapped in a single
+    /// <c>extension (Receiver)</c> block inside the host static class.
+    /// </summary>
+    [Fact]
+    public void Option_WrapsExternMethodsInExtensionBlock()
+    {
+        this.compilation = this.AddCode(
+            $"namespace Windows.Win32 {{ internal static class {ReceiverName} {{ }} }}",
+            fileName: "ReceiverStub.cs");
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("GetTickCount", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        List<ClassDeclarationSyntax> hostClasses = this.FindGeneratedType(HostClassName).OfType<ClassDeclarationSyntax>().ToList();
+        ClassDeclarationSyntax host = Assert.Single(hostClasses, c => c.Members.OfType<ExtensionBlockDeclarationSyntax>().Any());
+        ExtensionBlockDeclarationSyntax extBlock = Assert.Single(host.Members.OfType<ExtensionBlockDeclarationSyntax>());
+
+        Assert.Equal($"global::Windows.Win32.{ReceiverName}", ReceiverTypeName(extBlock));
+
+        // The extern method should live inside the extension block, not directly on the host class.
+        Assert.DoesNotContain(host.Members.OfType<MethodDeclarationSyntax>(), m => m.Identifier.ValueText == "GetTickCount");
+        Assert.Contains(extBlock.Members.OfType<MethodDeclarationSyntax>(), m => m.Identifier.ValueText == "GetTickCount");
+    }
+
+    /// <summary>
+    /// Constants must remain as <c>private</c> fields on the host class (C# 14 extension blocks do not allow fields)
+    /// while a public/internal forwarder property is generated inside the extension block.
+    /// </summary>
+    [Fact]
+    public void Option_ConstantsAreForwardedViaExtensionProperty()
+    {
+        this.compilation = this.AddCode(
+            $"namespace Windows.Win32 {{ internal static class {ReceiverName} {{ }} }}",
+            fileName: "ReceiverStub.cs");
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("WM_NULL", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        ClassDeclarationSyntax constantHost = SingleHostClass(this.FindGeneratedType(HostClassName));
+
+        // The backing field must still be present on the host class with its original visibility preserved
+        // (NOT privatized): this preserves the use of `<HostClass>.<Name>` in C# constant contexts such as
+        // enum initializers, attribute arguments, and `fixed`-array sizes. The forwarder property added in
+        // the extension block additionally surfaces it through the receiver type for runtime contexts.
+        FieldDeclarationSyntax backingField = Assert.Single(
+            constantHost.Members.OfType<FieldDeclarationSyntax>(),
+            f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == "WM_NULL"));
+        Assert.DoesNotContain(backingField.Modifiers, m => m.IsKind(SyntaxKind.PrivateKeyword));
+        Assert.Contains(backingField.Modifiers, m => m.IsKind(SyntaxKind.ConstKeyword) || m.IsKind(SyntaxKind.ReadOnlyKeyword));
+
+        // A forwarder property of the same name must live inside the extension block.
+        ExtensionBlockDeclarationSyntax extBlock = Assert.Single(constantHost.Members.OfType<ExtensionBlockDeclarationSyntax>());
+        PropertyDeclarationSyntax property = Assert.Single(
+            extBlock.Members.OfType<PropertyDeclarationSyntax>(),
+            p => p.Identifier.ValueText == "WM_NULL");
+        Assert.Contains(property.Modifiers, m => m.IsKind(SyntaxKind.StaticKeyword));
+
+        // The body should forward to the host class's backing field: => WinFormsPInvokes.WM_NULL
+        Assert.NotNull(property.ExpressionBody);
+        string bodyText = property.ExpressionBody!.Expression.ToString();
+        Assert.Contains(HostClassName, bodyText);
+        Assert.Contains("WM_NULL", bodyText);
+    }
+
+    /// <summary>
+    /// In multi-file mode every non-empty partial of the host class carries its own extension block.
+    /// </summary>
+    [Fact]
+    public void Option_MultiFile_EveryPartialWraps()
+    {
+        this.compilation = this.AddCode(
+            $"namespace Windows.Win32 {{ internal static class {ReceiverName} {{ }} }}",
+            fileName: "ReceiverStub.cs");
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = false,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+
+        // Two methods from different modules (kernel32 + advapi32) to force multiple partials.
+        Assert.True(this.generator.TryGenerate("GetTickCount", TestContext.Current.CancellationToken));
+        Assert.True(this.generator.TryGenerate("RegOpenKeyExW", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        List<ClassDeclarationSyntax> partials = this.FindGeneratedType(HostClassName).OfType<ClassDeclarationSyntax>()
+            .Where(c => c.Members.OfType<ExtensionBlockDeclarationSyntax>().Any())
+            .ToList();
+        Assert.True(partials.Count >= 2, $"Expected at least 2 partials with extension blocks; saw {partials.Count}.");
+        foreach (ClassDeclarationSyntax partial in partials)
+        {
+            Assert.Single(partial.Members.OfType<ExtensionBlockDeclarationSyntax>());
+        }
+    }
+
+    /// <summary>
+    /// End-to-end: generated output compiles cleanly under C# 14 with the receiver type stubbed in the same namespace.
+    /// </summary>
+    [Fact]
+    public void Option_GeneratedCodeCompilesUnderCSharp14()
+    {
+        // Switch the compilation to .NET 10 (so its references support modern APIs) and parse options to C# 14.
+        this.compilation = this.starterCompilations["net10.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(LanguageVersion.CSharp14);
+
+        // The receiver must already exist in the consuming compilation under the same namespace.
+        // Non-partial since `FindTypeSymbolsIfAlreadyAvailable` excludes same-assembly partial declarations.
+        this.compilation = this.AddCode(
+            $"namespace Windows.Win32 {{ internal static class {ReceiverName} {{ }} }}",
+            fileName: "ReceiverStub.cs");
+
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("GetTickCount", TestContext.Current.CancellationToken));
+        Assert.True(this.generator.TryGenerate("WM_NULL", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+    }
+
+    [Fact]
+    public void TryResolveExtensionReceiver_NoOption_ReturnsFalseWithNoError()
+    {
+        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions);
+        Generator inner = Assert.IsType<Generator>(((SuperGenerator)this.generator).Generators[Win32MetadataAssemblyName]);
+        Assert.False(inner.TryResolveExtensionReceiver(out INamedTypeSymbol? symbol, out string? reason));
+        Assert.Null(symbol);
+        Assert.Null(reason);
+    }
+
+    [Fact]
+    public void TryResolveExtensionReceiver_SelfReference_Fails()
+    {
+        // ExtensionReceiver equals ClassName.
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            ClassName = ReceiverName,
+            ExtensionReceiver = ReceiverName,
+            EmitSingleFile = true,
+        });
+        Generator inner = Assert.IsType<Generator>(((SuperGenerator)this.generator).Generators[Win32MetadataAssemblyName]);
+        Assert.False(inner.TryResolveExtensionReceiver(out INamedTypeSymbol? symbol, out string? reason));
+        Assert.Null(symbol);
+        Assert.NotNull(reason);
+        Assert.Contains("ClassName", reason);
+    }
+
+    [Fact]
+    public void TryResolveExtensionReceiver_Unresolved_Fails()
+    {
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            ClassName = HostClassName,
+            ExtensionReceiver = "NonExistentReceiverType",
+            EmitSingleFile = true,
+        });
+        Generator inner = Assert.IsType<Generator>(((SuperGenerator)this.generator).Generators[Win32MetadataAssemblyName]);
+        Assert.False(inner.TryResolveExtensionReceiver(out INamedTypeSymbol? symbol, out string? reason));
+        Assert.Null(symbol);
+        Assert.NotNull(reason);
+        Assert.Contains("not found", reason);
+    }
+
+    [Fact]
+    public void TryResolveExtensionReceiver_NonStaticType_Fails()
+    {
+        // Add a non-static class with the receiver name in the target namespace.
+        this.compilation = this.AddCode(
+            $"namespace Windows.Win32 {{ internal class {ReceiverName} {{ }} }}",
+            fileName: "NonStaticReceiver.cs");
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+            EmitSingleFile = true,
+        });
+        Generator inner = Assert.IsType<Generator>(((SuperGenerator)this.generator).Generators[Win32MetadataAssemblyName]);
+        Assert.False(inner.TryResolveExtensionReceiver(out _, out string? reason));
+        Assert.NotNull(reason);
+        Assert.Contains("static class", reason);
+    }
+
+    [Fact]
+    public void TryResolveExtensionReceiver_ValidStaticClass_Succeeds()
+    {
+        // Use a non-partial stub: FindTypeSymbolsIfAlreadyAvailable explicitly excludes same-assembly partial types
+        // (in real consumers the receiver lives in a referenced assembly, never partial in the consumer's own).
+        this.compilation = this.AddCode(
+            $"namespace Windows.Win32 {{ internal static class {ReceiverName} {{ }} }}",
+            fileName: "ReceiverStub.cs");
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+            EmitSingleFile = true,
+        });
+        Generator inner = Assert.IsType<Generator>(((SuperGenerator)this.generator).Generators[Win32MetadataAssemblyName]);
+        Assert.True(inner.TryResolveExtensionReceiver(out INamedTypeSymbol? symbol, out string? reason));
+        Assert.NotNull(symbol);
+        Assert.Null(reason);
+        Assert.Equal(ReceiverName, symbol.Name);
+        Assert.True(symbol.IsStatic);
+    }
+
+    /// <summary>
+    /// Multi-assembly composition: when the receiver type already has an extension method of the same name
+    /// (typically declared by another CsWin32-emitted host class in a referenced assembly), the generator
+    /// must skip regeneration so the consuming compilation sees only one definition.
+    /// </summary>
+    [Fact]
+    public void Dedup_ExternMethodAlreadyOnReceiver_NotRegenerated()
+    {
+        // Simulate a "lower" CsWin32 layer that already published GetTickCount as an extension member on PInvoke.
+        this.compilation = this.AddCode(
+            $@"namespace Windows.Win32
+{{
+    internal static class {ReceiverName} {{ }}
+    internal static class CoreLayerPInvokes
+    {{
+        extension ({ReceiverName})
+        {{
+            public static uint GetTickCount() => 0;
+        }}
+    }}
+}}",
+            fileName: "ExistingLayer.cs");
+
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("GetTickCount", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        // The generator should NOT have regenerated GetTickCount under the new host class.
+        IEnumerable<MethodDeclarationSyntax> hostMethods = this.FindGeneratedType(HostClassName)
+            .OfType<ClassDeclarationSyntax>()
+            .SelectMany(c => c.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            .Where(m => m.Identifier.ValueText == "GetTickCount");
+        Assert.Empty(hostMethods);
+    }
+
+    /// <summary>
+    /// Multi-assembly composition: a constant already exposed as an extension member on the receiver is not
+    /// re-emitted (neither the private backing field nor the forwarder property).
+    /// </summary>
+    [Fact]
+    public void Dedup_ConstantAlreadyOnReceiver_NotRegenerated()
+    {
+        this.compilation = this.AddCode(
+            $@"namespace Windows.Win32
+{{
+    internal static class {ReceiverName} {{ }}
+    internal static class CoreLayerConstants
+    {{
+        extension ({ReceiverName})
+        {{
+            public static uint WM_NULL => 0u;
+        }}
+    }}
+}}",
+            fileName: "ExistingConstants.cs");
+
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("WM_NULL", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        // Neither the private backing field nor the extension forwarder property should be emitted under HostClassName.
+        IEnumerable<FieldDeclarationSyntax> hostFields = this.FindGeneratedType(HostClassName)
+            .OfType<ClassDeclarationSyntax>()
+            .SelectMany(c => c.DescendantNodes().OfType<FieldDeclarationSyntax>())
+            .Where(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == "WM_NULL"));
+        Assert.Empty(hostFields);
+
+        IEnumerable<PropertyDeclarationSyntax> hostProperties = this.FindGeneratedType(HostClassName)
+            .OfType<ClassDeclarationSyntax>()
+            .SelectMany(c => c.DescendantNodes().OfType<PropertyDeclarationSyntax>())
+            .Where(p => p.Identifier.ValueText == "WM_NULL");
+        Assert.Empty(hostProperties);
+    }
+
+    /// <summary>
+    /// A different name (not pre-existing on the receiver) is still emitted normally.
+    /// </summary>
+    [Fact]
+    public void Dedup_DifferentName_StillEmitted()
+    {
+        this.compilation = this.AddCode(
+            $@"namespace Windows.Win32
+{{
+    internal static class {ReceiverName} {{ }}
+    internal static class CoreLayerPInvokes
+    {{
+        extension ({ReceiverName})
+        {{
+            public static uint SomeUnrelated() => 0;
+        }}
+    }}
+}}",
+            fileName: "ExistingLayer.cs");
+
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("GetTickCount", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        IEnumerable<MethodDeclarationSyntax> hostMethods = this.FindGeneratedType(HostClassName)
+            .OfType<ClassDeclarationSyntax>()
+            .SelectMany(c => c.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            .Where(m => m.Identifier.ValueText == "GetTickCount");
+        Assert.NotEmpty(hostMethods);
+    }
+
+    /// <summary>
+    /// Regression for WinForms-vet §1.1: name-only dedup is unsafe. A user-authored helper wrapper with
+    /// the same simple name but a different parameter count must NOT cause the raw P/Invoke to be skipped,
+    /// otherwise the helper silently recurses into itself at runtime. The dedup must match name + arity.
+    /// </summary>
+    [Fact]
+    public void Dedup_SameNameDifferentArity_StillEmitsExtern()
+    {
+        // The user pre-declares a 2-arg helper on the receiver. The metadata GetTickCount() has 0 args.
+        // The previous name-only dedup would skip the extern; the arity-aware dedup must NOT.
+        this.compilation = this.AddCode(
+            $@"namespace Windows.Win32
+{{
+    internal static class {ReceiverName} {{ }}
+    internal static class CoreLayerPInvokes
+    {{
+        extension ({ReceiverName})
+        {{
+            // Same simple name as the raw P/Invoke but different arity (2 args vs 0).
+            public static uint GetTickCount(int unused1, int unused2) => 0u;
+        }}
+    }}
+}}",
+            fileName: "ExistingLayer.cs");
+
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("GetTickCount", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        // The raw 0-arg extern must still be emitted (inside the extension block).
+        IEnumerable<MethodDeclarationSyntax> hostMethods = this.FindGeneratedType(HostClassName)
+            .OfType<ClassDeclarationSyntax>()
+            .SelectMany(c => c.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            .Where(m => m.Identifier.ValueText == "GetTickCount" && m.ParameterList.Parameters.Count == 0);
+        Assert.NotEmpty(hostMethods);
+    }
+
+    /// <summary>
+    /// Full signature dedup (name + arity + per-parameter type names): a user-authored helper that matches
+    /// the metadata signature's name and parameter count but with a different parameter type must NOT
+    /// be treated as a duplicate. Both signatures are valid overloads and both should be emitted.
+    /// </summary>
+    [Fact]
+    public void Dedup_SameNameSameArityDifferentParamType_StillEmitsExtern()
+    {
+        // IsWindow(HWND) is a 1-arg metadata signature. The user stubs a same-arity helper but with
+        // a wholly different parameter type (`int`). Full-signature dedup must not match these.
+        this.compilation = this.AddCode(
+            $@"namespace Windows.Win32
+{{
+    internal static class {ReceiverName} {{ }}
+    internal static class CoreLayerPInvokes
+    {{
+        extension ({ReceiverName})
+        {{
+            // Same name + same arity as the raw P/Invoke (1 param) but the param type differs.
+            public static bool IsWindow(int unused) => false;
+        }}
+    }}
+}}",
+            fileName: "ExistingLayer.cs");
+
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("IsWindow", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        // The raw IsWindow(HWND) must still be emitted because the user's same-arity helper has a
+        // different parameter type signature (it's a distinct overload, not a dedup).
+        IEnumerable<MethodDeclarationSyntax> hostMethods = this.FindGeneratedType(HostClassName)
+            .OfType<ClassDeclarationSyntax>()
+            .SelectMany(c => c.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            .Where(m => m.Identifier.ValueText == "IsWindow");
+        Assert.NotEmpty(hostMethods);
+    }
+
+    /// <summary>
+    /// Regression for the WinForms-vet second-round case: a user-authored *generic* helper wrapper of the
+    /// same simple name with a type-parameter argument must not be treated as a dedup of the raw P/Invoke
+    /// even though the wrapper has the same arity as the metadata signature. Specifically mirrors the
+    /// WinForms <c>DrawMenuBar&lt;T&gt;(T hWnd) where T : IHandle&lt;HWND&gt;</c> idiom that previously
+    /// caused silent self-recursion at runtime.
+    /// </summary>
+    [Fact]
+    public void Dedup_SameNameGenericUserWrapper_StillEmitsExtern()
+    {
+        // Mirror the WinForms idiom exactly: a generic helper with a constraint that includes the
+        // CsWin32-emitted struct (here HWND, which the test stubs as a struct in the same namespace
+        // so the constraint binds). The user's `extension(PInvoke) { DrawMenuBar<T>(T hWnd) where T :
+        // IHandle<HWND> }` should NOT cause CsWin32 to skip emitting the raw 1-arg `DrawMenuBar(HWND)`.
+        this.compilation = this.AddCode(
+            $@"namespace Windows.Win32.Foundation
+{{
+    internal interface IHandle<T> {{ T Handle {{ get; }} }}
+    internal readonly struct HWND : IHandle<HWND>
+    {{
+        public HWND Handle => this;
+    }}
+}}
+namespace Windows.Win32
+{{
+    using global::Windows.Win32.Foundation;
+    internal static class {ReceiverName} {{ }}
+    internal static class PrimitivesExtensions
+    {{
+        extension ({ReceiverName})
+        {{
+            // Same simple name + same arity as the metadata DrawMenuBar(HWND) but param is a type
+            // parameter T. Full-signature comparison must report ""T"" != ""HWND"".
+            public static bool DrawMenuBar<T>(T hWnd) where T : IHandle<HWND> => false;
+        }}
+    }}
+}}",
+            fileName: "ExistingPrimitives.cs");
+
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("DrawMenuBar", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        // The raw DrawMenuBar(HWND) (non-generic, single HWND parameter) must still be emitted under
+        // the host class because the user's wrapper has a generic type-parameter signature.
+        IEnumerable<MethodDeclarationSyntax> hostMethods = this.FindGeneratedType(HostClassName)
+            .OfType<ClassDeclarationSyntax>()
+            .SelectMany(c => c.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            .Where(m => m.Identifier.ValueText == "DrawMenuBar" && m.TypeParameterList is null);
+        Assert.NotEmpty(hostMethods);
+    }
+
+    private static ClassDeclarationSyntax SingleHostClass(IEnumerable<BaseTypeDeclarationSyntax> types)
+    {
+        // A single emitted host class with members (the one that actually has the wrap).
+        return types.OfType<ClassDeclarationSyntax>().Single(c => c.Members.Count > 0);
+    }
+
+    private static string ReceiverTypeName(ExtensionBlockDeclarationSyntax block)
+    {
+        ParameterSyntax receiverParam = Assert.Single(block.ParameterList!.Parameters);
+        Assert.NotNull(receiverParam.Type);
+        return receiverParam.Type!.ToString().Trim();
+    }
+}

--- a/test/Microsoft.Windows.CsWin32.Tests/ExtensionReceiverTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/ExtensionReceiverTests.cs
@@ -524,6 +524,89 @@ namespace Windows.Win32
         Assert.NotEmpty(hostMethods);
     }
 
+    /// <summary>
+    /// Member-kind discrimination: a constant must NOT be suppressed by a parameterless extension
+    /// <em>method</em> of the same simple name on the receiver. Both probe with zero parameters, so a
+    /// kind-agnostic match would have falsely deduped them; the constant must still be emitted.
+    /// </summary>
+    [Fact]
+    public void Dedup_ConstantVsParameterlessMethodSameName_StillEmitsConstant()
+    {
+        // A "lower" layer publishes a parameterless METHOD named WM_NULL on the receiver. The metadata
+        // WM_NULL is a CONSTANT of the same name. Different member kinds => must NOT dedup.
+        this.compilation = this.AddCode(
+            $@"namespace Windows.Win32
+{{
+    internal static class {ReceiverName} {{ }}
+    internal static class CoreLayer
+    {{
+        extension ({ReceiverName})
+        {{
+            public static uint WM_NULL() => 0u;
+        }}
+    }}
+}}",
+            fileName: "ExistingMethod.cs");
+
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("WM_NULL", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        // The constant's backing field must still be emitted under the host class because the pre-existing
+        // member is a method (different kind), not a field/property.
+        IEnumerable<FieldDeclarationSyntax> hostFields = this.FindGeneratedType(HostClassName)
+            .OfType<ClassDeclarationSyntax>()
+            .SelectMany(c => c.DescendantNodes().OfType<FieldDeclarationSyntax>())
+            .Where(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == "WM_NULL"));
+        Assert.NotEmpty(hostFields);
+    }
+
+    /// <summary>
+    /// Member-kind discrimination (the converse case): a parameterless extern method must NOT be suppressed
+    /// by an extension <em>property</em> of the same simple name on the receiver. The method must still be emitted.
+    /// </summary>
+    [Fact]
+    public void Dedup_ParameterlessMethodVsPropertySameName_StillEmitsExtern()
+    {
+        // A "lower" layer publishes a PROPERTY named GetTickCount on the receiver. The metadata
+        // GetTickCount() is a parameterless METHOD of the same name. Different member kinds => must NOT dedup.
+        this.compilation = this.AddCode(
+            $@"namespace Windows.Win32
+{{
+    internal static class {ReceiverName} {{ }}
+    internal static class CoreLayer
+    {{
+        extension ({ReceiverName})
+        {{
+            public static uint GetTickCount => 0u;
+        }}
+    }}
+}}",
+            fileName: "ExistingProperty.cs");
+
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            EmitSingleFile = true,
+            ClassName = HostClassName,
+            ExtensionReceiver = ReceiverName,
+        });
+        Assert.True(this.generator.TryGenerate("GetTickCount", TestContext.Current.CancellationToken));
+        this.CollectGeneratedCode(this.generator);
+
+        // The raw parameterless extern must still be emitted because the pre-existing member is a property
+        // (different kind), not a method.
+        IEnumerable<MethodDeclarationSyntax> hostMethods = this.FindGeneratedType(HostClassName)
+            .OfType<ClassDeclarationSyntax>()
+            .SelectMany(c => c.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            .Where(m => m.Identifier.ValueText == "GetTickCount" && m.ParameterList.Parameters.Count == 0);
+        Assert.NotEmpty(hostMethods);
+    }
+
     private static ClassDeclarationSyntax SingleHostClass(IEnumerable<BaseTypeDeclarationSyntax> types)
     {
         // A single emitted host class with members (the one that actually has the wrap).


### PR DESCRIPTION
Implements `extensionReceiver` in `NativeMethods.json` so multiple assemblies running CsWin32 can contribute to a single shared static class (typically `PInvoke`). Callers reach every generated native API through one discovery symbol regardless of which assembly emitted it.

Closes #1477.

## What this adds

A new `extensionReceiver` setting in `NativeMethods.json` names a static class declared in another assembly that also runs CsWin32 to receive this assembly's generated members. When set, members are emitted inside a C# 14 `extension(<Receiver>) { ... }` block on the configured `className`. The receiver must live in the same namespace as `className`, be a static class, be accessible, and differ from `className`.

Constants which the C# 14 extension grammar cannot host are emitted as fields on the host class (preserving the configured visibility) and re-exposed through a forwarder property inside the extension block, so both `PInvoke.X` (extension path, runtime contexts) and `<HostClass>.X` (const path, enum initializers / attribute args / fixed-array sizes / case labels) work.

Cross-assembly duplicates are skipped using a full-signature match (name + arity + per-parameter type-name comparison after normalization that strips `global::` and leading namespace segments). User-authored wrappers with the same name but a different signature do not suppress the underlying metadata extern.

When `SuperGenerator` runs multiple generators (e.g. `Windows.Win32` and `Windows.Wdk` side by side), each generator silently no-ops the wrap if the receiver doesn't resolve in its own namespace; `PInvoke011` is reported only when no generator could resolve.

The analyzer is multi-targeted into a Roslyn 4.11 floor leg (feature disabled) and a Roslyn 5.0+ leg (feature enabled, using `ExtensionBlockDeclarationSyntax` / `INamedTypeSymbol.IsExtension`). NuGet picks the appropriate leg from the host's Roslyn version.

## Diagnostics

| ID | Cause |
|---|---|
| `PInvoke011` | `extensionReceiver` couldn't be resolved, isn't a static class, isn't accessible, or equals `className`. |
| `PInvoke012` | Consuming project requires C# 14 (default on .NET 10+). |
| `PInvoke013` | Host analyzer doesn't support C# 14 extension members. |

## Documentation

`docfx/docs/composition.md` is added to the docs TOC with the conceptual model, configuration reference, dispatch rules, multi-assembly composition behavior, a step-by-step migration playbook for existing multi-layer projects, common-issue catalog, and the diagnostics matrix. `features.md` and `getting-started.md` cross-link to it.

## Validation

* 16 new unit tests in `ExtensionReceiverTests.cs` covering shape, multi-file emission, gating, the four `TryResolveExtensionReceiver` outcomes, and the full-signature dedup matrix (name match, arity mismatch, parameter-type mismatch, generic user-wrapper vs. metadata extern of the same simple name).
* Synthetic integration test `integration-tests/sdk-extension` consuming the locally-packed package via the SDK 11 preview.
* Independently vetted in `dotnet/winforms`: https://github.com/JeremyKuhne/winforms/commit/45562f1db39533e5b1357c73230375973ce8f61c

Feedback from the WinForms vet drove three refinements over the initial design:

1. Dedup upgraded from name-only to full-signature match, eliminating a self-recursion hazard where a user-authored wrapper could silently suppress the metadata extern of the same simple name.
2. Constant backing fields keep their configured visibility instead of being forced to `private`, so they remain usable in C# const contexts.
3. Receiver resolution short-circuits per generator under `SuperGenerator`, removing false `PInvoke011` reports when one of several side-by-side generators legitimately can't see the receiver.
