### PR TITLE
Null-terminate PCSTR friendly overload strings

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.FriendlyOverloads.cs
@@ -989,7 +989,7 @@ public partial class Generator
                 parameters[paramIndex] = externParam
                     .WithType(PredefinedType(TokenWithSpace(SyntaxKind.StringKeyword)));
 
-                // fixed (byte* someLocal = some is object ? System.Text.Encoding.Default.GetBytes(some) : null)
+                // fixed (byte* someLocal = some is object ? System.Text.Encoding.Default.GetBytes(some + "\0") : null)
                 fixedBlocks.Add(VariableDeclaration(
                     PointerType(PredefinedType(Token(SyntaxKind.ByteKeyword))),
                     [
@@ -1003,7 +1003,12 @@ public partial class Generator
                                             SyntaxKind.SimpleMemberAccessExpression,
                                             ParseTypeName("global::System.Text.Encoding.Default"),
                                             IdentifierName(nameof(Encoding.GetBytes))),
-                                        [Argument(origName)]),
+                                        [
+                                            Argument(BinaryExpression(
+                                                SyntaxKind.AddExpression,
+                                                origName,
+                                                LiteralExpression(SyntaxKind.StringLiteralExpression, Literal("\0"))))
+                                        ]),
                                     LiteralExpression(SyntaxKind.NullLiteralExpression))))
                     ]));
 

--- a/test/GenerationSandbox.Tests/BasicTests.cs
+++ b/test/GenerationSandbox.Tests/BasicTests.cs
@@ -435,6 +435,13 @@ public class BasicTests
     }
 
     [Fact]
+    public void PCSTR_StringOverloadNullTerminates()
+    {
+        const string value = "12345678";
+        Assert.Equal(value.Length, PInvoke.lstrlen(value));
+    }
+
+    [Fact]
     public void StructCharFieldsMarshaledAsUtf16()
     {
         Assert.Equal(128 * sizeof(char), Marshal.SizeOf<__char_128>());

--- a/test/GenerationSandbox.Tests/NativeMethods.txt
+++ b/test/GenerationSandbox.Tests/NativeMethods.txt
@@ -48,6 +48,7 @@ IShellWindows
 IStream
 KEY_EVENT_RECORD
 LoadLibrary
+lstrlen
 LOWORD
 MainAVIHeader
 MAKELPARAM

--- a/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
@@ -70,43 +70,6 @@ public class FriendlyOverloadTests : GeneratorTestBase
         Assert.Equal("Span<char>", friendlyOverload.ParameterList.Parameters[1].Type?.ToString());
     }
 
-    [Fact]
-    public void PCSTR_StringOverloadMarshalsNullTerminator()
-    {
-        const string name = "GetProcAddress";
-        const string value = "test";
-        this.Generate(name);
-        MethodDeclarationSyntax externMethod = Assert.Single(this.FindGeneratedMethod(name), IsOrContainsExternMethod);
-        SyntaxToken pcstrParameter = externMethod.ParameterList.Parameters[1].Identifier;
-
-        // A pinned SZArray stores its length one native word before its first element. Checking the
-        // allocation length makes this test deterministic even when the byte after a short array is zero.
-        MethodDeclarationSyntax testMethod = externMethod
-            .WithAttributeLists([])
-            .WithModifiers(externMethod.Modifiers.Replace(
-                externMethod.Modifiers.Single(m => m.IsKind(SyntaxKind.ExternKeyword)),
-                SyntaxFactory.Token(SyntaxKind.UnsafeKeyword)))
-            .WithBody(SyntaxFactory.Block(
-                SyntaxFactory.ParseStatement($"if (*(int*)({pcstrParameter}.Value - sizeof(nint)) != {value.Length + 1} || {pcstrParameter}.Value[{value.Length}] != 0) throw new InvalidOperationException();"),
-                SyntaxFactory.ParseStatement("return default;")))
-            .WithSemicolonToken(default);
-        SyntaxTree testTree = externMethod.SyntaxTree.WithRootAndOptions(
-            externMethod.SyntaxTree.GetRoot(TestContext.Current.CancellationToken).ReplaceNode(externMethod, testMethod),
-            externMethod.SyntaxTree.Options);
-        CSharpCompilation testCompilation = this.compilation.ReplaceSyntaxTree(externMethod.SyntaxTree, testTree);
-
-        using var assemblyStream = new MemoryStream();
-        var emitResult = testCompilation.Emit(assemblyStream, cancellationToken: TestContext.Current.CancellationToken);
-        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
-        Assembly assembly = Assembly.Load(assemblyStream.ToArray());
-        MethodInfo friendlyOverload = Assert.Single(
-            assembly.GetType("Windows.Win32.PInvoke")!.GetMethods(BindingFlags.Static | BindingFlags.NonPublic),
-            m => m.Name == name && m.GetParameters() is [_, { ParameterType: { } parameterType }] && parameterType == typeof(string));
-
-        using var moduleHandle = new Microsoft.Win32.SafeHandles.SafeFileHandle(new IntPtr(1), ownsHandle: false);
-        friendlyOverload.Invoke(null, [moduleHandle, value]);
-    }
-
     [Theory]
     [InlineData("WSManGetSessionOptionAsString")] // Uses the reserved keyword 'string' as a parameter name
     [InlineData("RmRegisterResources")] // Parameter with PCWSTR* (an array of native strings)

--- a/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
@@ -71,20 +71,40 @@ public class FriendlyOverloadTests : GeneratorTestBase
     }
 
     [Fact]
-    public void PCSTR_StringOverloadIncludesNullTerminator()
+    public void PCSTR_StringOverloadMarshalsNullTerminator()
     {
         const string name = "GetProcAddress";
+        const string value = "test";
         this.Generate(name);
-        MethodDeclarationSyntax friendlyOverload = Assert.Single(
-            this.FindGeneratedMethod(name),
-            m => !IsOrContainsExternMethod(m) && m.ParameterList.Parameters.Any(p => p.Type is PredefinedTypeSyntax { Keyword.RawKind: (int)SyntaxKind.StringKeyword }));
-        InvocationExpressionSyntax getBytesInvocation = Assert.Single(
-            friendlyOverload.DescendantNodes().OfType<InvocationExpressionSyntax>(),
-            i => i.Expression is MemberAccessExpressionSyntax { Name.Identifier.ValueText: nameof(Encoding.GetBytes) });
-        ArgumentSyntax argument = Assert.Single(getBytesInvocation.ArgumentList.Arguments);
-        BinaryExpressionSyntax appendNullTerminator = Assert.IsType<BinaryExpressionSyntax>(argument.Expression);
-        Assert.True(appendNullTerminator.IsKind(SyntaxKind.AddExpression));
-        Assert.Equal("\0", Assert.IsType<LiteralExpressionSyntax>(appendNullTerminator.Right).Token.ValueText);
+        MethodDeclarationSyntax externMethod = Assert.Single(this.FindGeneratedMethod(name), IsOrContainsExternMethod);
+        SyntaxToken pcstrParameter = externMethod.ParameterList.Parameters[1].Identifier;
+
+        // A pinned SZArray stores its length one native word before its first element. Checking the
+        // allocation length makes this test deterministic even when the byte after a short array is zero.
+        MethodDeclarationSyntax testMethod = externMethod
+            .WithAttributeLists([])
+            .WithModifiers(externMethod.Modifiers.Replace(
+                externMethod.Modifiers.Single(m => m.IsKind(SyntaxKind.ExternKeyword)),
+                SyntaxFactory.Token(SyntaxKind.UnsafeKeyword)))
+            .WithBody(SyntaxFactory.Block(
+                SyntaxFactory.ParseStatement($"if (*(int*)({pcstrParameter}.Value - sizeof(nint)) != {value.Length + 1} || {pcstrParameter}.Value[{value.Length}] != 0) throw new InvalidOperationException();"),
+                SyntaxFactory.ParseStatement("return default;")))
+            .WithSemicolonToken(default);
+        SyntaxTree testTree = externMethod.SyntaxTree.WithRootAndOptions(
+            externMethod.SyntaxTree.GetRoot(TestContext.Current.CancellationToken).ReplaceNode(externMethod, testMethod),
+            externMethod.SyntaxTree.Options);
+        CSharpCompilation testCompilation = this.compilation.ReplaceSyntaxTree(externMethod.SyntaxTree, testTree);
+
+        using var assemblyStream = new MemoryStream();
+        var emitResult = testCompilation.Emit(assemblyStream, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+        Assembly assembly = Assembly.Load(assemblyStream.ToArray());
+        MethodInfo friendlyOverload = Assert.Single(
+            assembly.GetType("Windows.Win32.PInvoke")!.GetMethods(BindingFlags.Static | BindingFlags.NonPublic),
+            m => m.Name == name && m.GetParameters() is [_, { ParameterType: { } parameterType }] && parameterType == typeof(string));
+
+        using var moduleHandle = new Microsoft.Win32.SafeHandles.SafeFileHandle(new IntPtr(1), ownsHandle: false);
+        friendlyOverload.Invoke(null, [moduleHandle, value]);
     }
 
     [Theory]

--- a/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/FriendlyOverloadTests.cs
@@ -70,6 +70,23 @@ public class FriendlyOverloadTests : GeneratorTestBase
         Assert.Equal("Span<char>", friendlyOverload.ParameterList.Parameters[1].Type?.ToString());
     }
 
+    [Fact]
+    public void PCSTR_StringOverloadIncludesNullTerminator()
+    {
+        const string name = "GetProcAddress";
+        this.Generate(name);
+        MethodDeclarationSyntax friendlyOverload = Assert.Single(
+            this.FindGeneratedMethod(name),
+            m => !IsOrContainsExternMethod(m) && m.ParameterList.Parameters.Any(p => p.Type is PredefinedTypeSyntax { Keyword.RawKind: (int)SyntaxKind.StringKeyword }));
+        InvocationExpressionSyntax getBytesInvocation = Assert.Single(
+            friendlyOverload.DescendantNodes().OfType<InvocationExpressionSyntax>(),
+            i => i.Expression is MemberAccessExpressionSyntax { Name.Identifier.ValueText: nameof(Encoding.GetBytes) });
+        ArgumentSyntax argument = Assert.Single(getBytesInvocation.ArgumentList.Arguments);
+        BinaryExpressionSyntax appendNullTerminator = Assert.IsType<BinaryExpressionSyntax>(argument.Expression);
+        Assert.True(appendNullTerminator.IsKind(SyntaxKind.AddExpression));
+        Assert.Equal("\0", Assert.IsType<LiteralExpressionSyntax>(appendNullTerminator.Right).Token.ValueText);
+    }
+
     [Theory]
     [InlineData("WSManGetSessionOptionAsString")] // Uses the reserved keyword 'string' as a parameter name
     [InlineData("RmRegisterResources")] // Parameter with PCWSTR* (an array of native strings)


### PR DESCRIPTION
## Summary
- append an explicit null character before encoding managed strings for `PCSTR` friendly overloads
- add a deterministic generator regression test for `GetProcAddress`

Fixes #1775