### PR TITLE
Run COM runtime tests on GitHub Actions windows-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,43 @@ jobs:
         path: TestResults/
         retention-days: 5
 
+  test-hardware-windows:
+    name: 🧪 Tests (Windows, Hardware)
+    needs: build
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: ⚙️ Install prerequisites
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      shell: pwsh
+    - name: 📦 Download build
+      uses: actions/download-artifact@v4
+      with:
+        name: build-windows
+        path: bin/
+    # GitHub-hosted windows-latest runners can execute these COM/Direct2D/WMI/Shell runtime
+    # tests (Direct2D uses the WARP software rasterizer, so no GPU is required). They remain
+    # tagged RequiresHardware so the locked-down Azure DevOps 1ES build pool keeps excluding
+    # them, but we exercise the real runtime code paths here rather than only on dev machines.
+    - name: 🧪 Run hardware-dependent tests
+      run: |
+        dotnet test --no-build -c ${{ env.BuildConfiguration }} `
+          --filter "TestCategory=RequiresHardware" `
+          --blame-hang-timeout 600s `
+          --blame-crash `
+          --logger trx `
+          --results-directory TestResults
+      shell: pwsh
+    - name: 📢 Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results-hardware-windows
+        path: TestResults/
+        retention-days: 5
+
   test-fast-linux:
     name: 🧪 Tests (Linux)
     runs-on: ubuntu-latest
@@ -242,18 +279,20 @@ jobs:
   validate:
     name: ✅ Validate
     if: always()
-    needs: [build, test-fast-windows, test-fast-linux, test-heavy, integration-test]
+    needs: [build, test-fast-windows, test-hardware-windows, test-fast-linux, test-heavy, integration-test]
     runs-on: ubuntu-latest
     steps:
     - name: Check results
       run: |
         echo "Build: ${{ needs.build.result }}"
         echo "Windows tests: ${{ needs.test-fast-windows.result }}"
+        echo "Windows hardware tests: ${{ needs.test-hardware-windows.result }}"
         echo "Linux tests: ${{ needs.test-fast-linux.result }}"
         echo "Heavy tests: ${{ needs.test-heavy.result }}"
         echo "Integration tests: ${{ needs.integration-test.result }}"
         if [[ "${{ needs.build.result }}" != "success" ||
               "${{ needs.test-fast-windows.result }}" != "success" ||
+              "${{ needs.test-hardware-windows.result }}" != "success" ||
               "${{ needs.test-fast-linux.result }}" != "success" ||
               "${{ needs.test-heavy.result }}" != "success" ||
               "${{ needs.integration-test.result }}" != "success" ]]; then

--- a/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/COMTests.cs
@@ -132,7 +132,7 @@ public partial class COMTests(ITestOutputHelper outputHelper)
 
 
     [Fact]
-    [Trait("TestCategory", "RequiresHardware")] // D3D APIs fail in cloud VMs
+    [Trait("TestCategory", "RequiresHardware")] // Excluded from the locked-down ADO 1ES build pool; runs on GitHub Actions (Direct2D uses WARP).
     public void ReturnValueMarshalsCorrectly()
     {
         // Create an ID2D1HwndRenderTarget and verify GetHwnd returns the original HWND.
@@ -188,7 +188,9 @@ public partial class COMTests(ITestOutputHelper outputHelper)
         // 3. Prepare render target properties.
         D2D1_RENDER_TARGET_PROPERTIES rtProps = new()
         {
-            type = D2D1_RENDER_TARGET_TYPE.D2D1_RENDER_TARGET_TYPE_DEFAULT,
+            // Use WARP (software) rendering so this exercises the same D2D render-target
+            // creation and HWND marshaling code paths on GPU-less CI VMs without a hardware GPU.
+            type = D2D1_RENDER_TARGET_TYPE.D2D1_RENDER_TARGET_TYPE_SOFTWARE,
             pixelFormat = new D2D1_PIXEL_FORMAT
             {
                 format = DXGI_FORMAT.DXGI_FORMAT_UNKNOWN,
@@ -224,7 +226,7 @@ public partial class COMTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "RequiresHardware")] // WMI APIs don't work in cloud VMs.
+    [Trait("TestCategory", "RequiresHardware")] // Excluded from the locked-down ADO 1ES build pool; runs on GitHub Actions.
     public void IWbemServices_GetObject_Works()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");

--- a/test/GenerationSandbox.Tests/ComRuntimeTests.cs
+++ b/test/GenerationSandbox.Tests/ComRuntimeTests.cs
@@ -35,7 +35,7 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "RequiresHardware")] // D3D APIs fail in cloud VMs
+    [Trait("TestCategory", "RequiresHardware")] // Excluded from the locked-down ADO 1ES build pool; runs on GitHub Actions (Direct2D uses WARP).
     public void ReturnValueMarshalsCorrectly()
     {
         // Create an ID2D1HwndRenderTarget and verify GetHwnd returns the original HWND.
@@ -90,7 +90,9 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
         // 3. Prepare render target properties.
         D2D1_RENDER_TARGET_PROPERTIES rtProps = new()
         {
-            type = D2D1_RENDER_TARGET_TYPE.D2D1_RENDER_TARGET_TYPE_DEFAULT,
+            // Use WARP (software) rendering so this exercises the same D2D render-target
+            // creation and HWND marshaling code paths on GPU-less CI VMs without a hardware GPU.
+            type = D2D1_RENDER_TARGET_TYPE.D2D1_RENDER_TARGET_TYPE_SOFTWARE,
             pixelFormat = new D2D1_PIXEL_FORMAT
             {
                 format = DXGI_FORMAT.DXGI_FORMAT_UNKNOWN,
@@ -126,7 +128,7 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "RequiresHardware")] // WMI APIs don't work in cloud VMs.
+    [Trait("TestCategory", "RequiresHardware")] // Excluded from the locked-down ADO 1ES build pool; runs on GitHub Actions.
     public void IWbemServices_GetObject_Works()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
@@ -161,7 +163,7 @@ public class ComRuntimeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [Trait("TestCategory", "RequiresHardware")] // WMI APIs don't work in cloud VMs.
+    [Trait("TestCategory", "RequiresHardware")] // Needs Shell/Explorer COM; excluded from the locked-down ADO 1ES build pool, runs on GitHub Actions.
     public void CanCallIDispatchOnlyMethods()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");

--- a/test/GenerationSandbox.Unmarshalled.Tests/COMTests.cs
+++ b/test/GenerationSandbox.Unmarshalled.Tests/COMTests.cs
@@ -43,7 +43,7 @@ public class COMTests
 #endif
 
     [Fact]
-    [Trait("TestCategory", "RequiresHardware")] // D3D APIs fail in cloud VMs
+    [Trait("TestCategory", "RequiresHardware")] // Excluded from the locked-down ADO 1ES build pool; runs on GitHub Actions (Direct2D uses WARP).
     public unsafe void ReturnValueMarshalsCorrectly()
     {
         // Create an ID2D1HwndRenderTarget and verify GetHwnd returns the original HWND.
@@ -78,7 +78,9 @@ public class COMTests
         // 3. Prepare render target properties.
         D2D1_RENDER_TARGET_PROPERTIES rtProps = new()
         {
-            type = D2D1_RENDER_TARGET_TYPE.D2D1_RENDER_TARGET_TYPE_DEFAULT,
+            // Use WARP (software) rendering so this exercises the same D2D render-target
+            // creation and HWND marshaling code paths on GPU-less CI VMs without a hardware GPU.
+            type = D2D1_RENDER_TARGET_TYPE.D2D1_RENDER_TARGET_TYPE_SOFTWARE,
             pixelFormat = new D2D1_PIXEL_FORMAT
             {
                 format = DXGI_FORMAT.DXGI_FORMAT_UNKNOWN,


### PR DESCRIPTION
﻿## Summary

The COM/Direct2D/WMI/Shell **runtime** tests were tagged `RequiresHardware` (formerly `FailsInCloudTest`) and excluded from **all** CI. That meant we only ever verified that the generated projection *compiled* — never that it actually *works at runtime* through the .NET / source-generated COM marshalers. This PR makes those tests run on GitHub Actions.

## Root cause (why they were excluded)

Archeology shows the original failures were on the **locked-down Azure DevOps 1ES build pool** (microbuild agents) — first disabled in 2024 (`7e10c766` "Disable test that fails on microbuild agents"), then carried forward defensively. Those agents lack:
- an interactive desktop session (Shell/Explorer COM servers)
- a GPU (`D2D1_RENDER_TARGET_TYPE_DEFAULT`)
- some WMI providers (Defender namespace)

GitHub-hosted `windows-latest` runners do **not** have those limitations. Empirically, all 14 tests run and pass there (`Skipped: 0`).

## Changes

- **New gating `test-hardware-windows` job** runs the `RequiresHardware` tests on `windows-latest` and is wired into the required `validate` check — so PRs now exercise the real runtime code paths.
- **Keep the `RequiresHardware` trait** so the Azure DevOps 1ES pool (`dotnet-test-cloud.ps1`) continues to exclude these tests (per maintainer guidance — it's fine for the DevDiv outer loop to keep skipping them).
- **Direct2D tests use WARP** (`D2D1_RENDER_TARGET_TYPE_SOFTWARE`) — same render-target creation + HWND marshaling code paths, no hardware GPU required.
- **No graceful `Assert.Skip` fallbacks** — if a test regresses or the environment changes, the job fails loudly instead of silently skipping. (This reverts the earlier fallback approach.)
- **Fix misleading trait comments**, including a copy-paste `// WMI APIs don't work in cloud VMs.` comment on `CanCallIDispatchOnlyMethods` (a Shell-only test, not WMI).

## Tests now exercised in CI

| Test | What it validates at runtime |
|------|------------------------------|
| `ReturnValueMarshalsCorrectly` ×3 | D2D struct-return marshaling (via WARP) |
| `IWbemServices_GetObject_Works` ×2 | optional out-interface args (WMI) |
| `CanCallINetFwMgrApis` ×2 | IDispatch/variant marshaling (Firewall) |
| `CanCallIDispatchOnlyMethods` | IDispatch property returns (Shell) |
| `RemotableInterface` | non-remotable COM pointer overloads (Shell) |
| `CanCallPnPAPIs` | SetupDi span/out overloads |
| `IShellItem_BindToHandler_IStream_ReadWorks` ×2 | inherited-interface friendly overloads (#1716) |
| `IShellItem_BindToHandler_GenericOverload`, `SHCreateItemFromParsingName_GenericOverload` | IID_PPV_ARGS generic overloads at runtime |

## Validation

- All 14 tests pass locally and on GitHub Actions `windows-latest` (`Skipped: 0`).
- The Azure DevOps 1ES loop (incl. DevDiv `CsWin32 unofficial` #25100) continues to exclude them via the existing `RequiresHardware` filter, so the official build stays green.