### PR TITLE
Quote generator tool path in command line

### DIFF
--- a/src/Microsoft.Windows.CsWin32.BuildTasks/CsWin32CodeGeneratorTask.cs
+++ b/src/Microsoft.Windows.CsWin32.BuildTasks/CsWin32CodeGeneratorTask.cs
@@ -145,7 +145,9 @@ public class CsWin32CodeGeneratorTask : ToolTask
     /// <inheritdoc />
     protected override string GenerateCommandLineCommands()
     {
-        return this.GeneratorToolPath;
+        var commandLine = new CommandLineBuilder();
+        commandLine.AppendFileNameIfNotNull(this.GeneratorToolPath);
+        return commandLine.ToString();
     }
 
     /// <inheritdoc />

--- a/test/CsWin32Generator.BuildTasks.Tests/BuildTaskTests.cs
+++ b/test/CsWin32Generator.BuildTasks.Tests/BuildTaskTests.cs
@@ -215,6 +215,38 @@ public class BuildTaskTests
     }
 
     [Fact]
+    public void GenerateCommandLineCommands_WithSpacesInGeneratorToolPath_QuotesIt()
+    {
+        // Arrange
+        var task = CreateTaskWithMockBuildEngine();
+        SetupRequiredParameters(task);
+        task.GeneratorToolPath = @"C:\Users\User Name\.nuget\packages\microsoft.windows.cswin32\0.3.321\build\tools\CsWin32Generator.dll";
+
+        // Act
+        string commandLine = task.GetCommandLineArguments();
+        this.Logger.WriteLine($"Command line: {commandLine}");
+
+        // Assert
+        Assert.Contains(@"""C:\Users\User Name\.nuget\packages\microsoft.windows.cswin32\0.3.321\build\tools\CsWin32Generator.dll""", commandLine);
+    }
+
+    [Fact]
+    public void GenerateCommandLineCommands_WithoutSpacesInGeneratorToolPath_DoesNotQuoteIt()
+    {
+        // Arrange
+        var task = CreateTaskWithMockBuildEngine();
+        SetupRequiredParameters(task);
+
+        // Act
+        string commandLine = task.GetCommandLineArguments();
+        this.Logger.WriteLine($"Command line: {commandLine}");
+
+        // Assert
+        Assert.Contains("CsWin32Generator.dll", commandLine);
+        Assert.DoesNotContain('"', commandLine.Split(' ')[0]);
+    }
+
+    [Fact]
     public void GenerateCommandLineCommands_WithSinglePathInSemicolonDelimitedString_FormatsCorrectly()
     {
         // Arrange


### PR DESCRIPTION
Fixes MSB6006 failures when the NuGet package cache path contains spaces: dotnet split the unquoted CsWin32Generator.dll path at the first space and failed to find the application. The path is now appended via CommandLineBuilder.AppendFileNameIfNotNull, which quotes only when necessary.