### PR TITLE
Fix #1716: emit friendly overloads for inherited COM methods on derived interfaces in source-generator mode

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Com.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Com.cs
@@ -849,10 +849,10 @@ public partial class Generator
                     topMostBaseTypeSyntax = SimpleBaseType(baseTypeSyntax);
 
                     // ComInterop requires that you re-declare all base methods. GeneratedComInterface fixes this so you just declare the derived interface.
-                    if (!this.useSourceGenerators)
-                    {
-                        allMethods.AddRange(baseType.Definition.GetMethods().Select(methodHandle => new QualifiedMethodDefinitionHandle(baseType.Generator, methodHandle)));
-                    }
+                    // We still iterate over the base methods even in source-generator mode so that we can emit friendly overload extension methods on the
+                    // derived interface. This avoids forcing callers to upcast to the base interface (which fails for COM objects, like Shell's IStream,
+                    // that do not honor QueryInterface for their base interfaces).
+                    allMethods.AddRange(baseType.Definition.GetMethods().Select(methodHandle => new QualifiedMethodDefinitionHandle(baseType.Generator, methodHandle)));
                 }
             }
         }
@@ -1024,7 +1024,15 @@ public partial class Generator
 
                 // Add documentation if we can find it.
                 propertyOrMethod = this.AddApiDocumentation($"{ifaceName}.{methodName}", propertyOrMethod);
-                members.Add(propertyOrMethod);
+
+                // In source-generator mode, GeneratedComInterface handles inheritance automatically, so inherited
+                // methods are NOT re-declared on the derived interface. We still need to emit the friendly overloads
+                // on the derived interface (below) so callers don't have to upcast to the base interface to invoke them.
+                bool addAsInterfaceMember = inheritedMethods < 0 || !this.useSourceGenerators;
+                if (addAsInterfaceMember)
+                {
+                    members.Add(propertyOrMethod);
+                }
 
                 if (methodDeclaration is not null)
                 {

--- a/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
@@ -289,4 +289,42 @@ public partial class COMTests(ITestOutputHelper outputHelper)
             this.outputHelper.WriteLine($"Device {devInfo.ClassGuid} Instance ID: {instanceIdSpan.ToString()}");
         }
     }
+
+    /// <summary>
+    /// Regression test for <see href="https://github.com/microsoft/CsWin32/issues/1716">#1716</see>.
+    /// Calls <see cref="IStream.Read"/> via the friendly Span overload on an IStream obtained from
+    /// <see cref="IShellItem.BindToHandler"/> when CsWin32 is configured with <c>useComSourceGenerators</c>.
+    /// Shell-returned IStream objects do not honor QueryInterface for <c>IID_ISequentialStream</c>, so the
+    /// friendly overload must dispatch via the derived IStream interface rather than upcasting to
+    /// ISequentialStream.
+    /// </summary>
+    [Fact]
+    [Trait("TestCategory", "RequiresHardware")]
+    public void IShellItem_BindToHandler_IStream_ReadWorks()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
+
+        // {1CEBB3AB-7C10-499a-A417-92CA16C4CB83}
+        Guid bhidStream = new Guid(0x1cebb3ab, 0x7c10, 0x499a, 0xa4, 0x17, 0x92, 0xca, 0x16, 0xc4, 0xcb, 0x83);
+
+        string filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "win.ini");
+        Assert.True(File.Exists(filePath), $"Expected '{filePath}' to exist on Windows.");
+
+        unsafe
+        {
+            PInvoke.SHCreateItemFromParsingName(filePath, null, typeof(IShellItem).GUID, out object shellItemObj).ThrowOnFailure();
+            IShellItem shellItem = (IShellItem)shellItemObj;
+            shellItem.BindToHandler(null, bhidStream, typeof(IStream).GUID, out object streamObj);
+            IStream stream = (IStream)streamObj;
+
+            // Friendly Span overload — the original repro for #1716. In source-generator mode this used to
+            // throw InvalidCastException because the extension method's `this` parameter was typed as
+            // ISequentialStream, forcing an upcast that triggered QI for IID_ISequentialStream on the
+            // Shell-returned IStream (which fails).
+            byte[] buffer = new byte[16];
+            stream.Read(buffer, out uint bytesRead);
+
+            Assert.True(bytesRead > 0, "Expected to read at least one byte from win.ini.");
+        }
+    }
 }

--- a/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
@@ -325,6 +325,19 @@ public partial class COMTests(ITestOutputHelper outputHelper)
             stream.Read(buffer, out uint bytesRead);
 
             Assert.True(bytesRead > 0, "Expected to read at least one byte from win.ini.");
+
+            // Also call methods declared on IStream itself (Seek and Stat) to verify that adding friendly
+            // overloads for inherited methods did not perturb the IStream interface's vtable layout.
+            stream.Seek(0, System.IO.SeekOrigin.Begin, out ulong newPosition);
+            Assert.Equal(0UL, newPosition);
+
+            STATSTG stat;
+            stream.Stat(&stat, STATFLAG.STATFLAG_NONAME);
+            Assert.True(stat.cbSize > 0, "Expected Stat to report a non-empty file size.");
+
+            // Read again after Seek to confirm the seek took effect on the same vtable slot.
+            stream.Read(buffer, out uint bytesReadAfterSeek);
+            Assert.Equal(bytesRead, bytesReadAfterSeek);
         }
     }
 }

--- a/test/GenerationSandbox.BuildTask.Tests/NativeMethods.txt
+++ b/test/GenerationSandbox.BuildTask.Tests/NativeMethods.txt
@@ -31,6 +31,7 @@ IEventSubscription
 InitializeAcl
 IPersistFile
 ISequentialStream
+IShellItem
 IShellLinkW
 IShellWindows
 IStream
@@ -47,6 +48,7 @@ S_OK
 SetTimer
 SetupDiCreateDeviceInterface
 ShellLink
+SHCreateItemFromParsingName
 SHGetFileInfo
 SHGFI_FLAGS
 STATFLAG

--- a/test/GenerationSandbox.Tests/ComRuntimeTests.cs
+++ b/test/GenerationSandbox.Tests/ComRuntimeTests.cs
@@ -250,6 +250,18 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
             stream.Read(buffer, out uint bytesRead);
 
             Assert.True(bytesRead > 0, "Expected to read at least one byte from win.ini.");
+
+            // Also call methods declared on IStream itself (Seek and Stat) to verify the IStream interface's
+            // vtable layout is intact alongside the inherited-method extension overloads.
+            stream.Seek(0, System.IO.SeekOrigin.Begin, out ulong newPosition);
+            Assert.Equal(0UL, newPosition);
+
+            STATSTG stat;
+            stream.Stat(&stat, STATFLAG.STATFLAG_NONAME);
+            Assert.True(stat.cbSize > 0, "Expected Stat to report a non-empty file size.");
+
+            stream.Read(buffer, out uint bytesReadAfterSeek);
+            Assert.Equal(bytesRead, bytesReadAfterSeek);
         }
     }
 }

--- a/test/GenerationSandbox.Tests/ComRuntimeTests.cs
+++ b/test/GenerationSandbox.Tests/ComRuntimeTests.cs
@@ -256,7 +256,7 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
             stream.Seek(0, System.IO.SeekOrigin.Begin, out ulong newPosition);
             Assert.Equal(0UL, newPosition);
 
-            STATSTG stat;
+            Windows.Win32.System.Com.STATSTG stat;
             stream.Stat(&stat, STATFLAG.STATFLAG_NONAME);
             Assert.True(stat.cbSize > 0, "Expected Stat to report a non-empty file size.");
 

--- a/test/GenerationSandbox.Tests/ComRuntimeTests.cs
+++ b/test/GenerationSandbox.Tests/ComRuntimeTests.cs
@@ -214,4 +214,42 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
             this.outputHelper.WriteLine($"IP Version: {app.IpVersion}");
         }
     }
+
+    /// <summary>
+    /// Regression test for <see href="https://github.com/microsoft/CsWin32/issues/1716">#1716</see>.
+    /// Calls <see cref="IStream.Read"/> via the friendly Span overload on an IStream obtained from
+    /// <see cref="IShellItem.BindToHandler"/>. Shell-returned IStream objects do not honor
+    /// QueryInterface for <c>IID_ISequentialStream</c>, so the friendly overload must dispatch via the
+    /// derived IStream interface rather than upcasting to ISequentialStream.
+    /// </summary>
+    [Fact]
+    [Trait("TestCategory", "RequiresHardware")]
+    public void IShellItem_BindToHandler_IStream_ReadWorks()
+    {
+        Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
+
+        // {1CEBB3AB-7C10-499a-A417-92CA16C4CB83}
+        Guid bhidStream = new Guid(0x1cebb3ab, 0x7c10, 0x499a, 0xa4, 0x17, 0x92, 0xca, 0x16, 0xc4, 0xcb, 0x83);
+
+        // Use an arbitrary file that always exists on Windows so the test is hermetic.
+        string filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "win.ini");
+        Assert.True(File.Exists(filePath), $"Expected '{filePath}' to exist on Windows.");
+
+        unsafe
+        {
+            PInvoke.SHCreateItemFromParsingName(filePath, null, typeof(IShellItem).GUID, out object shellItemObj).ThrowOnFailure();
+            IShellItem shellItem = (IShellItem)shellItemObj;
+            shellItem.BindToHandler(null, bhidStream, typeof(IStream).GUID, out object streamObj);
+            IStream stream = (IStream)streamObj;
+
+            // Friendly Span overload — the original repro for #1716. In source-generator mode this used to
+            // throw InvalidCastException because the extension method's `this` parameter was typed as
+            // ISequentialStream, forcing an upcast that triggered QI for IID_ISequentialStream on the
+            // Shell-returned IStream (which fails).
+            byte[] buffer = new byte[16];
+            stream.Read(buffer, out uint bytesRead);
+
+            Assert.True(bytesRead > 0, "Expected to read at least one byte from win.ini.");
+        }
+    }
 }

--- a/test/GenerationSandbox.Tests/NativeMethods.txt
+++ b/test/GenerationSandbox.Tests/NativeMethods.txt
@@ -43,6 +43,7 @@ IDirectorySearch
 IEnumDebugPropertyInfo
 IPersistFile
 IServiceProvider
+IShellItem
 IShellWindows
 IStream
 KEY_EVENT_RECORD
@@ -69,6 +70,7 @@ RmRegisterResources
 RmRegisterResources
 RmStartSession
 S_OK
+SHCreateItemFromParsingName
 SetupDiGetDeviceInterfaceDetail
 SHDESCRIPTIONID
 SHELLFLAGSTATE


### PR DESCRIPTION
﻿Fixes #1716.

## Root cause

When CsWin32 generates COM interfaces with `useComSourceGenerators=true`, `[GeneratedComInterface]` handles inheritance automatically, so base-interface methods are not redeclared on the derived interface. However, the **friendly-overload extension methods** for inherited methods were only emitted on the base interface.

That meant calling the friendly overload on a derived-interface reference (e.g. `IStream stream; stream.Read(buffer, out var n);`) implicitly upcast `this` to the base interface (`ISequentialStream`), which triggers `IDynamicInterfaceCastable.GetInterfaceImplementation` → `QueryInterface` for the base IID. Shell-returned `IStream` objects (e.g., from `IShellItem.BindToHandler(BHID_Stream, ...)`) do **not** honor `QueryInterface` for `IID_ISequentialStream`, so the cast throws `InvalidCastException`. This is a long-standing Windows Shell quirk.

The built-in COM interop path was unaffected because CsWin32 already redeclares all base methods on derived interfaces there, so the friendly overload was automatically generated on the derived interface too.

I confirmed empirically with a hand-written `[GeneratedComInterface]` repro (outside the repo) that this is purely a CsWin32 generation issue — `GeneratedComInterface` dispatches inherited methods through the derived interface vtable correctly when invoked on a derived-interface receiver. The bug was only in the friendly-overload extension method emission.

## Fix

In `Generator.Com.cs`:

1. Always iterate base-interface methods (including in source-generator mode), so friendly overloads can be generated for them.
2. In source-generator mode, do **not** add inherited methods to the derived interface's member list (preserves existing `[GeneratedComInterface]` behavior), but **do** emit their friendly overloads on the derived interface's `_Extensions` class.

After the fix, `IStream_Extensions` contains friendly overloads for `Read`/`Write` (inherited from `ISequentialStream`) in addition to the IStream-declared methods. Callers no longer have to upcast.

## Tests

Added a runtime regression test, `IShellItem_BindToHandler_IStream_ReadWorks`, in both:

- `GenerationSandbox.Tests/ComRuntimeTests.cs` — built-in COM interop path (already worked, locks down the behavior).
- `GenerationSandbox.BuildTask.Tests/COMTests.cs` — source-generator path (was the failing case).

Both tests open Windows' `win.ini` via `SHCreateItemFromParsingName` + `BindToHandler(BHID_Stream)` and read bytes via the friendly Span overload. They're marked `[Trait("TestCategory", "RequiresHardware")]` per existing convention.

Verified that without the generator fix, the source-generator test fails with the exact stack trace from the issue:

```
System.InvalidCastException : Specified cast is not valid.
   at System.Runtime.InteropServices.Marshalling.ComObject.System.Runtime.InteropServices.IDynamicInterfaceCastable.GetInterfaceImplementation(RuntimeTypeHandle interfaceType)
   at Windows.Win32.System.Com.ISequentialStream.Read(Void* pv, UInt32 cb, UInt32* pcbRead)
   at Windows.Win32.System_Com_ISequentialStream_Extensions.Read(ISequentialStream this, Span`1 pv, UInt32& pcbRead)
   at GenerationSandbox.BuildTask.Tests.COMTests.IShellItem_BindToHandler_IStream_ReadWorks()
```

With the fix, both tests pass.

## Verification

- 735 generator unit tests (`Microsoft.Windows.CsWin32.Tests`) ✅
- 243 generator integration tests (`CsWin32Generator.Tests`, excluding HighMemory) ✅
- 137 `GenerationSandbox.Tests` ✅
- 10 `GenerationSandbox.BuildTask.Tests` (incl. new test) ✅