### PR TITLE
Retry transient Renovate package restores

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NBGV_GitEngine: Disabled
   BuildConfiguration: Release
+  RestoreRetryCount: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' && 10 || 1 }}
 
 jobs:
   build:
@@ -31,7 +32,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
-      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider -RestoreRetryCount $env:RestoreRetryCount
       shell: pwsh
     - name: 🛠️ Build
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
@@ -51,7 +52,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
-      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider -RestoreRetryCount $env:RestoreRetryCount
       shell: pwsh
     - name: 📦 Download build
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -84,7 +85,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
-      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider -RestoreRetryCount $env:RestoreRetryCount
       shell: pwsh
     - name: 📦 Download build
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -120,7 +121,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
-      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider -RestoreRetryCount $env:RestoreRetryCount
       shell: pwsh
     - name: 🛠️ Build
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
@@ -188,7 +189,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: ⚙️ Install prerequisites
-      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider -RestoreRetryCount $env:RestoreRetryCount
       shell: pwsh
     - name: 📦 Download build
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -231,7 +232,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: ⚙️ Install prerequisites
-      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider -RestoreRetryCount $env:RestoreRetryCount
       shell: pwsh
     - name: ⚙️ Install .NET 8 analyzer-floor SDK
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0

--- a/.github/workflows/docs_validate.yml
+++ b/.github/workflows/docs_validate.yml
@@ -8,6 +8,9 @@ on:
     - main
     - microbuild
 
+env:
+  RestoreRetryCount: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' && 10 || 1 }}
+
 jobs:
   build:
     name: 📚 Doc validation
@@ -22,7 +25,7 @@ jobs:
         args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx -i https://aka.ms/onboardsupport,https://aka.ms/spot,https://msrc.microsoft.com/*,https://www.microsoft.com/msrc*,https://microsoft.com/msrc*,https://www.npmjs.com/package/*,https://get.dot.net/
     - name: ⚙ Install prerequisites
       run: |
-        ./init.ps1 -UpgradePrerequisites
+        ./init.ps1 -UpgradePrerequisites -RestoreRetryCount $env:RestoreRetryCount
         dotnet --info
       shell: pwsh
     - name: 📚 Verify docfx build

--- a/init.ps1
+++ b/init.ps1
@@ -47,6 +47,10 @@
     An optional access token for authenticating to Azure Artifacts authenticated feeds.
 .PARAMETER Interactive
     Runs NuGet restore in interactive mode. This can turn authentication failures into authentication challenges.
+.PARAMETER RestoreRetryCount
+    The maximum number of restore attempts when a package is not yet available from the configured feed.
+.PARAMETER RestoreRetryDelaySeconds
+    The delay between restore attempts when a package is not yet available from the configured feed.
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 Param (
@@ -75,8 +79,47 @@ Param (
     [Parameter()]
     [string]$AccessToken,
     [Parameter()]
-    [switch]$Interactive
+    [switch]$Interactive,
+    [Parameter()]
+    [ValidateRange(1, 10)]
+    [int]$RestoreRetryCount = 1,
+    [Parameter()]
+    [ValidateRange(0, 600)]
+    [int]$RestoreRetryDelaySeconds = 60
 )
+
+function Invoke-RestoreWithRetry {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Restore,
+        [Parameter(Mandatory = $true)]
+        [string]$FailureMessage
+    )
+
+    for ($attempt = 1; $attempt -le $RestoreRetryCount; $attempt++) {
+        if ($RestoreRetryCount -eq 1) {
+            & $Restore
+            $exitCode = $LASTEXITCODE
+            $restoreOutput = $null
+        } else {
+            & $Restore 2>&1 | Tee-Object -Variable restoreOutput | Out-Host
+            $exitCode = $LASTEXITCODE
+        }
+
+        if ($exitCode -eq 0) {
+            return
+        }
+
+        $feedCacheMiss = ($restoreOutput -join "`n") -match 'No local versions of package|Downloading \S+ version \S+ failed'
+        if (!$feedCacheMiss -or $attempt -eq $RestoreRetryCount) {
+            throw $FailureMessage
+        }
+
+        Write-Warning "A dependency is not available from the package feed yet. Retrying in $RestoreRetryDelaySeconds seconds (attempt $($attempt + 1) of $RestoreRetryCount)."
+        Start-Sleep -Seconds $RestoreRetryDelaySeconds
+    }
+}
 
 $EnvVars = @{}
 $PrependPath = @()
@@ -113,17 +156,17 @@ try {
 
     if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
         Write-Host "Restoring NuGet packages" -ForegroundColor $HeaderColor
-        dotnet restore @RestoreArguments
-        if ($lastexitcode -ne 0) {
-            throw "Failure while restoring packages."
-        }
+        Invoke-RestoreWithRetry -Restore {
+            $PSNativeCommandUseErrorActionPreference = $false
+            dotnet restore @RestoreArguments
+        } -FailureMessage "Failure while restoring packages."
     }
 
     if (!$NoToolRestore -and $PSCmdlet.ShouldProcess("dotnet tool", "restore")) {
-        dotnet tool restore @RestoreArguments
-        if ($lastexitcode -ne 0) {
-            throw "Failure while restoring dotnet CLI tools."
-        }
+        Invoke-RestoreWithRetry -Restore {
+            $PSNativeCommandUseErrorActionPreference = $false
+            dotnet tool restore @RestoreArguments
+        } -FailureMessage "Failure while restoring dotnet CLI tools."
     }
 
     $InstallNuGetPkgScriptPath = "$PSScriptRoot\tools\Install-NuGetPackage.ps1"


### PR DESCRIPTION
﻿## Summary

- retry package and tool restores when a Renovate PR encounters a transient package-feed cache miss
- preserve single-attempt behavior for all other callers and fail unrelated restore errors immediately
- apply the retry window to build, test, and documentation validation jobs

## Rationale

New dependency versions can appear in feed metadata before their package content is available to PR validation. A separate authenticated build may populate the configured feed shortly afterward. Waiting and retrying the recognized transient failure avoids leaving otherwise-valid Renovate PRs red until someone manually retriggers them.

## Validation

- exercised cache-miss retry and unrelated-failure behavior with synthetic restore commands
- validated PowerShell syntax and checked the diff for whitespace errors