### PR TITLE
Emit `IComIID` on downlevel TFMs (net472 / netstandard2.0)

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Com.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Com.cs
@@ -1165,53 +1165,83 @@ public partial class Generator
             {
                 baseTypes.Add(SimpleBaseType(IComIIDGuidInterfaceName));
 
-                IdentifierNameSyntax dataLocal = IdentifierName("data");
-
-                // Rather than just `return ref IID_Guid`, which returns a pointer to a 'movable' field,
-                // We leverage C# syntax that we know the modern C# compiler will turn into a pointer directly into the dll image,
-                // so that the pointer does not move.
-                // This does rely on at least the generated code running on a little endian machine, since we're laying raw bytes on top of integer fields.
-                // But at the moment, we also assume this source generator is running on little endian for convenience for the reverse operation.
-                if (!BitConverter.IsLittleEndian)
-                {
-                    throw new NotSupportedException("Conversion from big endian to little endian is not implemented.");
-                }
-
-                // ReadOnlySpan<byte> data = new byte[] { ... };
-                ReadOnlySpan<byte> guidBytes = new((byte*)&guidAttributeValue, sizeof(Guid));
-                LocalDeclarationStatementSyntax dataDecl = LocalDeclarationStatement(
-                    VariableDeclaration(
-                        MakeReadOnlySpanOfT(PredefinedType(Token(SyntaxKind.ByteKeyword))),
-                        [VariableDeclarator(dataLocal.Identifier, EqualsValueClause(NewByteArray(guidBytes)))]));
-
-                // return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
-                ReturnStatementSyntax returnStatement = ReturnStatement(RefExpression(
-                    InvocationExpression(
-                        MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            IdentifierName(nameof(Unsafe)),
-                            GenericName(nameof(Unsafe.As), [PredefinedType(Token(SyntaxKind.ByteKeyword)), IdentifierName(nameof(Guid))])),
-                        [
-                            Argument(
-                                InvocationExpression(
-                                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName(nameof(MemoryMarshal)), IdentifierName(nameof(MemoryMarshal.GetReference))),
-                                    [Argument(dataLocal)]))
-                            .WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword))
-                        ])));
+                bool canUseStaticAbstract = this.IsFeatureAvailable(Feature.InterfaceStaticMembers);
 
                 // The native assembly code for this property getter is just a `mov` and a `ret.
                 // For our callers to also enjoy just the `mov` instruction, we have to attribute for aggressive inlining.
                 // [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 AttributeListSyntax methodImplAttr = AttributeList(MethodImpl(MethodImplOptions.AggressiveInlining));
 
-                BlockSyntax getBody = Block(dataDecl, returnStatement);
+                if (canUseStaticAbstract)
+                {
+                    IdentifierNameSyntax dataLocal = IdentifierName("data");
 
-                // static ref readonly Guid IComIID.Guid { get { ... } }
-                PropertyDeclarationSyntax guidProperty = PropertyDeclaration(IdentifierName(nameof(Guid)).WithTrailingTrivia(Space), ComIIDGuidPropertyName.Identifier)
-                    .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(IComIIDGuidInterfaceName))
-                    .AddModifiers(TokenWithSpace(SyntaxKind.StaticKeyword), TokenWithSpace(SyntaxKind.RefKeyword), TokenWithSpace(SyntaxKind.ReadOnlyKeyword))
-                    .WithAccessorList(AccessorList(AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, getBody).AddAttributeLists(methodImplAttr)));
-                members.Add(guidProperty);
+                    // Rather than just `return ref IID_Guid`, which returns a pointer to a 'movable' field,
+                    // We leverage C# syntax that we know the modern C# compiler will turn into a pointer directly into the dll image,
+                    // so that the pointer does not move.
+                    // This does rely on at least the generated code running on a little endian machine, since we're laying raw bytes on top of integer fields.
+                    // But at the moment, we also assume this source generator is running on little endian for convenience for the reverse operation.
+                    if (!BitConverter.IsLittleEndian)
+                    {
+                        throw new NotSupportedException("Conversion from big endian to little endian is not implemented.");
+                    }
+
+                    // ReadOnlySpan<byte> data = new byte[] { ... };
+                    ReadOnlySpan<byte> guidBytes = new((byte*)&guidAttributeValue, sizeof(Guid));
+                    LocalDeclarationStatementSyntax dataDecl = LocalDeclarationStatement(
+                        VariableDeclaration(
+                            MakeReadOnlySpanOfT(PredefinedType(Token(SyntaxKind.ByteKeyword))),
+                            [VariableDeclarator(dataLocal.Identifier, EqualsValueClause(NewByteArray(guidBytes)))]));
+
+                    // return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+                    ReturnStatementSyntax returnStatement = ReturnStatement(RefExpression(
+                        InvocationExpression(
+                            MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                IdentifierName(nameof(Unsafe)),
+                                GenericName(nameof(Unsafe.As), [PredefinedType(Token(SyntaxKind.ByteKeyword)), IdentifierName(nameof(Guid))])),
+                            [
+                                Argument(
+                                    InvocationExpression(
+                                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName(nameof(MemoryMarshal)), IdentifierName(nameof(MemoryMarshal.GetReference))),
+                                        [Argument(dataLocal)]))
+                                .WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword))
+                            ])));
+
+                    BlockSyntax getBody = Block(dataDecl, returnStatement);
+
+                    // static ref readonly Guid IComIID.Guid { get { ... } }
+                    PropertyDeclarationSyntax guidProperty = PropertyDeclaration(IdentifierName(nameof(Guid)).WithTrailingTrivia(Space), ComIIDGuidPropertyName.Identifier)
+                        .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(IComIIDGuidInterfaceName))
+                        .AddModifiers(TokenWithSpace(SyntaxKind.StaticKeyword), TokenWithSpace(SyntaxKind.RefKeyword), TokenWithSpace(SyntaxKind.ReadOnlyKeyword))
+                        .WithAccessorList(AccessorList(AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, getBody).AddAttributeLists(methodImplAttr)));
+                    members.Add(guidProperty);
+                }
+                else
+                {
+                    // Downlevel TFMs (net472 / netstandard2.0) do not support static abstract interface members.
+                    // Emit an instance-form explicit interface implementation matching the shape used by
+                    // dotnet/winforms' polyfill (see https://github.com/microsoft/CsWin32/issues/1704):
+                    //   readonly ref readonly Guid IComIID.Guid => ref Unsafe.AsRef(in IID_Guid);
+                    // This preserves the `ref readonly Guid` signature so generic helpers written against
+                    // `ref readonly Guid` can target both the upper (static-abstract) and downlevel forms.
+                    ExpressionSyntax body = RefExpression(
+                        InvocationExpression(
+                            MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                IdentifierName(nameof(Unsafe)),
+                                IdentifierName(nameof(Unsafe.AsRef))),
+                            [Argument(iidGuidFieldName).WithRefKindKeyword(Token(SyntaxKind.InKeyword))]));
+                    AccessorDeclarationSyntax getter = AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                        .WithExpressionBody(ArrowExpressionClause(body))
+                        .WithSemicolonToken(Semicolon)
+                        .AddAttributeLists(methodImplAttr);
+                    PropertyDeclarationSyntax guidProperty = PropertyDeclaration(IdentifierName(nameof(Guid)).WithTrailingTrivia(Space), ComIIDGuidPropertyName.Identifier)
+                        .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(IComIIDGuidInterfaceName))
+                        .AddModifiers(TokenWithSpace(SyntaxKind.ReadOnlyKeyword), TokenWithSpace(SyntaxKind.RefKeyword), TokenWithSpace(SyntaxKind.ReadOnlyKeyword))
+                        .WithAccessorList(AccessorList(getter));
+                    members.Add(guidProperty);
+                }
             }
         }
 
@@ -1385,29 +1415,43 @@ public partial class Generator
 
     private bool TryDeclareCOMGuidInterfaceIfNecessary()
     {
-        // Static interface members require C# 11 and .NET 7 at minimum.
-        if (!this.IsFeatureAvailable(Feature.InterfaceStaticMembers))
-        {
-            return false;
-        }
-
         if (this.comIIDInterfacePredefined)
         {
             return true;
         }
 
+        bool canUseStaticAbstract = this.IsFeatureAvailable(Feature.InterfaceStaticMembers);
+
         this.volatileCode.GenerateSpecialType(IComIIDGuidInterfaceName.Identifier.ValueText, delegate
         {
-            // internal static abstract ref readonly Guid Guid { get; }
-            PropertyDeclarationSyntax guidProperty = PropertyDeclaration(IdentifierName(nameof(Guid)).WithTrailingTrivia(Space), ComIIDGuidPropertyName.Identifier)
-                .AddModifiers(
-                    TokenWithSpace(this.Visibility),
-                    TokenWithSpace(SyntaxKind.StaticKeyword),
-                    TokenWithSpace(SyntaxKind.AbstractKeyword),
-                    TokenWithSpace(SyntaxKind.RefKeyword),
-                    TokenWithSpace(SyntaxKind.ReadOnlyKeyword))
-                .WithAccessorList(AccessorList(AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(Semicolon)))
-                .WithLeadingTrivia(ParseLeadingTrivia($"/// <summary>The IID guid for this interface.</summary>\n/// <remarks>The <see cref=\"Guid\" /> reference that is returned comes from a permanent memory address, and is therefore safe to convert to a pointer and pass around or hold long-term.</remarks>\n"));
+            PropertyDeclarationSyntax guidProperty;
+            if (canUseStaticAbstract)
+            {
+                // internal static abstract ref readonly Guid Guid { get; }
+                guidProperty = PropertyDeclaration(IdentifierName(nameof(Guid)).WithTrailingTrivia(Space), ComIIDGuidPropertyName.Identifier)
+                    .AddModifiers(
+                        TokenWithSpace(this.Visibility),
+                        TokenWithSpace(SyntaxKind.StaticKeyword),
+                        TokenWithSpace(SyntaxKind.AbstractKeyword),
+                        TokenWithSpace(SyntaxKind.RefKeyword),
+                        TokenWithSpace(SyntaxKind.ReadOnlyKeyword))
+                    .WithAccessorList(AccessorList(AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(Semicolon)))
+                    .WithLeadingTrivia(ParseLeadingTrivia($"/// <summary>The IID guid for this interface.</summary>\n/// <remarks>The <see cref=\"Guid\" /> reference that is returned comes from a permanent memory address, and is therefore safe to convert to a pointer and pass around or hold long-term.</remarks>\n"));
+            }
+            else
+            {
+                // Downlevel polyfill form (see https://github.com/microsoft/CsWin32/issues/1704):
+                // internal ref readonly Guid Guid { get; }
+                // Matches the dotnet/winforms polyfill shape so a single `ref readonly Guid` signature
+                // works for both the upper (static-abstract) and downlevel forms.
+                guidProperty = PropertyDeclaration(IdentifierName(nameof(Guid)).WithTrailingTrivia(Space), ComIIDGuidPropertyName.Identifier)
+                    .AddModifiers(
+                        TokenWithSpace(this.Visibility),
+                        TokenWithSpace(SyntaxKind.RefKeyword),
+                        TokenWithSpace(SyntaxKind.ReadOnlyKeyword))
+                    .WithAccessorList(AccessorList(AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(Semicolon)))
+                    .WithLeadingTrivia(ParseLeadingTrivia($"/// <summary>The IID guid for this interface.</summary>\n"));
+            }
 
             // internal interface IComIID { ... }
             InterfaceDeclarationSyntax ifaceDecl = InterfaceDeclaration(IComIIDGuidInterfaceName.Identifier, [guidProperty])

--- a/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
@@ -458,6 +458,126 @@ public class COMTests : GeneratorTestBase
         }
     }
 
+    /// <summary>
+    /// Regression test for <see href="https://github.com/microsoft/CsWin32/issues/1704">issue 1704</see>:
+    /// the <c>IComIID</c> interface (and its attachment on generated COM structs) must also be emitted
+    /// on target frameworks that do not support static abstract interface members
+    /// (<c>net472</c>, <c>netstandard2.0</c>), using an instance-form property.
+    /// </summary>
+    [Theory]
+    [CombinatorialData]
+    public void COMInterfaceIIDInterfaceOnDownlevelTFMs(
+        [CombinatorialValues("net472", "netstandard2.0")] string tfm)
+    {
+        const string structName = "IEnumBstr";
+        this.compilation = this.starterCompilations[tfm];
+        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions with { AllowMarshaling = false });
+        this.GenerateApi(structName);
+
+        BaseTypeDeclarationSyntax type = this.FindGeneratedType(structName).Single();
+        Assert.IsType<StructDeclarationSyntax>(type);
+        IEnumerable<BaseTypeSyntax> baseTypes = type.BaseList?.Types ?? Enumerable.Empty<BaseTypeSyntax>();
+        Assert.Contains(baseTypes, t => t.Type.ToString().Contains("IComIID"));
+
+        // The IComIID interface itself must be generated.
+        InterfaceDeclarationSyntax icomIidDecl = Assert.IsType<InterfaceDeclarationSyntax>(this.FindGeneratedType("IComIID").Single());
+
+        // Its Guid property must be instance-form (no 'static' modifier) on these TFMs,
+        // and must be `ref readonly Guid` to match the dotnet/winforms polyfill shape.
+        PropertyDeclarationSyntax guidProp = icomIidDecl.Members.OfType<PropertyDeclarationSyntax>().Single(p => p.Identifier.ValueText == "Guid");
+        Assert.DoesNotContain(guidProp.Modifiers, m => m.IsKind(SyntaxKind.StaticKeyword));
+        Assert.DoesNotContain(guidProp.Modifiers, m => m.IsKind(SyntaxKind.AbstractKeyword));
+        string guidPropText = guidProp.NormalizeWhitespace().ToFullString();
+        Assert.Contains("ref readonly Guid Guid", guidPropText);
+
+        // And the struct must contain an explicit interface implementation of IComIID.Guid,
+        // also as `ref readonly Guid` (matching the WinForms `ref Unsafe.AsRef(in IID_Guid)` pattern).
+        var explicitImpl = ((StructDeclarationSyntax)type).Members.OfType<PropertyDeclarationSyntax>()
+            .SingleOrDefault(p => p.ExplicitInterfaceSpecifier is not null && p.Identifier.ValueText == "Guid");
+        Assert.NotNull(explicitImpl);
+        Assert.DoesNotContain(explicitImpl!.Modifiers, m => m.IsKind(SyntaxKind.StaticKeyword));
+        string implText = explicitImpl.NormalizeWhitespace().ToFullString();
+        Assert.Contains("ref readonly Guid IComIID.Guid", implText);
+        Assert.Contains("Unsafe.AsRef(in IID_Guid)", implText);
+    }
+
+    /// <summary>
+    /// Multi-targeting regression test for <see href="https://github.com/microsoft/CsWin32/issues/1704">issue 1704</see>.
+    /// Mirrors the issue's repro project (TargetFrameworks = net10.0;net472 with the exact
+    /// NativeMethods.txt content) and asserts that <c>IComIID</c> is generated, attached, and
+    /// usable as a generic type constraint on every TFM a typical multi-targeted project
+    /// might build for — not only those that support static abstract interface members.
+    /// </summary>
+    [Theory]
+    [CombinatorialData]
+    public void IComIID_MultiTargeting_Issue1704(
+        [CombinatorialValues("net472", "netstandard2.0", "net8.0", "net9.0", "net10.0")] string tfm)
+    {
+        this.compilation = this.starterCompilations[tfm];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(GetLanguageVersionForTfm(tfm) ?? LanguageVersion.Latest);
+        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions with { AllowMarshaling = false });
+
+        // The exact NativeMethods.txt content from the issue repro.
+        Assert.True(this.generator.TryGenerate("GetRunningObjectTable", CancellationToken.None));
+        Assert.True(this.generator.TryGenerate("IRunningObjectTable", CancellationToken.None));
+        Assert.True(this.generator.TryGenerate("IMoniker", CancellationToken.None));
+        Assert.True(this.generator.TryGenerate("CoCreateInstance", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics();
+
+        // 1. The IComIID interface itself must be generated on every TFM.
+        InterfaceDeclarationSyntax icomIidDecl = Assert.IsType<InterfaceDeclarationSyntax>(this.FindGeneratedType("IComIID").Single());
+
+        // 2. Every generated COM struct must list IComIID in its base list.
+        foreach (string structName in new[] { "IRunningObjectTable", "IMoniker" })
+        {
+            BaseTypeDeclarationSyntax type = this.FindGeneratedType(structName).Single();
+            Assert.IsType<StructDeclarationSyntax>(type);
+            IEnumerable<BaseTypeSyntax> baseTypes = type.BaseList?.Types ?? Enumerable.Empty<BaseTypeSyntax>();
+            Assert.Contains(baseTypes, t => t.Type.ToString().Contains("IComIID"));
+        }
+
+        // 3. Consumer code that uses IComIID as a generic constraint must compile on every TFM.
+        //    Use the WinForms-style `ref readonly Guid` pattern (see dotnet/winforms IDataObject.cs)
+        //    which is uniform across both static-abstract and downlevel forms — only the call site differs.
+        bool hasStaticAbstract = this.parseOptions.LanguageVersion >= LanguageVersion.CSharp11
+            && (tfm.StartsWith("net8", StringComparison.Ordinal)
+                || tfm.StartsWith("net9", StringComparison.Ordinal)
+                || tfm.StartsWith("net10", StringComparison.Ordinal));
+
+        string consumerSnippet = hasStaticAbstract
+            ? """
+                using System;
+                using Windows.Win32;
+                using Windows.Win32.System.Com;
+
+                internal static unsafe class Issue1704Consumer
+                {
+                    private static ref readonly Guid GetIID<T>() where T : unmanaged, IComIID => ref T.Guid;
+                    public static Guid M() => GetIID<IRunningObjectTable>();
+                }
+                """
+            : """
+                using System;
+                using Windows.Win32;
+                using Windows.Win32.System.Com;
+
+                internal static unsafe class Issue1704Consumer
+                {
+                    private static ref readonly Guid GetIID<T>() where T : unmanaged, IComIID
+                    {
+                        T local = default;
+                        return ref ((IComIID)local).Guid;
+                    }
+
+                    public static Guid M() => GetIID<IRunningObjectTable>();
+                }
+                """;
+
+        this.compilation = this.AddCode(consumerSnippet);
+        this.AssertNoDiagnostics(this.compilation, logAllGeneratedCode: false);
+    }
+
     [Fact]
     public void FunctionPointersAsParameters()
     {


### PR DESCRIPTION
Fixes #1704.

## Summary

On target frameworks that do not support static abstract interface members (`net472`, `netstandard2.0`), CsWin32 previously skipped emitting the `IComIID` interface entirely and did not attach it to generated COM struct wrappers. Consumers multi-targeting (e.g. `net10.0;net472`) had to hand-author two polyfill files per project — an instance-form `IComIID` interface plus one `partial struct Foo : IComIID { Guid IComIID.Guid => IID_Guid; }` per generated COM type used through `ComScope<T>` — and add a new partial every time a COM type was added to `NativeMethods.txt`. See [dotnet/msbuild's `IComIIDPolyfills.cs`](https://github.com/dotnet/msbuild/blob/main/src/Framework/Polyfills/IComIIDPolyfills.cs) and [dotnet/winforms's `IDataObject.cs`](https://github.com/dotnet/winforms/blob/main/src/System.Private.Windows.Core/src/Framework/Windows/Win32/System/Com/IDataObject.cs) for the workarounds in production today.

## Fix

The generator now emits `IComIID` on every TFM. On TFMs that support static abstract interface members the existing optimized form is unchanged. On downlevel TFMs the generator emits an instance-form polyfill matching the shape used by `dotnet/winforms` and `dotnet/msbuild` byte-for-byte:

```csharp
// Interface
internal interface IComIID
{
    internal ref readonly Guid Guid { get; }
}

// Per-struct attachment
internal unsafe partial struct IRunningObjectTable : IComIID
{
    internal static readonly Guid IID_Guid = new Guid(...);

    readonly ref readonly Guid IComIID.Guid
    {
        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        get => ref Unsafe.AsRef(in IID_Guid);
    }
}
```

The uniform `ref readonly Guid Guid { get; }` signature across both forms means a single consumer signature works on every TFM — only the `static abstract` modifiers differ. Adopters can delete their hand-authored polyfills entirely on upgrade.

## Tests

- New `COMInterfaceIIDInterfaceOnDownlevelTFMs` test asserts the interface declaration, the explicit-interface implementation, and the `ref Unsafe.AsRef(in IID_Guid)` body shape on `net472` and `netstandard2.0`.
- New `IComIID_MultiTargeting_Issue1704` theory mirrors the exact `NativeMethods.txt` from issue #1704 against `net472`, `netstandard2.0`, `net8.0`, `net9.0`, and `net10.0`. It generates `GetRunningObjectTable`, `IRunningObjectTable`, `IMoniker`, `CoCreateInstance`, asserts every COM struct lists `IComIID` in its base list, and compiles a consumer snippet using `where T : unmanaged, IComIID` as a generic constraint on every TFM.
- Full suite: 742 passed, 0 failed.

## Manual repro verification

Built the exact repro project from #1704 (`TargetFrameworks=net10.0;net472`):
- Against published `0.3.275` → `error CS0246: 'IComIID' could not be found` on net472 ✅ (reproduced)
- Against locally-packed build of this branch → both TFMs build clean, `dotnet run` on net10.0 prints `00000010-0000-0000-c000-000000000046` ✅ (fixed)

Inspected the per-TFM generated output:
- `net10.0`: `internal static abstract ref readonly Guid Guid { get; }` (unchanged optimal form)
- `net472`: `internal ref readonly Guid Guid { get; }` + `readonly ref readonly Guid IComIID.Guid => ref Unsafe.AsRef(in IID_Guid);` (new)
