### PR TITLE
Fix CsWin32 analyzer load failure in non-SDK projects

### DIFF
--- a/src/Microsoft.Windows.CsWin32.Roslyn4/Microsoft.Windows.CsWin32.Roslyn4.csproj
+++ b/src/Microsoft.Windows.CsWin32.Roslyn4/Microsoft.Windows.CsWin32.Roslyn4.csproj
@@ -47,7 +47,17 @@
   <ItemGroup>
     <Compile Remove="**\*.cs" />
     <Compile Include="$(CsWin32SharedSourceRoot)**\*.cs" Exclude="$(CsWin32SharedSourceRoot)bin\**\*.cs;$(CsWin32SharedSourceRoot)obj\**\*.cs;$(CsWin32SharedSourceRoot)templates\**\*.cs" />
-    <EmbeddedResource Include="$(CsWin32SharedSourceRoot)templates\**\*.cs" />
+    <!--
+      The templates are embedded resources fetched at runtime by name (see Generator.FetchTemplateText,
+      which looks them up as "{RootNamespace}.templates.{name}.cs"). Because these files live OUTSIDE
+      this project's directory (under the sibling Roslyn 5 project), MSBuild cannot infer the
+      "templates\" subfolder for the manifest resource name and would drop it, producing the wrong
+      name (e.g. "Microsoft.Windows.CsWin32.IVTable.cs" instead of
+      "Microsoft.Windows.CsWin32.templates.IVTable.cs") and making every template lookup fail at
+      runtime (Generator's static constructor throws). Set Link to reproduce the in-project layout so
+      the embedded resource names match the Roslyn 5 leg exactly.
+    -->
+    <EmbeddedResource Include="$(CsWin32SharedSourceRoot)templates\**\*.cs" Link="templates\%(RecursiveDir)%(Filename)%(Extension)" />
     <AdditionalFiles Include="$(CsWin32SharedSourceRoot)BannedSymbols.txt" />
     <AdditionalFiles Include="$(CsWin32SharedSourceRoot)AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="$(CsWin32SharedSourceRoot)AnalyzerReleases.Unshipped.md" />

--- a/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.targets
+++ b/src/Microsoft.Windows.CsWin32/build/Microsoft.Windows.CsWin32.targets
@@ -80,7 +80,7 @@
     Name="AddGeneratedCsWin32FilesToCompile"
     AfterTargets="GenerateCsWin32Code"
     Condition="'$(CsWin32RunAsBuildTask)'=='true'">
-    
+
     <ReadLinesFromFile
       File="$(CsWin32GeneratorGeneratedFilesList)"
       Condition="Exists('$(CsWin32GeneratorGeneratedFilesList)')">
@@ -94,5 +94,52 @@
       <FileWrites Include="$(CsWin32GeneratorGeneratedFilesList)" Condition="Exists('$(CsWin32GeneratorGeneratedFilesList)')" />
     </ItemGroup>
 
+  </Target>
+
+  <!--
+    ============================================================================================
+    Drop the Roslyn 5.0 analyzer leg on hosts that do not understand Roslyn component versioning.
+
+    This package ships its source generator twice, following the NuGet "Roslyn component
+    versioning" convention:
+
+        analyzers/dotnet/roslyn4.11/cs/   (floor leg, built against Microsoft.CodeAnalysis 4.11)
+        analyzers/dotnet/roslyn5.0/cs/    (C# 14 'extensionReceiver' leg, Microsoft.CodeAnalysis 5.0)
+
+    The .NET SDK understands this convention: it advertises $(SupportsRoslynComponentVersioning)
+    =='true' and selects exactly one folder that matches the host compiler version. We must not
+    interfere with that, so this target is a no-op for SDK-style projects.
+
+    Hosts that do NOT understand the convention - classic (non-SDK-style) projects, which resolve
+    analyzers via NuGet.BuildTasks' ResolveNuGetPackageAssets - add EVERY analyzer DLL under
+    analyzers/ to @(Analyzer), i.e. BOTH legs. The two Microsoft.Windows.CsWin32.dll copies share
+    an assembly identity but were compiled separately (different MVIDs), so the C# compiler aborts:
+
+        "analyzer assembly '...roslyn5.0...' has MVID 'X' but loaded assembly '...roslyn4.11...'
+         has MVID 'Y'"
+
+    which fails the source generator (CS8785) and leaves every requested Win32 API ungenerated
+    (CS0103). Per the design of this feature (dotnet/sdk#20355, dotnet/sdk#41352) the prescriptive
+    fix is for the package to keep only the LOWEST (floor) Roslyn leg in this case; non-SDK
+    consumers get the floor generator (the C# 14 'extensionReceiver' feature is unavailable there,
+    which is expected - it requires an SDK-style project on a Roslyn 5.0+ toolset anyway).
+
+    We scope the removal to THIS package's own roslyn5.0 directory (resolved relative to this
+    targets file) so we never disturb analyzers contributed by other packages.
+    ============================================================================================
+  -->
+  <Target Name="CsWin32SelectAnalyzerRoslynLeg"
+          BeforeTargets="CoreCompile"
+          Condition="'$(SupportsRoslynComponentVersioning)' != 'true'">
+
+    <PropertyGroup>
+      <_CsWin32Roslyn5LegDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..\analyzers\dotnet\roslyn5.0'))</_CsWin32Roslyn5LegDir>
+      <_CsWin32Roslyn5LegDir>$(_CsWin32Roslyn5LegDir.ToLowerInvariant())</_CsWin32Roslyn5LegDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)"
+                Condition="$([System.String]::new('%(FullPath)').ToLowerInvariant().StartsWith('$(_CsWin32Roslyn5LegDir)'))" />
+    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
## Problem

The `Integration tests vs2022 / 🧪 MSBuild non-sdk style` CI leg started failing on `main` after #1701 ([build 0.3.283](https://dev.azure.com/azure-public/winsdk/_build/results?buildId=23622)):

```
CompilerServer: server failed - server rejected the request due to analyzer / generator issues
'analyzer assembly '...\roslyn5.0\cs\Microsoft.Windows.CsWin32.dll' has MVID '201d21f9-…'
 but loaded assembly '...\roslyn4.11\cs\Microsoft.Windows.CsWin32.dll' has MVID '63ca795c-…''
→ CS8785 (Generator 'SourceGenerator' failed … TypeInitializationException)
→ Program.cs(5,9): error CS0103: The name 'Windows' does not exist in the current context
```

#1701 began shipping the source generator as two Roslyn-versioned analyzer legs:

```
analyzers/dotnet/roslyn4.11/cs/   (floor leg, Microsoft.CodeAnalysis 4.11)
analyzers/dotnet/roslyn5.0/cs/    (C# 14 'extensionReceiver' leg, Microsoft.CodeAnalysis 5.0)
```

The `analyzers/dotnet/roslynX.Y/` convention is **only** understood by the .NET SDK, which selects a single leg and advertises `$(SupportsRoslynComponentVersioning)=='true'`. Classic (non-SDK-style) projects resolve analyzers through NuGet.BuildTasks' `ResolveNuGetPackageAssets`, which loads **both** legs. The two `Microsoft.Windows.CsWin32.dll` copies share an assembly identity but were compiled separately (different MVIDs), so `csc` shuts the compiler server down and no APIs are generated.

This is the exact scenario described in [dotnet/sdk#20355](https://github.com/dotnet/sdk/issues/20355) (the multi-targeting design, by `@eerhardt`) and [dotnet/sdk#41352](https://github.com/dotnet/sdk/issues/41352) (same MVID symptom, confirmed by `@jaredpar`/`@baronfel`). The prescriptive fallback is for the package to keep only the **lowest (floor)** Roslyn leg when the host doesn't support component versioning.

## Fixes

**1. `build/Microsoft.Windows.CsWin32.targets`** — add a `CsWin32SelectAnalyzerRoslynLeg` target (`BeforeTargets="CoreCompile"`) that, when `$(SupportsRoslynComponentVersioning) != 'true'`, removes this package's `roslyn5.0` leg from `@(Analyzer)`, leaving only the floor leg. The removal is scoped to this package's own analyzer directory so other packages' analyzers are never touched. SDK-style projects are unaffected (the SDK still selects the right leg). Non-SDK consumers get the floor generator; the C# 14 `extensionReceiver` feature remains SDK-only, as intended.

**2. `Microsoft.Windows.CsWin32.Roslyn4.csproj`** — the floor leg embeds the templates from the sibling project's directory, so MSBuild dropped the `templates` segment from the manifest resource names (e.g. `Microsoft.Windows.CsWin32.IVTable.cs` instead of `Microsoft.Windows.CsWin32.templates.IVTable.cs`). `Generator.FetchTemplateText` then found nothing and the static constructor threw — so the floor leg had **never** worked. Add `Link` metadata to reproduce the in-project layout so the embedded resource names match the Roslyn 5 leg.

## Validation

Packed locally and built both integration projects with full `MSBuild.exe` in a clean environment (no node reuse, no shared compilation, fresh global-packages folder):

- ✅ non-SDK build now loads only the `roslyn4.11` floor leg and **succeeds** (was failing)
- ✅ SDK-style build continues to select the `roslyn5.0` leg
- ✅ rebuilt floor leg exposes correctly-named template resources (`…templates.IVTable.cs`)
