### PR TITLE
Consolidate dependency updates and protect analyzer compatibility

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "nbgv": {
-      "version": "3.9.50",
+      "version": "3.10.91",
       "commands": [
         "nbgv"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -31,7 +31,7 @@
       "rollForward": false
     },
     "nerdbank.dotnetrepotools": {
-      "version": "1.0.92",
+      "version": "1.5.15",
       "commands": [
         "repo"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.5.4",
+      "version": "7.6.4",
       "commands": [
         "pwsh"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.1.0",
+      "version": "18.9.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,11 @@
 		"github>microsoft/vs-renovate-presets:microbuild",
 		"github>microsoft/vs-renovate-presets:vs_main_dependencies"
 	],
+	"prConcurrentLimit": 1,
+	"prHourlyLimit": 1,
+	"prCreation": "not-pending",
+	"separateMajorMinor": false,
+	"separateMultipleMajor": false,
 	"packageRules": [
 		{
 			"matchPackageNames": ["MessagePack", "MessagePackAnalyzer"],
@@ -12,6 +17,11 @@
 		{
 			"matchFileNames": ["Directory.Packages.Analyzers.props"],
 			"enabled": false
+		},
+		{
+			"matchPackageNames": ["*"],
+			"groupName": "dependency updates",
+			"groupSlug": "dependency-updates"
 		}
 	]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,6 @@
 		"github>microsoft/vs-renovate-presets:microbuild",
 		"github>microsoft/vs-renovate-presets:vs_main_dependencies"
 	],
-	"prConcurrentLimit": 1,
-	"prHourlyLimit": 1,
-	"prCreation": "not-pending",
 	"packageRules": [
 		{
 			"matchPackageNames": ["MessagePack", "MessagePackAnalyzer"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,8 +7,6 @@
 	"prConcurrentLimit": 1,
 	"prHourlyLimit": 1,
 	"prCreation": "not-pending",
-	"separateMajorMinor": false,
-	"separateMultipleMajor": false,
 	"packageRules": [
 		{
 			"matchPackageNames": ["MessagePack", "MessagePackAnalyzer"],
@@ -17,11 +15,6 @@
 		{
 			"matchFileNames": ["Directory.Packages.Analyzers.props"],
 			"enabled": false
-		},
-		{
-			"matchPackageNames": ["*"],
-			"groupName": "dependency updates",
-			"groupSlug": "dependency-updates"
 		}
 	]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
   integration-test:
     name: 🧪 Integration tests
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     name: 🛠️ Build
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
@@ -47,7 +47,7 @@ jobs:
     needs: build
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
@@ -80,7 +80,7 @@ jobs:
     needs: build
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
@@ -116,7 +116,7 @@ jobs:
     name: 🧪 Tests (Linux)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
@@ -184,7 +184,7 @@ jobs:
             filter: "TestCategory=HighMemory&TestShard!=FastMethods&TestShard!=EverythingModern&TestShard!=EverythingLegacy&TestShard!=FullGen-Net8&TestShard!=FullGen-Net9&TestShard!=FullGen-Net9-Ptrs&TestShard!=FullGen-Net10-PreserveSig"
             threads: "1"
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
@@ -227,7 +227,7 @@ jobs:
     needs: build
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 1
     - name: ⚙️ Install prerequisites

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,26 +234,11 @@ jobs:
       run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
       shell: pwsh
     - name: ⚙️ Install compatibility SDKs
-      run: |
-        $dotnet8Root = Join-Path $env:RUNNER_TEMP dotnet8
-        & ./obj/tools/dotnet-install.ps1 -Version 8.0.423 -InstallDir $dotnet8Root -NoPath
-        if ($LASTEXITCODE -ne 0) {
-          exit $LASTEXITCODE
-        }
-
-        $dotnet9Root = Join-Path $env:RUNNER_TEMP dotnet9
-        & ./obj/tools/dotnet-install.ps1 -Version 9.0.316 -InstallDir $dotnet9Root -NoPath
-        if ($LASTEXITCODE -ne 0) {
-          exit $LASTEXITCODE
-        }
-
-        $dotnet8Path = Join-Path $dotnet8Root dotnet.exe
-        $dotnet9Path = Join-Path $dotnet9Root dotnet.exe
-        Add-Content -Path $env:GITHUB_ENV -Value "DOTNET8_PATH=$dotnet8Path"
-        Add-Content -Path $env:GITHUB_ENV -Value "DOTNET9_PATH=$dotnet9Path"
-        & $dotnet8Path --version
-        & $dotnet9Path --version
-      shell: pwsh
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        dotnet-version: |
+          8.0.423
+          9.0.316
     - name: 📦 Download build
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -298,13 +283,13 @@ jobs:
     - name: 🧪 VS 2022 MSBuild sdk-style
       run: |
         $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version '[17.0,18.0)' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
-        $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = Split-Path -Parent $env:DOTNET8_PATH
+        $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = Split-Path -Parent (Get-Command dotnet).Source
         & $msbuild "${{ runner.temp }}\integration-tests\sdk\sdk.csproj" /r
       shell: pwsh
     - name: 🧪 dotnet build SDK 8 analyzer floor
       run: |
         $buildLog = Join-Path $env:RUNNER_TEMP sdk8-build.log
-        & $env:DOTNET8_PATH build --nologo --verbosity diagnostic *> $buildLog
+        dotnet build --nologo --verbosity diagnostic *> $buildLog
         $buildExitCode = $LASTEXITCODE
         if ($buildExitCode -ne 0) {
           Get-Content $buildLog
@@ -320,7 +305,7 @@ jobs:
         }
 
         Write-Host $roslyn4Analyzer.Line.Trim()
-        & $env:DOTNET8_PATH run --no-build
+        dotnet run --no-build
         if ($LASTEXITCODE -ne 0) {
           exit $LASTEXITCODE
         }
@@ -332,12 +317,11 @@ jobs:
     - name: 🧪 VS 2022 MSBuild buildtask-sdk-style
       run: |
         $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version '[17.0,18.0)' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
-        $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = Split-Path -Parent $env:DOTNET9_PATH
+        $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = Split-Path -Parent (Get-Command dotnet).Source
         & $msbuild "${{ runner.temp }}\integration-tests\buildtask-sdk\buildtask-sdk.slnx" /r
       shell: pwsh
     - name: 🧪 dotnet publish buildtask-sdk-style
-      run: |
-        & $env:DOTNET9_PATH publish -r win-x64
+      run: dotnet publish -r win-x64
       working-directory: ${{ runner.temp }}/integration-tests/buildtask-sdk
       shell: pwsh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,12 +233,14 @@ jobs:
     - name: ⚙️ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
       shell: pwsh
-    - name: ⚙️ Install compatibility SDKs
+    - name: ⚙️ Install .NET 8 analyzer-floor SDK
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: |
-          8.0.423
-          9.0.316
+        global-json-file: integration-tests/sdk/global.json
+    - name: ⚙️ Install .NET 9 build-task SDK
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        global-json-file: integration-tests/buildtask-sdk/global.json
     - name: 📦 Download build
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -259,21 +261,6 @@ jobs:
         $nugetConfig = "${{ runner.temp }}/integration-tests/nuget.config"
         $pkgDir = (Resolve-Path bin/Packages/Release/NuGet).Path
         (Get-Content $nugetConfig) -replace '%PIPELINE_WORKSPACE%\\deployables-Windows', $pkgDir | Set-Content $nugetConfig
-
-        @{
-          sdk = @{
-            version = "8.0.423"
-            rollForward = "patch"
-            allowPrerelease = $false
-          }
-        } | ConvertTo-Json -Depth 2 | Set-Content "${{ runner.temp }}/integration-tests/sdk/global.json"
-        @{
-          sdk = @{
-            version = "9.0.316"
-            rollForward = "patch"
-            allowPrerelease = $false
-          }
-        } | ConvertTo-Json -Depth 2 | Set-Content "${{ runner.temp }}/integration-tests/buildtask-sdk/global.json"
       shell: pwsh
     - name: 🧪 VS 2022 MSBuild non-sdk style
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
     - name: ⚙️ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
       shell: pwsh
-    - name: ⚙️ Install .NET 8 analyzer-floor SDK
+    - name: ⚙️ Install compatibility SDKs
       run: |
         $dotnet8Root = Join-Path $env:RUNNER_TEMP dotnet8
         & ./obj/tools/dotnet-install.ps1 -Version 8.0.423 -InstallDir $dotnet8Root -NoPath
@@ -241,9 +241,18 @@ jobs:
           exit $LASTEXITCODE
         }
 
+        $dotnet9Root = Join-Path $env:RUNNER_TEMP dotnet9
+        & ./obj/tools/dotnet-install.ps1 -Version 9.0.316 -InstallDir $dotnet9Root -NoPath
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
         $dotnet8Path = Join-Path $dotnet8Root dotnet.exe
+        $dotnet9Path = Join-Path $dotnet9Root dotnet.exe
         Add-Content -Path $env:GITHUB_ENV -Value "DOTNET8_PATH=$dotnet8Path"
+        Add-Content -Path $env:GITHUB_ENV -Value "DOTNET9_PATH=$dotnet9Path"
         & $dotnet8Path --version
+        & $dotnet9Path --version
       shell: pwsh
     - name: 📦 Download build
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -265,6 +274,21 @@ jobs:
         $nugetConfig = "${{ runner.temp }}/integration-tests/nuget.config"
         $pkgDir = (Resolve-Path bin/Packages/Release/NuGet).Path
         (Get-Content $nugetConfig) -replace '%PIPELINE_WORKSPACE%\\deployables-Windows', $pkgDir | Set-Content $nugetConfig
+
+        @{
+          sdk = @{
+            version = "8.0.423"
+            rollForward = "patch"
+            allowPrerelease = $false
+          }
+        } | ConvertTo-Json -Depth 2 | Set-Content "${{ runner.temp }}/integration-tests/sdk/global.json"
+        @{
+          sdk = @{
+            version = "9.0.316"
+            rollForward = "patch"
+            allowPrerelease = $false
+          }
+        } | ConvertTo-Json -Depth 2 | Set-Content "${{ runner.temp }}/integration-tests/buildtask-sdk/global.json"
       shell: pwsh
     - name: 🧪 VS 2022 MSBuild non-sdk style
       run: |
@@ -274,11 +298,9 @@ jobs:
     - name: 🧪 VS 2022 MSBuild sdk-style
       run: |
         $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version '[17.0,18.0)' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
+        $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = Split-Path -Parent $env:DOTNET8_PATH
         & $msbuild "${{ runner.temp }}\integration-tests\sdk\sdk.csproj" /r
       shell: pwsh
-    - name: 🧪 dotnet build sdk-style
-      run: dotnet build
-      working-directory: ${{ runner.temp }}/integration-tests/sdk
     - name: 🧪 dotnet build SDK 8 analyzer floor
       run: |
         $buildLog = Join-Path $env:RUNNER_TEMP sdk8-build.log
@@ -310,11 +332,14 @@ jobs:
     - name: 🧪 VS 2022 MSBuild buildtask-sdk-style
       run: |
         $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version '[17.0,18.0)' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
+        $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = Split-Path -Parent $env:DOTNET9_PATH
         & $msbuild "${{ runner.temp }}\integration-tests\buildtask-sdk\buildtask-sdk.slnx" /r
       shell: pwsh
     - name: 🧪 dotnet publish buildtask-sdk-style
-      run: dotnet publish -r win-x64
+      run: |
+        & $env:DOTNET9_PATH publish -r win-x64
       working-directory: ${{ runner.temp }}/integration-tests/buildtask-sdk
+      shell: pwsh
 
   validate:
     name: ✅ Validate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,18 @@ jobs:
     - name: ⚙️ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
       shell: pwsh
+    - name: ⚙️ Install .NET 8 analyzer-floor SDK
+      run: |
+        $dotnet8Root = Join-Path $env:RUNNER_TEMP dotnet8
+        & ./obj/tools/dotnet-install.ps1 -Version 8.0.423 -InstallDir $dotnet8Root -NoPath
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        $dotnet8Path = Join-Path $dotnet8Root dotnet.exe
+        Add-Content -Path $env:GITHUB_ENV -Value "DOTNET8_PATH=$dotnet8Path"
+        & $dotnet8Path --version
+      shell: pwsh
     - name: 📦 Download build
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -254,25 +266,50 @@ jobs:
         $pkgDir = (Resolve-Path bin/Packages/Release/NuGet).Path
         (Get-Content $nugetConfig) -replace '%PIPELINE_WORKSPACE%\\deployables-Windows', $pkgDir | Set-Content $nugetConfig
       shell: pwsh
-    - name: 🧪 MSBuild non-sdk style
+    - name: 🧪 VS 2022 MSBuild non-sdk style
       run: |
-        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
+        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version '[17.0,18.0)' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
         & $msbuild "${{ runner.temp }}\integration-tests\nonsdk\nonsdk.csproj" /r
       shell: pwsh
-    - name: 🧪 MSBuild sdk-style
+    - name: 🧪 VS 2022 MSBuild sdk-style
       run: |
-        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
+        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version '[17.0,18.0)' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
         & $msbuild "${{ runner.temp }}\integration-tests\sdk\sdk.csproj" /r
       shell: pwsh
     - name: 🧪 dotnet build sdk-style
       run: dotnet build
       working-directory: ${{ runner.temp }}/integration-tests/sdk
+    - name: 🧪 dotnet build SDK 8 analyzer floor
+      run: |
+        $buildLog = Join-Path $env:RUNNER_TEMP sdk8-build.log
+        & $env:DOTNET8_PATH build --nologo --verbosity diagnostic *> $buildLog
+        $buildExitCode = $LASTEXITCODE
+        if ($buildExitCode -ne 0) {
+          Get-Content $buildLog
+          exit $buildExitCode
+        }
+
+        $roslyn4Analyzer = Select-String `
+          -Path $buildLog `
+          -Pattern 'analyzers[\\/]+dotnet[\\/]+roslyn4\.11[\\/]+cs[\\/]+Microsoft\.Windows\.CsWin32\.dll' |
+          Select-Object -First 1
+        if (-not $roslyn4Analyzer) {
+          throw "The SDK 8 build did not select the packaged Roslyn 4.11 analyzer."
+        }
+
+        Write-Host $roslyn4Analyzer.Line.Trim()
+        & $env:DOTNET8_PATH run --no-build
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+      working-directory: ${{ runner.temp }}/integration-tests/sdk
+      shell: pwsh
     - name: 🧪 dotnet build sdk-roslyn5 (extensionReceiver)
       run: dotnet build
       working-directory: ${{ runner.temp }}/integration-tests/sdk-roslyn5
-    - name: 🧪 MSBuild buildtask-sdk-style
+    - name: 🧪 VS 2022 MSBuild buildtask-sdk-style
       run: |
-        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
+        $msbuild = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -version '[17.0,18.0)' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | Select-Object -First 1
         & $msbuild "${{ runner.temp }}\integration-tests\buildtask-sdk\buildtask-sdk.slnx" /r
       shell: pwsh
     - name: 🧪 dotnet publish buildtask-sdk-style

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       name: 📚 Generate documentation
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: docfx/_site
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,4 +40,4 @@ jobs:
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites

--- a/.github/workflows/docs_validate.yml
+++ b/.github/workflows/docs_validate.yml
@@ -13,7 +13,7 @@ jobs:
     name: 📚 Doc validation
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: 🔗 Markup Link Checker (mlc)

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 

--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -17,7 +17,7 @@
     <!--
       ANALYZER SUPPORT-ASSEMBLY VERSION BINDINGS — DO NOT BUMP HERE.
 
-      The following System.* versions are the support assemblies that get copied next to
+      The following versions are the support assemblies that get copied next to
       the analyzer (CopyLocalLockFileAssemblies=true) and shipped inside the NuGet package.
       They are intentionally pinned to the FLOOR (Roslyn 4.11 / VS 2022 Update 14 / .NET 8)
       versions because the analyzer must load inside older Visual Studio and `dotnet build`
@@ -32,6 +32,7 @@
       versions locally via <VersionOverride> in its .csproj. Keep the floor numbers here
       and add per-leg overrides there; never raise the floor to satisfy the newer leg.
     -->
+    <PackageVersion Update="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
     <PackageVersion Update="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Update="System.Memory" Version="4.5.5" />
     <PackageVersion Update="System.Reflection.Metadata" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,8 +17,8 @@
     <PackageVersion Include="MessagePack" Version="2.2.85" />
     <PackageVersion Include="MessagePackAnalyzer" Version="2.5.192" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.11.6" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="16.11.6" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.3-beta1.24352.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,8 @@
     <WDKMetadataVersion>0.13.25-experimental</WDKMetadataVersion>
     <!-- <DiaMetadataVersion>0.2.185-preview-g7e1e6a442c</DiaMetadataVersion> -->
     <ApiDocsVersion>0.1.42-alpha</ApiDocsVersion>
-    <CodeAnalysisVersion>5.0.0</CodeAnalysisVersion>
+    <!-- Tooling and test Roslyn version. Shipping analyzer legs override this independently. -->
+    <CodeAnalysisVersion>5.6.0</CodeAnalysisVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- We have to use the MessagePack version used by win32metadata (https://github.com/microsoft/CsWin32/issues/371) -->
@@ -19,6 +20,7 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(CodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.3-beta1.24352.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,7 @@
   </ItemGroup>
   <Import Project="Directory.Packages.Analyzers.props" Condition="'$(IsTestProject)'!='true' and '$(MSBuildProjectName)'!='CsWin32Generator'" />
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,7 +57,7 @@
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
-    <GlobalPackageReference Include="PolySharp" Version="1.15.0" Condition="'$(DisablePolyfill)'!='true'" />
+    <GlobalPackageReference Include="PolySharp" Version="1.16.0" Condition="'$(DisablePolyfill)'!='true'" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,7 +56,7 @@
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
     <GlobalPackageReference Include="PolySharp" Version="1.16.0" Condition="'$(DisablePolyfill)'!='true'" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Microsoft.Windows.SDK.Win32Docs" Version="$(ApiDocsVersion)" />
     <PackageVersion Include="Microsoft.Windows.SDK.Win32Metadata" Version="$(MetadataVersion)" />
     <PackageVersion Include="Microsoft.Windows.WDK.Win32Metadata" Version="$(WDKMetadataVersion)" />
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NuGet.Protocol" Version="6.13.2" />
     <PackageVersion Include="System.CommandLine" Version="2.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.Windows.WDK.Win32Metadata" Version="$(WDKMetadataVersion)" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.13.2" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.2" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.18" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,10 +16,10 @@
     <!-- We have to use the MessagePack version used by win32metadata (https://github.com/microsoft/CsWin32/issues/371) -->
     <PackageVersion Include="MessagePack" Version="2.2.85" />
     <PackageVersion Include="MessagePackAnalyzer" Version="2.5.192" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.18" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.11.6" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="16.11.6" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.3-beta1.24352.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisVersion)" />
@@ -33,11 +33,11 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.2" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.18" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.9" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.18" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.9" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.18" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="Xunit.Combinatorial" Version="2.0.24" />
     <PackageVersion Include="Xunit.Assert" Version="2.9.3" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.1.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->

--- a/azure-pipelines/unofficial.yml
+++ b/azure-pipelines/unofficial.yml
@@ -4,7 +4,7 @@ trigger:
     include:
     - main
     - microbuild
-    - renovate/dependency-updates
+    - 'renovate/*'
     - 'validate/*'
   paths:
     exclude:

--- a/azure-pipelines/unofficial.yml
+++ b/azure-pipelines/unofficial.yml
@@ -4,6 +4,7 @@ trigger:
     include:
     - main
     - microbuild
+    - renovate/dependency-updates
     - 'validate/*'
   paths:
     exclude:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.108",
+    "version": "10.0.302",
     "rollForward": "patch",
     "allowPrerelease": false
   },

--- a/integration-tests/buildtask-sdk/global.json
+++ b/integration-tests/buildtask-sdk/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.316",
+    "rollForward": "patch",
+    "allowPrerelease": false
+  }
+}

--- a/integration-tests/sdk/global.json
+++ b/integration-tests/sdk/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.423",
+    "rollForward": "patch",
+    "allowPrerelease": false
+  }
+}

--- a/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
+++ b/src/Microsoft.Windows.CsWin32/Microsoft.Windows.CsWin32.csproj
@@ -97,7 +97,7 @@
     corresponding override below rather than editing the central props.
   -->
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" VersionOverride="9.0.18" />
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.9" />
     <PackageReference Include="System.Memory" VersionOverride="4.6.3" PrivateAssets="none" />
   </ItemGroup>
 

--- a/src/Microsoft.Windows.CsWin32/PrimitiveTypeHandleInfo.cs
+++ b/src/Microsoft.Windows.CsWin32/PrimitiveTypeHandleInfo.cs
@@ -44,7 +44,7 @@ internal record PrimitiveTypeHandleInfo(PrimitiveTypeCode PrimitiveTypeCode) : T
 
     internal override bool? IsValueType(TypeSyntaxSettings inputs)
     {
-        return this.PrimitiveTypeCode is not PrimitiveTypeCode.Object or PrimitiveTypeCode.Void;
+        return this.PrimitiveTypeCode is not (PrimitiveTypeCode.Object or PrimitiveTypeCode.Void);
     }
 
     internal static TypeSyntax ToTypeSyntax(PrimitiveTypeCode typeCode, bool preferNativeInt)

--- a/test/CsWin32Generator.BuildTasks.Tests/BuildTaskTests.cs
+++ b/test/CsWin32Generator.BuildTasks.Tests/BuildTaskTests.cs
@@ -19,7 +19,7 @@ public class BuildTaskTests
     public void TestBuildTasks()
     {
         Mock<IBuildEngine> buildEngine = new();
-        buildEngine.Setup(x => x.LogErrorEvent(It.IsAny<BuildErrorEventArgs>())).Callback<BuildErrorEventArgs>(e => this.Logger.WriteLine(e.Message));
+        buildEngine.Setup(x => x.LogErrorEvent(It.IsAny<BuildErrorEventArgs>())).Callback<BuildErrorEventArgs>(e => this.Logger.WriteLine(e.Message ?? string.Empty));
 
         CsWin32CodeGeneratorTask task = new()
         {

--- a/test/CsWin32Generator.BuildTasks.Tests/CsWin32Generator.BuildTasks.Tests.csproj
+++ b/test/CsWin32Generator.BuildTasks.Tests/CsWin32Generator.BuildTasks.Tests.csproj
@@ -40,7 +40,7 @@
 
     <!-- Pull STJ version forward to 9.0.0 to avoid conflict resolution problem where the 8.0.0 assemblies conflict 
          with assembly version 8.0.0.0 on the netstandard side and 8.0.0.5 on the net472 side. -->
-    <PackageVersion Update="System.Text.Json" Version="9.0.18" />
+    <PackageVersion Update="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTestsBase.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTestsBase.cs
@@ -4,6 +4,7 @@
 #pragma warning disable SA1402
 
 using System.Collections.Immutable;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -302,9 +303,18 @@ using System.Runtime.CompilerServices;
         {
             // Load the assembly from the analyzer path
             var assembly = System.Reflection.Assembly.LoadFrom(analyzerPath);
+            Type[] assemblyTypes;
+            try
+            {
+                assemblyTypes = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                assemblyTypes = ex.Types.OfType<Type>().ToArray();
+            }
 
             // Look for types that have the [Generator] attribute
-            var generatorTypes = assembly.GetTypes()
+            var generatorTypes = assemblyTypes
                 .Where(t => t.GetCustomAttributes(typeof(GeneratorAttribute), inherit: false).Length > 0)
                 .Where(t => typeof(IIncrementalGenerator).IsAssignableFrom(t) && !t.IsAbstract)
                 .ToList();
@@ -314,7 +324,7 @@ using System.Runtime.CompilerServices;
                 generators.Add((IIncrementalGenerator?)Activator.CreateInstance(type) ?? throw new InvalidOperationException($"Could not construct {type} generator"));
             }
 
-            var analyzerTypes = assembly.GetTypes()
+            var analyzerTypes = assemblyTypes
                 .Where(t => typeof(DiagnosticAnalyzer).IsAssignableFrom(t) && !t.IsAbstract)
                 .ToList();
 


### PR DESCRIPTION
﻿## Summary

- consolidate the remaining Renovate dependency, tool, SDK, MSBuild, NuGet, test framework, and GitHub Actions updates into one compatibility-tested change
- keep the shipping analyzer legs explicitly pinned to Roslyn 4.11 and 5.0 while updating the standalone tooling/test stack to Roslyn 5.6
- add a PR-gated SDK 8.0.423 package test that selects `analyzers/dotnet/roslyn4.11`, generates and compiles code, and runs the resulting app
- pin the Visual Studio integration coverage to VS 2022 and automatically run the unofficial build for future Renovate branches

## Compatibility safeguards

Commit `80aec9ba964117085a2545467d93f487db3d57b7` restored compatibility after newer analyzer dependencies broke .NET 8 and older compiler hosts. This change preserves that boundary:

- Roslyn 4.11 analyzer: `Microsoft.CodeAnalysis` 4.11, `System.Collections.Immutable` 8, `System.Text.Json` 8, and `Microsoft.Bcl.AsyncInterfaces` 9
- Roslyn 5 analyzer: remains compiled against `Microsoft.CodeAnalysis` 5.0
- tooling/tests: move independently to Roslyn 5.6 so they match SDK 10.0.302 without raising the packaged analyzer floor

## Validation

- release build and NuGet pack with warnings as errors
- full non-hardware/non-high-memory test suite
- isolated package consumption under SDK 8.0.423, selecting the Roslyn 4.11 analyzer and running generated code
- isolated package consumption under SDK 10.0.302, selecting the Roslyn 5.0 analyzer
- build-task NativeAOT publish
- Renovate configuration validation

## Supersedes

#1712, #1752, #1753, #1754, #1755, #1756, #1757, #1758, #1759, #1760, #1761, #1762, #1763, #1764, #1765, and #1766.