### PR TITLE
Disable Azure Pipelines PR validation (PR testing moved to GitHub Actions)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,12 @@ trigger:
     - .github/
     - azure-pipelines/release.yml
 
+# PR validation has moved to GitHub Actions (.github/workflows/build.yml), which runs more
+# of the test matrix and works on forks. Disable Azure Pipelines PR validation so it no longer
+# queues a build or posts a status check on GitHub pull requests. CI on the branches above and
+# release builds continue to run.
+pr: none
+
 parameters:
 - name: EnableMacOSBuild
   displayName: Build on macOS


### PR DESCRIPTION
﻿## Summary

The `azure-public` **`microsoft.CsWin32`** pipeline (`azure-pipelines.yml`) has a `trigger:` (CI) block but **no `pr:` block**. For GitHub-backed YAML pipelines, Azure DevOps **enables PR validation by default when `pr:` is omitted**, so it keeps queuing a build and posting a `microsoft.CsWin32` status check on every pull request.

PR testing has moved to **GitHub Actions** (`.github/workflows/build.yml`), which runs more of the test matrix and works on forks. This sets **`pr: none`** so the Azure Pipelines pipeline no longer builds PRs.

## Effect

- ❌ No more Azure Pipelines PR builds / status checks on GitHub PRs.
- ✅ CI on `main`, `v*.*`, and `validate/*` is unchanged (the `trigger:` block above is untouched).
- ✅ Official/release/VS-insertion builds are unaffected.

## Note on timing

Azure DevOps evaluates PR triggers from the YAML in the **target branch (`main`)**, so `pr: none` takes effect for PRs opened **after** this merges. To silence in-flight PRs immediately, disable PR validation in the pipeline's **Triggers** UI (Override the YAML pull request trigger from here → Disable pull request validation).