### PR TITLE
Prevent major updates to compatibility SDKs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,16 @@
 		{
 			"matchFileNames": ["Directory.Packages.Analyzers.props"],
 			"enabled": false
+		},
+		{
+			"description": "Preserve the SDK major versions used for VS compatibility testing",
+			"matchManagers": ["dotnet-sdk"],
+			"matchFileNames": [
+				"integration-tests/buildtask-sdk/global.json",
+				"integration-tests/sdk/global.json"
+			],
+			"matchUpdateTypes": ["major"],
+			"enabled": false
 		}
 	]
 }


### PR DESCRIPTION
﻿## Summary

- prevent Renovate from proposing major .NET SDK updates for the SDK 8 and SDK 9 integration-test compatibility projects
- continue allowing minor and patch updates within each project's existing SDK major version
- preserve the VS 2022/MSBuild compatibility coverage that #1773 currently breaks