### PR TITLE
fix: document inherited COM interface methods

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Com.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Com.cs
@@ -1014,13 +1014,17 @@ public partial class Generator
                     propertyOrMethod = methodDeclaration;
                 }
 
+                string apiDocsKey = $"{ifaceName}.{methodName}";
                 if (inheritedMethods >= 0)
                 {
                     propertyOrMethod = propertyOrMethod.AddModifiers(TokenWithSpace(SyntaxKind.NewKeyword));
+                    TypeDefinition declaringType = methodDefinition.Reader.GetTypeDefinition(methodDefinition.Method.GetDeclaringType());
+                    string declaringIfaceName = methodDefinition.Reader.GetString(declaringType.Name);
+                    apiDocsKey = $"{declaringIfaceName}.{methodName}";
                 }
 
                 // Add documentation if we can find it.
-                propertyOrMethod = this.AddApiDocumentation($"{ifaceName}.{methodName}", propertyOrMethod);
+                propertyOrMethod = this.AddApiDocumentation(apiDocsKey, propertyOrMethod);
 
                 // In source-generator mode, GeneratedComInterface handles inheritance automatically, so inherited
                 // methods are NOT re-declared on the derived interface. We still need to emit the friendly overloads

--- a/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
@@ -35,6 +35,28 @@ public class COMTests : GeneratorTestBase
     }
 
     [Fact]
+    public void InheritedCOMInterfaceMethodsUseBaseMethodDocs()
+    {
+        this.generator = this.CreateGenerator(includeDocs: true);
+        this.GenerateApi("IShellDispatch2");
+
+        InterfaceDeclarationSyntax baseInterface = Assert.Single(this.FindGeneratedType("IShellDispatch").OfType<InterfaceDeclarationSyntax>());
+        MethodDeclarationSyntax baseFileRun = Assert.Single(baseInterface.Members.OfType<MethodDeclarationSyntax>(), m => m.Identifier.ValueText == "FileRun");
+
+        InterfaceDeclarationSyntax derivedInterface = Assert.Single(this.FindGeneratedType("IShellDispatch2").OfType<InterfaceDeclarationSyntax>());
+        MethodDeclarationSyntax derivedFileRun = Assert.Single(derivedInterface.Members.OfType<MethodDeclarationSyntax>(), m => m.Identifier.ValueText == "FileRun");
+        MethodDeclarationSyntax derivedIsRestricted = Assert.Single(derivedInterface.Members.OfType<MethodDeclarationSyntax>(), m => m.Identifier.ValueText == "IsRestricted");
+
+        Assert.Equal("void", derivedFileRun.ReturnType.ToString());
+        Assert.Empty(derivedFileRun.ParameterList.Parameters);
+        Assert.Contains(derivedFileRun.Modifiers, m => m.IsKind(SyntaxKind.NewKeyword));
+        string? baseFileRunDocs = GetDocumentationComment(baseFileRun);
+        Assert.NotNull(baseFileRunDocs);
+        Assert.Equal(baseFileRunDocs, GetDocumentationComment(derivedFileRun));
+        Assert.NotNull(GetDocumentationComment(derivedIsRestricted));
+    }
+
+    [Fact]
     public void CreateDispatcherQueueController_CreatesWinRTCustomMarshaler()
     {
         this.GenerateApi("CreateDispatcherQueueController");
@@ -1073,4 +1095,11 @@ public class COMTests : GeneratorTestBase
 
     private static string StripWarningDisablePragmas(string code) =>
         string.Join("\n", code.Split('\n').Where(line => !line.TrimStart().StartsWith("#pragma warning disable", StringComparison.Ordinal)));
+
+    private static string? GetDocumentationComment(MemberDeclarationSyntax member) =>
+        member.GetLeadingTrivia()
+            .Select(t => t.GetStructure())
+            .OfType<DocumentationCommentTriviaSyntax>()
+            .SingleOrDefault()
+            ?.ToFullString();
 }


### PR DESCRIPTION
## Summary

Fixes #1391.

Inherited COM interface methods are re-emitted with `new`, but their documentation lookup used the derived interface name. That made inherited `IShellDispatch2` members such as `FileRun` search for `IShellDispatch2.FileRun`, even though the docs entry belongs to the declaring base interface, `IShellDispatch.FileRun`.

This updates the COM interface generator to use the method metadata declaring interface only for inherited members while preserving the existing lookup key for methods declared directly on the generated interface. A focused regression test generates `IShellDispatch2`, checks that inherited `FileRun` is still emitted as `new void FileRun();`, and verifies it receives the same XML docs as `IShellDispatch.FileRun`. The test also checks a direct `IShellDispatch2` method still receives documentation.

## Verification

`/tmp/dotnet-cswin32/dotnet test test/Microsoft.Windows.CsWin32.Tests/Microsoft.Windows.CsWin32.Tests.csproj --no-restore --filter FullyQualifiedName~COMTests.InheritedCOMInterfaceMethodsUseBaseMethodDocs`
