### PR TITLE
Bump .NET SDK to 10.0.108 (CG alert 12352554)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.108",
     "rollForward": "patch",
     "allowPrerelease": false
   },


### PR DESCRIPTION
Fixes CG Alert by bumping the .NET SDK pinned in `global.json` from `10.0.100` to `10.0.108`.

## Why

CG flags .NET SDK `10.0.100` as having security vulnerabilities that have been patched in later 10.0.x servicing releases. CG's recommended remediation is `10.0.108`.

See https://aka.ms/dotnet-security-notes and https://aka.ms/dotnet-download for advisory details.