### PR TITLE
Update MessagePack to 2.5.301 (CVE-2026-48109, CVE-2026-48506)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- We have to use the MessagePack version used by win32metadata (https://github.com/microsoft/CsWin32/issues/371) -->
-    <PackageVersion Include="MessagePack" Version="2.2.85" />
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
     <PackageVersion Include="MessagePackAnalyzer" Version="2.5.192" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />


### PR DESCRIPTION
## Why is this change being made?

S360 flagged two high-severity Component Governance alerts against `MessagePack 2.2.85` in this repo (`/Directory.Packages.props`, branch `main`):

| CVE | Advisory | Issue |
|---|---|---|
| CVE-2026-48109 | [GHSA-hv8m-jj95-wg3x](https://github.com/MessagePack-CSharp/MessagePack-CSharp/security/advisories/GHSA-hv8m-jj95-wg3x) | Out-of-bounds read in the deprecated LZ4 fast-decompression path (`Lz4Block`/`Lz4BlockArray`) → `AccessViolationException` / possible memory disclosure |
| CVE-2026-48506 | [GHSA-vh6j-jc39-fggf](https://github.com/MessagePack-CSharp/MessagePack-CSharp/security/advisories/GHSA-vh6j-jc39-fggf) | Missing depth check in `MessagePackReader.TrySkip()` bypasses `MaximumObjectGraphDepth` → unbounded recursion / `StackOverflowException` |

Both are fixed in **2.5.301** (v2 line).

Tracked by AB#63114275 and AB#63114279.

The `<PackageVersion>` carried a comment saying we must match the MessagePack version used by win32metadata (#371). That comment is now stale in the *opposite* direction: win32metadata's `ScrapeDocs` and `Microsoft.Windows.SDK.Win32Docs` — the producers of `apidocs.msgpack` that `Docs.cs` reads — already reference **MessagePack 2.5.187**. Moving to 2.5.301 brings us back into alignment rather than out of it. (Renovate is configured to skip MessagePack updates in `.github/renovate.json`, which is why this drifted.)

## What changed?

- `Directory.Packages.props`: `MessagePack` `2.2.85` → `2.5.301`. Single-line change; the explanatory comment is left in place.

No source changes were needed. `Docs.cs` only *deserializes*, via a hand-written `IMessagePackFormatter<ApiDetails>` on top of `StandardResolver` (deliberately avoiding `DynamicObjectResolver`). Every API it uses — `MessagePackSerializerOptions.Standard.WithResolver`, `CompositeResolver.Create`, `MessagePackReader.ReadArrayHeader/ReadString/Skip`, `IFormatterResolver.GetFormatterWithVerify<T>` — is unchanged in 2.5.x, and the msgpack wire format is stable across the 2.x line.

`MessagePackAnalyzer` was already on `2.5.192`, so the library and analyzer are now on matching majors/minors.

## How was the change tested?

Packaging path reviewed for regressions: `Microsoft.Windows.CsWin32.nuspec` and `Microsoft.Windows.CsWin32.targets` copy `MessagePack.dll` and `MessagePack.Annotations.dll` into `analyzers\dotnet\roslyn5.0\cs\` by filename (no version-pinned paths), and 2.5.301 still ships exactly those two assemblies with a `netstandard2.0` target — so the analyzer package layout and the `Authenticode="3PartySHA2"` signing conditions are unaffected.

Locally, on Windows with the .NET 10.0.302 SDK:

```
dotnet build src\Microsoft.Windows.CsWin32\Microsoft.Windows.CsWin32.csproj -c Release
```
> Build succeeded. 0 Warning(s), 0 Error(s)

Confirmed the flowed assemblies:
```
MessagePack.Annotations.dll  2.5.301+5657b1e34e
MessagePack.dll              2.5.301+5657b1e34e
```

And exercised the actual deserialization of the shipped `apidocs.msgpack` (the only real compatibility risk):
```
dotnet test test\Microsoft.Windows.CsWin32.Tests\Microsoft.Windows.CsWin32.Tests.csproj -c Release --filter "FullyQualifiedName~Doc"
```
> Passed! - Failed: 0, Passed: 2, Skipped: 0

No pipelines were queued; CI on this PR will provide full coverage.

_For more information on the code review process, see the [Code Review Guidelines & Etiquette](https://aka.ms/codereviewguidelines)._
