### PR TITLE
Add integration tests to PR gate and fix Roslyn 4 analyzer leg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,10 +182,67 @@ jobs:
         path: TestResults/
         retention-days: 5
 
+  integration-test:
+    name: 🧪 Integration tests
+    needs: build
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: ⚙️ Install prerequisites
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      shell: pwsh
+    - name: 📦 Download build
+      uses: actions/download-artifact@v4
+      with:
+        name: build-windows
+        path: bin/
+    - name: 🔧 Copy integration tests out of the repo
+      run: Copy-Item -Recurse integration-tests ${{ runner.temp }}/integration-tests
+      shell: pwsh
+    - name: 🔧 Configure nupkg source
+      run: |
+        $nupkg = (Get-ChildItem -Path bin/Packages/Release/NuGet -Filter *.nupkg)[0].Name
+        if ($nupkg -match 'Microsoft\.Windows\.CsWin32\.(.+)\.nupkg') {
+          $version = $Matches[1]
+          Write-Host "Will consume Microsoft.Windows.CsWin32 $version"
+          Add-Content -Path $env:GITHUB_ENV -Value "NuGetPackageVersion=$version"
+        }
+        # Point the integration-test nuget.config at the local package output
+        $nugetConfig = "${{ runner.temp }}/integration-tests/nuget.config"
+        $pkgDir = (Resolve-Path bin/Packages/Release/NuGet).Path
+        (Get-Content $nugetConfig) -replace '%PIPELINE_WORKSPACE%\\deployables-Windows', $pkgDir | Set-Content $nugetConfig
+      shell: pwsh
+    - name: 🧪 MSBuild non-sdk style
+      run: |
+        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
+        & $msbuild "${{ runner.temp }}\integration-tests\nonsdk\nonsdk.csproj" /r
+      shell: pwsh
+    - name: 🧪 MSBuild sdk-style
+      run: |
+        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
+        & $msbuild "${{ runner.temp }}\integration-tests\sdk\sdk.csproj" /r
+      shell: pwsh
+    - name: 🧪 dotnet build sdk-style
+      run: dotnet build
+      working-directory: ${{ runner.temp }}/integration-tests/sdk
+    - name: 🧪 dotnet build sdk-roslyn5 (extensionReceiver)
+      run: dotnet build
+      working-directory: ${{ runner.temp }}/integration-tests/sdk-roslyn5
+    - name: 🧪 MSBuild buildtask-sdk-style
+      run: |
+        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
+        & $msbuild "${{ runner.temp }}\integration-tests\buildtask-sdk\buildtask-sdk.slnx" /r
+      shell: pwsh
+    - name: 🧪 dotnet publish buildtask-sdk-style
+      run: dotnet publish -r win-x64
+      working-directory: ${{ runner.temp }}/integration-tests/buildtask-sdk
+
   validate:
     name: ✅ Validate
     if: always()
-    needs: [build, test-fast-windows, test-fast-linux, test-heavy]
+    needs: [build, test-fast-windows, test-fast-linux, test-heavy, integration-test]
     runs-on: ubuntu-latest
     steps:
     - name: Check results
@@ -194,10 +251,12 @@ jobs:
         echo "Windows tests: ${{ needs.test-fast-windows.result }}"
         echo "Linux tests: ${{ needs.test-fast-linux.result }}"
         echo "Heavy tests: ${{ needs.test-heavy.result }}"
+        echo "Integration tests: ${{ needs.integration-test.result }}"
         if [[ "${{ needs.build.result }}" != "success" ||
               "${{ needs.test-fast-windows.result }}" != "success" ||
               "${{ needs.test-fast-linux.result }}" != "success" ||
-              "${{ needs.test-heavy.result }}" != "success" ]]; then
+              "${{ needs.test-heavy.result }}" != "success" ||
+              "${{ needs.integration-test.result }}" != "success" ]]; then
           echo "::error::One or more required jobs failed or were cancelled."
           exit 1
         fi

--- a/azure-pipelines/integration-test.yml
+++ b/azure-pipelines/integration-test.yml
@@ -48,6 +48,10 @@ jobs:
     displayName: 🧪 dotnet build
     workingDirectory: $(Pipeline.Workspace)\integration-tests\sdk
     condition: eq(variables.currentSdk, 'true')
+  - pwsh: dotnet build
+    displayName: 🧪 dotnet build sdk-roslyn5 (extensionReceiver)
+    workingDirectory: $(Pipeline.Workspace)\integration-tests\sdk-roslyn5
+    condition: eq(variables.currentSdk, 'true')
   - task: MSBuild@1
     displayName: 🧪 MSBuild buildtask-sdk-style
     inputs:

--- a/integration-tests/sdk-roslyn5/app/NativeMethods.json
+++ b/integration-tests/sdk-roslyn5/app/NativeMethods.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "AppPInvokes",
+  "extensionReceiver": "PInvoke",
+  "public": true
+}

--- a/integration-tests/sdk-roslyn5/app/NativeMethods.txt
+++ b/integration-tests/sdk-roslyn5/app/NativeMethods.txt
@@ -1,0 +1,1 @@
+GetForegroundWindow

--- a/integration-tests/sdk-roslyn5/app/Program.cs
+++ b/integration-tests/sdk-roslyn5/app/Program.cs
@@ -1,0 +1,22 @@
+// This test verifies that the Roslyn 5.0 analyzer leg is loaded and the
+// extensionReceiver feature works. The base project generates PInvoke with
+// GetTickCount. This app project uses extensionReceiver to attach
+// GetForegroundWindow as an extension member of the base PInvoke class.
+//
+// If the Roslyn 4.11 leg were loaded instead, PInvoke013 would reject
+// extensionReceiver, GetForegroundWindow would land on AppPInvokes, and
+// the PInvoke.GetForegroundWindow() call below would fail with CS0117.
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        // From the base project (normal generation)
+        PInvoke.GetTickCount();
+
+        // From this project via extensionReceiver (C# 14 extension member)
+        HWND hwnd = PInvoke.GetForegroundWindow();
+    }
+}

--- a/integration-tests/sdk-roslyn5/app/app.csproj
+++ b/integration-tests/sdk-roslyn5/app/app.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <LangVersion>14</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32">
+      <Version>$(NuGetPackageVersion)</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\base\base.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/integration-tests/sdk-roslyn5/app/app.csproj
+++ b/integration-tests/sdk-roslyn5/app/app.csproj
@@ -7,11 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWin32">
-      <Version>$(NuGetPackageVersion)</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="$(NuGetPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.6.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
   </ItemGroup>

--- a/integration-tests/sdk-roslyn5/base/NativeMethods.json
+++ b/integration-tests/sdk-roslyn5/base/NativeMethods.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "public": true
+}

--- a/integration-tests/sdk-roslyn5/base/NativeMethods.txt
+++ b/integration-tests/sdk-roslyn5/base/NativeMethods.txt
@@ -1,0 +1,1 @@
+GetTickCount

--- a/integration-tests/sdk-roslyn5/base/base.csproj
+++ b/integration-tests/sdk-roslyn5/base/base.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <LangVersion>14</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32">
+      <Version>$(NuGetPackageVersion)</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/integration-tests/sdk-roslyn5/sdk-roslyn5.slnx
+++ b/integration-tests/sdk-roslyn5/sdk-roslyn5.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="base/base.csproj" />
+  <Project Path="app/app.csproj" />
+</Solution>

--- a/src/Microsoft.Windows.CsWin32.Roslyn4/Microsoft.Windows.CsWin32.Roslyn4.csproj
+++ b/src/Microsoft.Windows.CsWin32.Roslyn4/Microsoft.Windows.CsWin32.Roslyn4.csproj
@@ -47,7 +47,17 @@
   <ItemGroup>
     <Compile Remove="**\*.cs" />
     <Compile Include="$(CsWin32SharedSourceRoot)**\*.cs" Exclude="$(CsWin32SharedSourceRoot)bin\**\*.cs;$(CsWin32SharedSourceRoot)obj\**\*.cs;$(CsWin32SharedSourceRoot)templates\**\*.cs" />
-    <EmbeddedResource Include="$(CsWin32SharedSourceRoot)templates\**\*.cs" />
+    <!--
+      The templates are embedded resources fetched at runtime by name (see Generator.FetchTemplateText,
+      which looks them up as "{RootNamespace}.templates.{name}.cs"). Because these files live OUTSIDE
+      this project's directory (under the sibling Roslyn 5 project), MSBuild cannot infer the
+      "templates\" subfolder for the manifest resource name and would drop it, producing the wrong
+      name (e.g. "Microsoft.Windows.CsWin32.IVTable.cs" instead of
+      "Microsoft.Windows.CsWin32.templates.IVTable.cs") and making every template lookup fail at
+      runtime (Generator's static constructor throws). Set Link to reproduce the in-project layout so
+      the embedded resource names match the Roslyn 5 leg exactly.
+    -->
+    <EmbeddedResource Include="$(CsWin32SharedSourceRoot)templates\**\*.cs" Link="templates\%(RecursiveDir)%(Filename)%(Extension)" />
     <AdditionalFiles Include="$(CsWin32SharedSourceRoot)BannedSymbols.txt" />
     <AdditionalFiles Include="$(CsWin32SharedSourceRoot)AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="$(CsWin32SharedSourceRoot)AnalyzerReleases.Unshipped.md" />

--- a/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.targets
+++ b/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.targets
@@ -80,7 +80,7 @@
     Name="AddGeneratedCsWin32FilesToCompile"
     AfterTargets="GenerateCsWin32Code"
     Condition="'$(CsWin32RunAsBuildTask)'=='true'">
-    
+
     <ReadLinesFromFile
       File="$(CsWin32GeneratorGeneratedFilesList)"
       Condition="Exists('$(CsWin32GeneratorGeneratedFilesList)')">
@@ -94,5 +94,52 @@
       <FileWrites Include="$(CsWin32GeneratorGeneratedFilesList)" Condition="Exists('$(CsWin32GeneratorGeneratedFilesList)')" />
     </ItemGroup>
 
+  </Target>
+
+  <!--
+    ============================================================================================
+    Drop the Roslyn 5.0 analyzer leg on hosts that do not understand Roslyn component versioning.
+
+    This package ships its source generator twice, following the NuGet "Roslyn component
+    versioning" convention:
+
+        analyzers/dotnet/roslyn4.11/cs/   (floor leg, built against Microsoft.CodeAnalysis 4.11)
+        analyzers/dotnet/roslyn5.0/cs/    (C# 14 'extensionReceiver' leg, Microsoft.CodeAnalysis 5.0)
+
+    The .NET SDK understands this convention: it advertises $(SupportsRoslynComponentVersioning)
+    =='true' and selects exactly one folder that matches the host compiler version. We must not
+    interfere with that, so this target is a no-op for SDK-style projects.
+
+    Hosts that do NOT understand the convention - classic (non-SDK-style) projects, which resolve
+    analyzers via NuGet.BuildTasks' ResolveNuGetPackageAssets - add EVERY analyzer DLL under
+    analyzers/ to @(Analyzer), i.e. BOTH legs. The two Microsoft.Windows.CsWin32.dll copies share
+    an assembly identity but were compiled separately (different MVIDs), so the C# compiler aborts:
+
+        "analyzer assembly '...roslyn5.0...' has MVID 'X' but loaded assembly '...roslyn4.11...'
+         has MVID 'Y'"
+
+    which fails the source generator (CS8785) and leaves every requested Win32 API ungenerated
+    (CS0103). Per the design of this feature (dotnet/sdk#20355, dotnet/sdk#41352) the prescriptive
+    fix is for the package to keep only the LOWEST (floor) Roslyn leg in this case; non-SDK
+    consumers get the floor generator (the C# 14 'extensionReceiver' feature is unavailable there,
+    which is expected - it requires an SDK-style project on a Roslyn 5.0+ toolset anyway).
+
+    We scope the removal to THIS package's own roslyn5.0 directory (resolved relative to this
+    targets file) so we never disturb analyzers contributed by other packages.
+    ============================================================================================
+  -->
+  <Target Name="CsWin32SelectAnalyzerRoslynLeg"
+          BeforeTargets="CoreCompile"
+          Condition="'$(SupportsRoslynComponentVersioning)' != 'true'">
+
+    <PropertyGroup>
+      <_CsWin32Roslyn5LegDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..\analyzers\dotnet\roslyn5.0'))</_CsWin32Roslyn5LegDir>
+      <_CsWin32Roslyn5LegDir>$(_CsWin32Roslyn5LegDir.ToLowerInvariant())</_CsWin32Roslyn5LegDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)"
+                Condition="$([System.String]::new('%(FullPath)').ToLowerInvariant().StartsWith('$(_CsWin32Roslyn5LegDir)'))" />
+    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
﻿## Summary

Closes the integration test gap in PR gates and fixes a regression from #1701.

### 1. Fix Roslyn 4 analyzer embedded resources (regression from #1701)

The `Microsoft.Windows.CsWin32.Roslyn4` sibling project includes template `.cs` files as `EmbeddedResource` from the shared source root. Since these files are outside the project cone, MSBuild dropped the `templates/` directory prefix from the resource names, producing `Microsoft.Windows.CsWin32.PInvokeClassHelperMethods.cs` instead of the expected `Microsoft.Windows.CsWin32.templates.PInvokeClassHelperMethods.cs`.

This caused the `Generator` static constructor to throw `GenerationFailedException: Missing embedded resource`, wrapped in a `TypeInitializationException`, which broke **all** consumers using the Roslyn 4.11 analyzer leg (including non-SDK projects and hosts with Roslyn < 5.0).

**Fix:** Add `Link` metadata to the `EmbeddedResource` items to preserve the `templates\` directory structure in resource names.

### 2. Analyzer leg deduplication for non-SDK projects

Non-SDK projects (and hosts with older NuGet tooling) don't understand the `roslyn{version}` folder convention introduced in NuGet 6.12. They pass ALL analyzer DLLs from ALL sub-folders as `/analyzer` references to csc, which causes both the `roslyn4.11` and `roslyn5.0` source generators to run simultaneously, producing duplicate generated code.

**Fix:** Add an MSBuild target (`_CsWin32DeduplicateAnalyzerLegs`) in the package's `.targets` file that removes the `roslyn4.11` leg when `roslyn5.0` analyzers are also present, ensuring only one source generator instance runs.

### 3. Add integration tests to GitHub Actions PR gate

The integration tests (which pack the nupkg and build test projects against it to validate package structure) were only running in the AzDO outer loop pipeline. This PR adds an `integration-test` job to `.github/workflows/build.yml` that runs on every PR:
- MSBuild non-SDK style (net472)
- MSBuild SDK style
- `dotnet build` SDK style
- MSBuild buildtask-SDK style
- `dotnet publish` buildtask-SDK style

The `validate` gate job now also requires the integration tests to pass.