### PR TITLE
Fix PreserveSig COM source generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,8 +177,11 @@ jobs:
           - name: FullGen-Net9-Ptrs
             filter: "TestCategory=HighMemory&TestShard=FullGen-Net9-Ptrs"
             threads: "1"
+          - name: FullGen-Net10-PreserveSig
+            filter: "TestCategory=HighMemory&TestShard=FullGen-Net10-PreserveSig"
+            threads: "1"
           - name: Default
-            filter: "TestCategory=HighMemory&TestShard!=FastMethods&TestShard!=EverythingModern&TestShard!=EverythingLegacy&TestShard!=FullGen-Net8&TestShard!=FullGen-Net9&TestShard!=FullGen-Net9-Ptrs"
+            filter: "TestCategory=HighMemory&TestShard!=FastMethods&TestShard!=EverythingModern&TestShard!=EverythingLegacy&TestShard!=FullGen-Net8&TestShard!=FullGen-Net9&TestShard!=FullGen-Net9-Ptrs&TestShard!=FullGen-Net10-PreserveSig"
             threads: "1"
     steps:
     - uses: actions/checkout@v4

--- a/src/Microsoft.Windows.CsWin32/Generator.Com.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Com.cs
@@ -279,6 +279,7 @@ public partial class Generator
 
             ParameterListSyntax parameterList = methodDefinition.Generator.CreateParameterList(methodDefinition.Method, signature, typeSettings, GeneratingElement.InterfaceAsStructMember);
             ParameterListSyntax parameterListPreserveSig = parameterList; // preserve a copy that has no mutations.
+            bool preserveSig = methodDefinition.Generator.UsePreserveSigForComMethod(methodDefinition.Method, signature, ifaceName.Identifier.ValueText, methodName) || emulateMemberFunctionCallConv;
             bool requiresMarshaling = parameterList.Parameters.Any(p => p.AttributeLists.SelectMany(al => al.Attributes).Any(a => a.Name is IdentifierNameSyntax { Identifier.ValueText: "MarshalAs" }) || p.Modifiers.Any(SyntaxKind.RefKeyword) || p.Modifiers.Any(SyntaxKind.OutKeyword) || p.Modifiers.Any(SyntaxKind.InKeyword));
             FunctionPointerParameterListSyntax funcPtrParameters = FunctionPointerParameterList(FunctionPointerParameter(PointerType(ifaceName)))
                 .AddParameters(emulateMemberFunctionCallConv ? [FunctionPointerParameter(PointerType(returnType))] : [])
@@ -328,8 +329,9 @@ public partial class Generator
                     ArgumentSyntax arg;
 
                     // Can't use "out" or "ref" with runtime marshaling disabled. We're in an unsafe context so just use fixed + pointers like friendly overloads.
-                    // Only do this for parameters, not the parameter that will be moved to the return value.
-                    if ((p.Modifiers.Any(SyntaxKind.OutKeyword) || p.Modifiers.Any(SyntaxKind.RefKeyword)) && !p.HasAnnotation(IsRetValAnnotation))
+                    // Skip a RetVal parameter only when it will actually be moved to the managed return value.
+                    bool willMoveToReturnValue = p.HasAnnotation(IsRetValAnnotation) && !preserveSig;
+                    if ((p.Modifiers.Any(SyntaxKind.OutKeyword) || p.Modifiers.Any(SyntaxKind.RefKeyword)) && !willMoveToReturnValue)
                     {
                         string origName = p.Identifier.ValueText;
                         IdentifierNameSyntax localName = IdentifierName(origName + "Local");
@@ -431,7 +433,6 @@ public partial class Generator
                         [VariableDeclarator(emulatedMemberFunctionCallConvReturnLocal!.Identifier).WithInitializer(EqualsValueClause(DefaultExpression(returnType)))]));
                 }
 
-                bool preserveSig = methodDefinition.Generator.UsePreserveSigForComMethod(methodDefinition.Method, signature, ifaceName.Identifier.ValueText, methodName) || emulateMemberFunctionCallConv;
                 if (preserveSig)
                 {
                     if (emulateMemberFunctionCallConv)
@@ -954,6 +955,11 @@ public partial class Generator
                     ParameterListSyntax? parameterList = methodDefinition.Generator.CreateParameterList(methodDefinition.Method, signature, functionSignatureSettings, GeneratingElement.InterfaceMember);
 
                     bool preserveSig = interfaceAsSubtype || this.UsePreserveSigForComMethod(methodDefinition.Method, signature, actualIfaceName, methodName) || emulateMemberFunctionCallConv;
+                    if (this.useSourceGenerators && preserveSig && IsHresult(signature.ReturnType))
+                    {
+                        parameterList = this.RenameRetValParametersForComSourceGenerator(parameterList);
+                    }
+
                     if (!preserveSig)
                     {
                         ParameterSyntax? lastParameter = parameterList.Parameters.Count > 0 ? parameterList.Parameters[parameterList.Parameters.Count - 1] : null;
@@ -1255,6 +1261,32 @@ public partial class Generator
         }
 
         return (members, baseTypes);
+    }
+
+    private ParameterListSyntax RenameRetValParametersForComSourceGenerator(ParameterListSyntax parameterList)
+    {
+        SeparatedSyntaxList<ParameterSyntax> parameters = parameterList.Parameters;
+        var parameterNames = new HashSet<string>(parameters.Select(parameter => parameter.Identifier.ValueText), StringComparer.Ordinal);
+        foreach (ParameterSyntax parameter in parameters)
+        {
+            if (parameter.Identifier.ValueText == "retVal" &&
+                (parameter.Modifiers.Any(SyntaxKind.OutKeyword) || parameter.Modifiers.Any(SyntaxKind.RefKeyword) || parameter.Modifiers.Any(SyntaxKind.InKeyword)))
+            {
+                // ComInterfaceGenerator uses __retVal_native for a custom-marshaled return and for a parameter named retVal.
+                string replacementName = "retValParameter";
+                while (!parameterNames.Add(replacementName))
+                {
+                    replacementName += "_";
+                }
+
+                SyntaxToken replacementIdentifier = Identifier(replacementName)
+                    .WithLeadingTrivia(parameter.Identifier.LeadingTrivia)
+                    .WithTrailingTrivia(parameter.Identifier.TrailingTrivia);
+                parameters = parameters.Replace(parameter, parameter.WithIdentifier(replacementIdentifier));
+            }
+        }
+
+        return parameterList.WithParameters(parameters);
     }
 
     private bool UsePreserveSigForComMethod(MethodDefinition methodDefinition, MethodSignature<TypeHandleInfo> signature, string ifaceName, string methodName)

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorFullTests.cs
@@ -48,4 +48,16 @@ public partial class CsWin32GeneratorFullTests : CsWin32GeneratorTestsBase
         this.nativeMethodsJson = "NativeMethods.IncludePointerOverloads.json";
         await this.InvokeGeneratorAndCompile("FullGeneration_net9.0_CSharp13_pointers", TestOptions.None);
     }
+
+    [Fact]
+    [Trait("TestCategory", "HighMemory")]
+    [Trait("TestShard", "FullGen-Net10-PreserveSig")]
+    public async Task FullGeneration_Net10_PreserveSig()
+    {
+        this.fullGeneration = true;
+        this.compilation = this.starterCompilations["net10.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(LanguageVersion.CSharp14);
+        this.nativeMethodsJson = "NativeMethods.PreserveSig.json";
+        await this.InvokeGeneratorAndCompile("FullGeneration_net10.0_CSharp14_preserveSig", TestOptions.None);
+    }
 }

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -38,6 +38,22 @@ public partial class CsWin32GeneratorTests : CsWin32GeneratorTestsBase
     }
 
     [Fact]
+    public async Task PreserveSigRetValParametersCompileWithComSourceGenerators()
+    {
+        this.compilation = this.starterCompilations["net10.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(LanguageVersion.CSharp14);
+        this.nativeMethodsJson = "NativeMethods.PreserveSig.json";
+        this.nativeMethods.Add("IUIAutomationScrollPattern");
+        await this.InvokeGeneratorAndCompileFromFact();
+
+        IEnumerable<MethodDeclarationSyntax> methods = this.FindGeneratedType("IUIAutomationScrollPattern")
+            .OfType<InterfaceDeclarationSyntax>()
+            .SelectMany(type => type.Members.OfType<MethodDeclarationSyntax>());
+        MethodDeclarationSyntax method = Assert.Single(methods, method => method.Identifier.ValueText == "get_CurrentHorizontalScrollPercent");
+        Assert.Equal("retValParameter", Assert.Single(method.ParameterList.Parameters).Identifier.ValueText);
+    }
+
+    [Fact]
     public async Task TestGenerateIDispatch()
     {
         // IDispatch is not normally emitted, but we need it for source generated com so check that it got generated.

--- a/test/CsWin32Generator.Tests/TestContent/NativeMethods.PreserveSig.json
+++ b/test/CsWin32Generator.Tests/TestContent/NativeMethods.PreserveSig.json
@@ -1,0 +1,14 @@
+﻿{
+  "$schema": "..\\..\\..\\src\\Microsoft.Windows.CsWin32\\settings.schema.json",
+  "allowMarshaling": true,
+  "emitSingleFile": true,
+  "comInterop": {
+    "preserveSigMethods": [
+      "*"
+    ],
+    "useComSourceGenerators": true
+  },
+  "friendlyOverloads": {
+    "enabled": true
+  }
+}

--- a/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
@@ -20,6 +20,29 @@ public class COMTests : GeneratorTestBase
         Assert.Contains(this.FindGeneratedMethod("Next"), m => m.ParameterList.Parameters.Count == 3 && m.ParameterList.Parameters[0].Modifiers.Any(SyntaxKind.ThisKeyword));
     }
 
+    [Fact]
+    public void PreserveSigRetValParametersInUnmanagedComWrappersCompile()
+    {
+        this.compilation = this.starterCompilations["net10.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(LanguageVersion.CSharp14);
+        this.generator = this.CreateGenerator(new GeneratorOptions
+        {
+            AllowMarshaling = true,
+            ComInterop = new()
+            {
+                PreserveSigMethods = ["*"],
+                UseComSourceGenerators = true,
+            },
+        });
+
+        Assert.True(this.generator.TryGenerate("LPFNACCESSIBLECHILDREN", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+        this.AssertNoDiagnostics(
+            this.compilation,
+            logAllGeneratedCode: false,
+            acceptable: d => d.Id is "CS8795" or "CS1574");
+    }
+
     [Theory]
     [InlineData("IHTMLDocument")]
     [InlineData("IHTMLDocument2")]


### PR DESCRIPTION
﻿## Summary
- fix preserved `[RetVal]` parameters in unmanaged COM wrappers so vtable calls receive pointers
- avoid the .NET COM source generator's `__retVal_native` collision by renaming by-ref `retVal` parameters on preserved HRESULT interfaces
- add focused regressions plus a `net10.0` PreserveSig full-generation test and dedicated CI shard

## Validation
- observed 2,898 unique compiler errors in the new full-generation test before the fixes
- `dotnet build -t:build,pack -c Release -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904`
- non-high-memory Release test suite
- `FullGeneration_Net10_PreserveSig`

Fixes #1745