### PR TITLE
Migrate tests to Microsoft Testing Platform v2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@
 
 * There should generally be one test project (under the `test` directory) per shipping project (under the `src` directory). Test projects are named after the project being tested with a `.Test` suffix.
 * Tests should use the Xunit testing framework.
-* Some tests are known to be unstable or require special hardware. When running tests locally, you can skip hardware-dependent tests by running `dotnet test --filter "TestCategory!=RequiresHardware"`. To also skip high-memory tests (which each consume ~4GB), add `&TestCategory!=HighMemory` to the filter.
+* Some tests are known to be unstable or require special hardware. When running tests locally, you can skip hardware-dependent tests by running `dotnet test --filter-query "/[TestCategory!=RequiresHardware]"`. To also skip high-memory tests (which each consume ~4GB), use `dotnet test --filter-query "/[(TestCategory!=RequiresHardware)&(TestCategory!=HighMemory)]"`.
 
 ## Coding style
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,12 +60,12 @@ jobs:
         path: bin/
     - name: 🧪 Run tests
       run: |
-        dotnet test --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
-          --blame-hang-timeout 600s `
-          --blame-crash `
-          --logger trx `
-          --results-directory TestResults
+        dotnet test --solution Microsoft.Windows.CsWin32.sln --no-build -c ${{ env.BuildConfiguration }} `
+          --filter-query "/[(TestCategory!=HighMemory)&(TestCategory!=RequiresHardware)]" `
+          --hangdump --hangdump-timeout 600s --hangdump-type Heap `
+          --crashdump --crashdump-type Heap `
+          --report-trx `
+          --results-directory "${{ github.workspace }}/TestResults"
       shell: pwsh
     - name: 📢 Upload test results
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -97,12 +97,12 @@ jobs:
     # them, but we exercise the real runtime code paths here rather than only on dev machines.
     - name: 🧪 Run hardware-dependent tests
       run: |
-        dotnet test --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "TestCategory=RequiresHardware" `
-          --blame-hang-timeout 600s `
-          --blame-crash `
-          --logger trx `
-          --results-directory TestResults
+        dotnet test --solution Microsoft.Windows.CsWin32.sln --no-build -c ${{ env.BuildConfiguration }} `
+          --filter-query "/[TestCategory=RequiresHardware]" `
+          --hangdump --hangdump-timeout 600s --hangdump-type Heap `
+          --crashdump --crashdump-type Heap `
+          --report-trx `
+          --results-directory "${{ github.workspace }}/TestResults"
       shell: pwsh
     - name: 📢 Upload test results
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -113,12 +113,27 @@ jobs:
         retention-days: 5
 
   test-fast-linux:
-    name: 🧪 Tests (Linux)
+    name: 🧪 Tests (Linux, SDK ${{ matrix.dotnet-sdk }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dotnet-sdk: ['10.0.400', '10.0.302']
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+    - name: ⚙️ Install .NET SDK ${{ matrix.dotnet-sdk }}
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        dotnet-version: ${{ matrix.dotnet-sdk }}
+    - name: ⚙️ Select .NET SDK ${{ matrix.dotnet-sdk }}
+      if: matrix.dotnet-sdk != '10.0.400'
+      run: |
+        $config = Get-Content global.json -Raw | ConvertFrom-Json
+        $config.sdk.version = '${{ matrix.dotnet-sdk }}'
+        $config | ConvertTo-Json -Depth 10 | Set-Content global.json
+      shell: pwsh
     - name: ⚙️ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
       shell: pwsh
@@ -129,24 +144,24 @@ jobs:
         # Only run cross-platform test projects. Windows-specific projects
         # (GenerationSandbox.*, SpellChecker, WinRTInteropTest) use Windows TFMs
         # and produce app hosts that cannot execute on Linux.
-        dotnet test test/CsWin32Generator.Tests --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
-          --blame-hang-timeout 600s `
-          --blame-crash `
-          --logger trx `
-          --results-directory TestResults
-        dotnet test test/Microsoft.Windows.CsWin32.Tests --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
-          --blame-hang-timeout 600s `
-          --blame-crash `
-          --logger trx `
-          --results-directory TestResults
+        dotnet test --project test/CsWin32Generator.Tests/CsWin32Generator.Tests.csproj --no-build -c ${{ env.BuildConfiguration }} `
+          --filter-query "/[(TestCategory!=HighMemory)&(TestCategory!=RequiresHardware)]" `
+          --hangdump --hangdump-timeout 600s --hangdump-type Heap `
+          --crashdump --crashdump-type Heap `
+          --report-trx `
+          --results-directory "${{ github.workspace }}/TestResults"
+        dotnet test --project test/Microsoft.Windows.CsWin32.Tests/Microsoft.Windows.CsWin32.Tests.csproj --no-build -c ${{ env.BuildConfiguration }} `
+          --filter-query "/[(TestCategory!=HighMemory)&(TestCategory!=RequiresHardware)]" `
+          --hangdump --hangdump-timeout 600s --hangdump-type Heap `
+          --crashdump --crashdump-type Heap `
+          --report-trx `
+          --results-directory "${{ github.workspace }}/TestResults"
       shell: pwsh
     - name: 📢 Upload test results
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
-        name: test-results-linux
+        name: test-results-linux-${{ matrix.dotnet-sdk }}
         path: TestResults/
         retention-days: 5
 
@@ -160,28 +175,28 @@ jobs:
       matrix:
         include:
           - name: FastMethods
-            filter: "TestCategory=HighMemory&TestShard=FastMethods"
+            filter: "/[(TestCategory=HighMemory)&(TestShard=FastMethods)]"
             threads: "2"
           - name: EverythingModern
-            filter: "TestCategory=HighMemory&TestShard=EverythingModern"
+            filter: "/[(TestCategory=HighMemory)&(TestShard=EverythingModern)]"
             threads: "2"
           - name: EverythingLegacy
-            filter: "TestCategory=HighMemory&TestShard=EverythingLegacy"
+            filter: "/[(TestCategory=HighMemory)&(TestShard=EverythingLegacy)]"
             threads: "2"
           - name: FullGen-Net8
-            filter: "TestCategory=HighMemory&TestShard=FullGen-Net8"
+            filter: "/[(TestCategory=HighMemory)&(TestShard=FullGen-Net8)]"
             threads: "1"
           - name: FullGen-Net9
-            filter: "TestCategory=HighMemory&TestShard=FullGen-Net9"
+            filter: "/[(TestCategory=HighMemory)&(TestShard=FullGen-Net9)]"
             threads: "1"
           - name: FullGen-Net9-Ptrs
-            filter: "TestCategory=HighMemory&TestShard=FullGen-Net9-Ptrs"
+            filter: "/[(TestCategory=HighMemory)&(TestShard=FullGen-Net9-Ptrs)]"
             threads: "1"
           - name: FullGen-Net10-PreserveSig
-            filter: "TestCategory=HighMemory&TestShard=FullGen-Net10-PreserveSig"
+            filter: "/[(TestCategory=HighMemory)&(TestShard=FullGen-Net10-PreserveSig)]"
             threads: "1"
           - name: Default
-            filter: "TestCategory=HighMemory&TestShard!=FastMethods&TestShard!=EverythingModern&TestShard!=EverythingLegacy&TestShard!=FullGen-Net8&TestShard!=FullGen-Net9&TestShard!=FullGen-Net9-Ptrs&TestShard!=FullGen-Net10-PreserveSig"
+            filter: "/[(TestCategory=HighMemory)&(TestShard!=FastMethods)&(TestShard!=EverythingModern)&(TestShard!=EverythingLegacy)&(TestShard!=FullGen-Net8)&(TestShard!=FullGen-Net9)&(TestShard!=FullGen-Net9-Ptrs)&(TestShard!=FullGen-Net10-PreserveSig)]"
             threads: "1"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -197,20 +212,18 @@ jobs:
         path: bin/
     - name: 🧪 Run heavy tests
       run: |
-        dotnet test test/Microsoft.Windows.CsWin32.Tests --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "${{ matrix.filter }}" `
-          --blame-hang-timeout 7200s `
-          --blame-crash `
-          --logger trx `
-          --results-directory TestResults `
-          -- RunConfiguration.TreatNoTestsAsError=false
-        dotnet test test/CsWin32Generator.Tests --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "${{ matrix.filter }}" `
-          --blame-hang-timeout 7200s `
-          --blame-crash `
-          --logger trx `
-          --results-directory TestResults `
-          -- RunConfiguration.TreatNoTestsAsError=false
+        dotnet test --project test/Microsoft.Windows.CsWin32.Tests/Microsoft.Windows.CsWin32.Tests.csproj --no-build -c ${{ env.BuildConfiguration }} `
+          --filter-query "${{ matrix.filter }}" `
+          --hangdump --hangdump-timeout 7200s --hangdump-type Heap `
+          --crashdump --crashdump-type Heap `
+          --report-trx `
+          --results-directory "${{ github.workspace }}/TestResults"
+        dotnet test --project test/CsWin32Generator.Tests/CsWin32Generator.Tests.csproj --no-build -c ${{ env.BuildConfiguration }} `
+          --filter-query "${{ matrix.filter }}" `
+          --hangdump --hangdump-timeout 7200s --hangdump-type Heap `
+          --crashdump --crashdump-type Heap `
+          --report-trx `
+          --results-directory "${{ github.workspace }}/TestResults"
       shell: pwsh
       env:
         XUNIT_MAX_PARALLEL_THREADS: ${{ matrix.threads }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ To pull the new version through:
    $idx.versions | Where-Object { $_ -like '<new-version>*' }
    ```
 
-After the package is on the feed, build and run the tests (`dotnet test --filter "TestCategory!=RequiresHardware"`) and fix any regressions before opening the PR.
+After the package is on the feed, build and run the tests (`dotnet test --filter-query "/[TestCategory!=RequiresHardware]"`) and fix any regressions before opening the PR.
 
 [pwsh]: https://learn.microsoft.com/powershell/scripting/install/installing-powershell
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <ApiDocsVersion>0.1.42-alpha</ApiDocsVersion>
     <!-- Tooling and test Roslyn version. Shipping analyzer legs override this independently. -->
     <CodeAnalysisVersion>5.9.0</CodeAnalysisVersion>
+    <MicrosoftTestingPlatformVersion>2.3.3</MicrosoftTestingPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- We have to use the MessagePack version used by win32metadata (https://github.com/microsoft/CsWin32/issues/371) -->
@@ -45,10 +46,12 @@
   </ItemGroup>
   <Import Project="Directory.Packages.Analyzers.props" Condition="'$(IsTestProject)'!='true' and '$(MSBuildProjectName)'!='CsWin32Generator'" />
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->

--- a/Microsoft.Windows.CsWin32.sln
+++ b/Microsoft.Windows.CsWin32.sln
@@ -28,7 +28,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{36CCE840-6
 	ProjectSection(SolutionItems) = preProject
 		test\.editorconfig = test\.editorconfig
 		test\Directory.Build.props = test\Directory.Build.props
-		test\Directory.Build.targets = test\Directory.Build.targets
 		test\GenerationSandbox.props = test\GenerationSandbox.props
 	EndProjectSection
 EndProject

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -232,7 +232,7 @@ jobs:
     - job: Linux
       pool: ${{ parameters.linuxPool }}
       variables:
-        TestFilter: "&WindowsOnly!=true"
+        TestFilter: "&(WindowsOnly!=true)"
         Platform: NonWindows
       ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
         templateContext:
@@ -273,7 +273,7 @@ jobs:
     - job: macOS
       pool: ${{ parameters.macOSPool }}
       variables:
-        TestFilter: "&WindowsOnly!=true"
+        TestFilter: "&(WindowsOnly!=true)"
         Platform: NonWindows
       ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
         templateContext:

--- a/global.json
+++ b/global.json
@@ -4,6 +4,9 @@
     "rollForward": "patch",
     "allowPrerelease": false
   },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.134",
     "Microsoft.Windows.WinmdGenerator": "0.63.31-preview"

--- a/test/CsWin32Generator.BuildTasks.Tests/CsWin32Generator.BuildTasks.Tests.csproj
+++ b/test/CsWin32Generator.BuildTasks.Tests/CsWin32Generator.BuildTasks.Tests.csproj
@@ -29,14 +29,16 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="NuGet.Protocol" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.assert" ExcludeAssets="compile" />
     <PackageReference Include="Xunit.Combinatorial" />
-    <PackageReference Include="xunit.runner.visualstudio" />
 
     <!-- Pull STJ version forward to 9.0.0 to avoid conflict resolution problem where the 8.0.0 assemblies conflict 
          with assembly version 8.0.0.0 on the netstandard side and 8.0.0.5 on the net472 side. -->

--- a/test/CsWin32Generator.BuildTasks.Tests/xunit.runner.json
+++ b/test/CsWin32Generator.BuildTasks.Tests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "shadowCopy": false
-}

--- a/test/CsWin32Generator.Tests/CsWin32Generator.Tests.csproj
+++ b/test/CsWin32Generator.Tests/CsWin32Generator.Tests.csproj
@@ -37,14 +37,16 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
     <PackageReference Include="NuGet.Protocol" />
     <!-- <PackageReference Include="Microsoft.Dia.Win32Metadata" PrivateAssets="none" /> -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.assert" ExcludeAssets="compile" />
     <PackageReference Include="Xunit.Combinatorial" />
-    <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" />
   </ItemGroup>
 

--- a/test/CsWin32Generator.Tests/xunit.runner.json
+++ b/test/CsWin32Generator.Tests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "shadowCopy": false
-}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,6 +6,9 @@
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <!-- Preserve VSTest's success behavior for intentionally empty or fully filtered modules. -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --ignore-exit-code 8</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project>
-  <ItemGroup>
-    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" Condition="Exists('xunit.runner.json')" />
-  </ItemGroup>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
-</Project>

--- a/test/GenerationSandbox.Tests/xunit.runner.json
+++ b/test/GenerationSandbox.Tests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "shadowCopy": false
-}

--- a/test/GenerationSandbox.props
+++ b/test/GenerationSandbox.props
@@ -25,9 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Windows.CsWin32.Tests/Microsoft.Windows.CsWin32.Tests.csproj
+++ b/test/Microsoft.Windows.CsWin32.Tests/Microsoft.Windows.CsWin32.Tests.csproj
@@ -40,14 +40,16 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
     <PackageReference Include="NuGet.Protocol" />
     <!-- <PackageReference Include="Microsoft.Dia.Win32Metadata" PrivateAssets="none" /> -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.assert" ExcludeAssets="compile"/>
     <PackageReference Include="Xunit.Combinatorial" />
-    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Windows.CsWin32.Tests/xunit.runner.json
+++ b/test/Microsoft.Windows.CsWin32.Tests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "shadowCopy": false
-}

--- a/tools/artifacts/coverageResults.ps1
+++ b/tools/artifacts/coverageResults.ps1
@@ -1,13 +1,18 @@
 $RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
 
-$coverageFiles = @(Get-ChildItem "$RepoRoot/test/*.cobertura.xml" -Recurse | Where {$_.FullName -notlike "*/In/*"  -and $_.FullName -notlike "*\In\*" })
+$coverageFilesUnderRoot = @(Get-ChildItem "$RepoRoot/test/*.cobertura.xml" -Recurse | Where-Object { $_.FullName -notlike "*/In/*" -and $_.FullName -notlike "*\In\*" })
+
+# MTP writes coverage files directly to the requested results directory.
+$ArtifactStagingFolder = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
+$directTestLogs = Join-Path $ArtifactStagingFolder test_logs
+$coverageFilesUnderArtifacts = if (Test-Path $directTestLogs) { @(Get-ChildItem "$directTestLogs/*.cobertura.xml" -Recurse) } else { @() }
 
 # Prepare code coverage reports for merging on another machine
 $repoRoot = $env:SYSTEM_DEFAULTWORKINGDIRECTORY
 if (!$repoRoot) { $repoRoot = $env:GITHUB_WORKSPACE }
 if ($repoRoot) {
     Write-Host "Substituting $repoRoot with `"{reporoot}`""
-    $coverageFiles |% {
+    @($coverageFilesUnderRoot + $coverageFilesUnderArtifacts) | Where-Object { $_ } | ForEach-Object {
         $content = Get-Content -LiteralPath $_ |% { $_ -Replace [regex]::Escape($repoRoot), "{reporoot}" }
         Set-Content -LiteralPath $_ -Value $content -Encoding UTF8
     }
@@ -18,8 +23,9 @@ if ($repoRoot) {
 if (!((Test-Path $RepoRoot\bin) -and (Test-Path $RepoRoot\obj))) { return }
 
 @{
+    $directTestLogs = $coverageFilesUnderArtifacts;
     $RepoRoot = (
-        $coverageFiles +
+        $coverageFilesUnderRoot +
         (Get-ChildItem "$RepoRoot\obj\*.cs" -Recurse)
     );
 }

--- a/tools/artifacts/crashDumps.ps1
+++ b/tools/artifacts/crashDumps.ps1
@@ -5,8 +5,8 @@ Param(
 $result = @{}
 
 # Crash dumps and related diagnostics are staged into $(Build.ArtifactStagingDirectory)/crashDumps
-# by tools/dotnet-test-cloud.ps1 when --blame-crash or the .NET DbgEnableMiniDump runtime
-# environment captures a dump (e.g. for OOM-killed test hosts on Linux).
+# by tools/dotnet-test-cloud.ps1 when the MTP crash/hang dump extensions or the .NET
+# DbgEnableMiniDump runtime environment captures a dump.
 $artifactStaging = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
 $dumpsPath = Join-Path $artifactStaging 'crashDumps'
 if (Test-Path $dumpsPath) {

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -45,7 +45,7 @@ if ($x86) {
 }
 
 $testBinLog = Join-Path $ArtifactStagingFolder (Join-Path build_logs test.binlog)
-$testDiagLog = Join-Path $ArtifactStagingFolder (Join-Path test_logs diag.log)
+$testLogs = Join-Path $ArtifactStagingFolder 'test_logs'
 $dumpStagingFolder = Join-Path $ArtifactStagingFolder 'crashDumps'
 
 function Write-MemorySnapshot([string]$Label) {
@@ -79,16 +79,18 @@ function Write-DmesgTail {
     }
 }
 
+# Avoid publishing stale local artifacts from an earlier invocation.
+if (Test-Path $testLogs) { Remove-Item $testLogs -Recurse -Force }
+if (Test-Path $dumpStagingFolder) { Remove-Item $dumpStagingFolder -Recurse -Force }
+
 # Enable .NET runtime crash dumps on managed unhandled exceptions / aborts.
-# These are emitted in addition to the dumps captured by `--blame-crash`,
-# and survive scenarios where blame's createdump invocation cannot fire
-# (for example, SIGKILL by the kernel OOM-killer never reaches managed code,
-# but a runtime abort / unhandled exception that precedes the kill is captured).
-New-Item -ItemType Directory -Force -Path $dumpStagingFolder | Out-Null
+# These complement the MTP crash dump extension and survive scenarios where
+# the extension cannot fire before process termination.
+New-Item -ItemType Directory -Force -Path $testLogs, $dumpStagingFolder, (Split-Path $testBinLog -Parent) | Out-Null
 # Always drop a readme so the artifact upload has at least one file to publish.
 @'
-This artifact collects test-host crash dumps captured by `dotnet test --blame-crash`
-and by the .NET runtime (DOTNET_DbgEnableMiniDump).
+This artifact collects test-host crash and hang dumps captured by Microsoft Testing
+Platform extensions and by the .NET runtime (DOTNET_DbgEnableMiniDump).
 
 If the artifact only contains this README, no managed crashes were captured. That is
 often the case when a test host is killed by the kernel (e.g. the Linux OOM-killer
@@ -101,34 +103,41 @@ $env:DOTNET_DbgMiniDumpType = '2' # 2 = Heap (managed heap + threads; smaller th
 $env:DOTNET_DbgMiniDumpName = (Join-Path $dumpStagingFolder 'coredump.%p.%t.dmp')
 $env:DOTNET_CreateDumpDiagnostics = '1'
 
-# On Linux/macOS, the heavy generator test projects each consume several GB of RAM,
-# and the default `dotnet test <slnFile>` schedules MSBuild's VSTest target for multiple
-# projects in parallel — causing the kernel OOM-killer to terminate test hosts on the
-# memory-constrained ADO agents (exit code 137 = SIGKILL). Force a single MSBuild node
-# so VSTest is invoked one project at a time. Use the solution-level invocation so that
-# the sln's `NonWindows` configuration correctly filters out Windows-only projects.
+# On Linux/macOS, the heavy generator test projects each consume several GB of RAM.
+# Serialize MTP test modules and restrain xUnit's intra-assembly parallelism to avoid
+# the kernel OOM-killer on memory-constrained agents.
 $extraTestArgs = @()
 if (-not $IsWindows -and -not $x86) {
-    Write-Host 'Non-Windows agent: forcing single MSBuild node (-m:1) to serialize test runs.' -ForegroundColor Cyan
-    $extraTestArgs += '-m:1'
-    # Also restrain xunit's intra-assembly parallelism: while it does not prevent
-    # cross-project OOM on its own, it reduces peak RSS during the heavy test runs.
+    Write-Host 'Non-Windows agent: serializing MTP test modules.' -ForegroundColor Cyan
+    $extraTestArgs += '-p:Platform=NonWindows', '--max-parallel-test-modules', '1'
     $env:XUNIT_MAX_PARALLEL_THREADS = '1'
     Write-MemorySnapshot 'Pre-test memory state'
 }
 
-& $dotnet test $RepoRoot `
-    --no-build `
-    -c $Configuration `
-    --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware$env:TESTFILTER" `
-    --collect "Code Coverage;Format=cobertura" `
-    --settings "$PSScriptRoot/test.runsettings" `
-    --blame-hang-timeout 1500s `
-    --blame-crash `
-    -bl:"$testBinLog" `
-    --diag "$testDiagLog;TraceLevel=info" `
-    --logger trx `
-    @extraTestArgs
+$filterQuery = "/[(TestCategory!=HighMemory)&(TestCategory!=RequiresHardware)$env:TESTFILTER]"
+$solutionPath = Join-Path $RepoRoot 'Microsoft.Windows.CsWin32.sln'
+$testArgs = @(
+    '--solution', $solutionPath,
+    '--no-build',
+    '-c', $Configuration,
+    "-bl:$testBinLog",
+    '--filter-query', $filterQuery,
+    '--coverage',
+    '--coverage-output-format', 'cobertura',
+    '--coverage-settings', "$PSScriptRoot/test.runsettings",
+    '--hangdump',
+    '--hangdump-timeout', '1500s',
+    '--hangdump-type', 'Heap',
+    '--crashdump',
+    '--crashdump-type', 'Heap',
+    '--diagnostic',
+    '--diagnostic-output-directory', $testLogs,
+    '--diagnostic-verbosity', 'Information',
+    '--report-trx',
+    '--results-directory', $testLogs
+) + $extraTestArgs
+
+& $dotnet test @testArgs
 
 $overallExitCode = $LASTEXITCODE
 if ($overallExitCode -ne 0) {
@@ -137,9 +146,10 @@ if ($overallExitCode -ne 0) {
     Write-DmesgTail
 }
 
-# Move any captured crash dumps (from --blame-crash or DOTNET_DbgEnableMiniDump) into
-# the dedicated staging folder so they're easy to find in the published artifact.
-Get-ChildItem -Path "$RepoRoot/test" -Recurse -File -ErrorAction SilentlyContinue |
+# Move any captured crash or hang dumps into the dedicated staging folder.
+@("$RepoRoot/test", $testLogs) |
+  Where-Object { Test-Path $_ } |
+  ForEach-Object { Get-ChildItem -Path $_ -Recurse -File -ErrorAction SilentlyContinue } |
     Where-Object { $_.Name -like '*.dmp' -or $_.Name -like 'core.*' -or $_.Name -like 'coredump.*' } |
     ForEach-Object {
         $dest = Join-Path $dumpStagingFolder $_.Name
@@ -152,9 +162,7 @@ Get-ChildItem -Path "$RepoRoot/test" -Recurse -File -ErrorAction SilentlyContinu
     }
 
 $unknownCounter = 0
-Get-ChildItem -Recurse -Path $RepoRoot\test\*.trx |% {
-  Copy-Item $_ -Destination $ArtifactStagingFolder/test_logs/
-
+Get-ChildItem -Recurse -Path $testLogs\*.trx | ForEach-Object {
   if ($PublishResults) {
     $x = [xml](Get-Content -LiteralPath $_)
     $runTitle = $null
@@ -169,10 +177,16 @@ Get-ChildItem -Recurse -Path $RepoRoot\test\*.trx |% {
       }
     }
     if (!$runTitle) {
-      $unknownCounter += 1;
-      $runTitle = "unknown$unknownCounter ($Agent$x86RunTitleSuffix)";
+      if ($_.BaseName -match '^(?<lib>.+)_(?<tfm>net[^_]+)_(?<arch>[^_]+)$') {
+        $runTitle = "$($matches.lib) ($($matches.tfm), $($matches.arch), $Agent)"
+      } else {
+        $unknownCounter += 1;
+        $runTitle = "unknown$unknownCounter ($Agent$x86RunTitleSuffix)";
+      }
     }
 
+    # Azure Pipelines uses "VSTest" as the TRX publication protocol identifier,
+    # including when Microsoft Testing Platform produced the TRX file.
     Write-Host "##vso[results.publish type=VSTest;runTitle=$runTitle;publishRunAttachments=true;resultFiles=$_;failTaskOnFailedTests=true;testRunSystem=VSTS - PTR;]"
   }
 }


### PR DESCRIPTION
﻿## Summary
- migrate test projects to xUnit 4.0.0 on explicit Microsoft Testing Platform v2
- replace VSTest filters, logging, coverage, and dump options with MTP-native equivalents
- preserve CI sharding, zero-test behavior, diagnostics, TRX publication, and cross-platform serialization
- validate the migration with both .NET SDK 10.0.400 and 10.0.302

Supersedes #1794.

## Validation
- `dotnet build Microsoft.Windows.CsWin32.sln -c Release`
- `tools/dotnet-test-cloud.ps1 -Configuration Release -PublishResults` (1,647 passed)
- all high-memory shard filters verified with MTP test discovery