### PR TITLE
Preserve coclass generic type fields for AOT

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.Com.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.Com.cs
@@ -1567,6 +1567,12 @@ public partial class Generator
                 //    return ret;
                 // }
                 TypeParameterSyntax typeParameter = TypeParameter(Identifier("T"));
+                if (this.UseAutoWinRTMarshalling)
+                {
+                    typeParameter = typeParameter.AddAttributeLists(
+                        AttributeList(DynamicallyAccessedPublicFieldsAttributeSyntax));
+                }
+
                 GenericNameSyntax genericName = GenericName("CreateInstance", [IdentifierName("T")]);
                 MethodDeclarationSyntax createInstanceMethod = MethodDeclaration(IdentifierName("T"), genericName.Identifier)
                     .AddModifiers(TokenWithSpace(SyntaxKind.PublicKeyword), TokenWithSpace(SyntaxKind.StaticKeyword))

--- a/test/GenerationSandbox.BuildTask.Tests/ComOutPtrMarshallingTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/ComOutPtrMarshallingTests.cs
@@ -254,12 +254,14 @@ public partial class ComOutPtrMarshallingTests
 
     [Fact]
     [Trait("TestCategory", "RequiresHardware")]
-    [UnconditionalSuppressMessage("AOT", "IL2072", Justification = "The test activates a known Windows coclass by CLSID.")]
     public void ClassicComRcw_RoundTripsWithOriginalIdentity()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
-        Type shellLinkType = Type.GetTypeFromCLSID(typeof(ShellLink).GUID, throwOnError: true)!;
-        object shellLink = Activator.CreateInstance(shellLinkType)!;
+        PInvoke.CoCreateInstance<object>(
+            typeof(ShellLink).GUID,
+            null,
+            CLSCTX.CLSCTX_INPROC_SERVER,
+            out object shellLink).ThrowOnFailure();
         try
         {
             Assert.True(Marshal.IsComObject(shellLink));

--- a/test/GenerationSandbox.BuildTask.Tests/ComOutPtrMarshallingTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/ComOutPtrMarshallingTests.cs
@@ -257,11 +257,16 @@ public partial class ComOutPtrMarshallingTests
     public void ClassicComRcw_RoundTripsWithOriginalIdentity()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
-        PInvoke.CoCreateInstance<object>(
-            typeof(ShellLink).GUID,
-            null,
+        Guid clsid = typeof(ShellLink).GUID;
+        Guid iid = typeof(IUnknown).GUID;
+        Marshal.ThrowExceptionForHR(CoCreateInstanceForClassicRcw(
+            in clsid,
+            0,
             CLSCTX.CLSCTX_INPROC_SERVER,
-            out object shellLink).ThrowOnFailure();
+            in iid,
+            out nint unknown));
+        object shellLink = Marshal.GetObjectForIUnknown(unknown);
+        Marshal.Release(unknown);
         try
         {
             Assert.True(Marshal.IsComObject(shellLink));
@@ -289,6 +294,15 @@ public partial class ComOutPtrMarshallingTests
             Marshal.FinalReleaseComObject(shellLink);
         }
     }
+
+    [LibraryImport("ole32.dll", EntryPoint = "CoCreateInstance")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial int CoCreateInstanceForClassicRcw(
+        in Guid rclsid,
+        nint pUnkOuter,
+        CLSCTX dwClsContext,
+        in Guid riid,
+        out nint ppv);
 
     private static IShellItem CreateShellItem()
     {

--- a/test/GenerationSandbox.BuildTask.Tests/ComOutPtrMarshallingTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/ComOutPtrMarshallingTests.cs
@@ -254,6 +254,7 @@ public partial class ComOutPtrMarshallingTests
 
     [Fact]
     [Trait("TestCategory", "RequiresHardware")]
+    [UnconditionalSuppressMessage("AOT", "IL2072", Justification = "The test activates a known Windows coclass by CLSID.")]
     public void ClassicComRcw_RoundTripsWithOriginalIdentity()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");

--- a/test/GenerationSandbox.BuildTask.Tests/ComOutPtrMarshallingTests.cs
+++ b/test/GenerationSandbox.BuildTask.Tests/ComOutPtrMarshallingTests.cs
@@ -257,16 +257,7 @@ public partial class ComOutPtrMarshallingTests
     public void ClassicComRcw_RoundTripsWithOriginalIdentity()
     {
         Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "Test calls Windows-specific APIs");
-        Guid clsid = typeof(ShellLink).GUID;
-        Guid iid = typeof(IUnknown).GUID;
-        Marshal.ThrowExceptionForHR(CoCreateInstanceForClassicRcw(
-            in clsid,
-            0,
-            CLSCTX.CLSCTX_INPROC_SERVER,
-            in iid,
-            out nint unknown));
-        object shellLink = Marshal.GetObjectForIUnknown(unknown);
-        Marshal.Release(unknown);
+        object shellLink = Activator.CreateInstance<ShellLinkComObject>();
         try
         {
             Assert.True(Marshal.IsComObject(shellLink));
@@ -294,15 +285,6 @@ public partial class ComOutPtrMarshallingTests
             Marshal.FinalReleaseComObject(shellLink);
         }
     }
-
-    [LibraryImport("ole32.dll", EntryPoint = "CoCreateInstance")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static partial int CoCreateInstanceForClassicRcw(
-        in Guid rclsid,
-        nint pUnkOuter,
-        CLSCTX dwClsContext,
-        in Guid riid,
-        out nint ppv);
 
     private static IShellItem CreateShellItem()
     {
@@ -398,6 +380,12 @@ public partial class ComOutPtrMarshallingTests
         {
             ((ComObject)rcw).FinalRelease();
         }
+    }
+
+    [ComImport]
+    [Guid("00021401-0000-0000-C000-000000000046")]
+    private class ShellLinkComObject
+    {
     }
 
     [GeneratedComClass]

--- a/test/GenerationSandbox.BuildTask.Tests/GenerationSandbox.BuildTask.Tests.csproj
+++ b/test/GenerationSandbox.BuildTask.Tests/GenerationSandbox.BuildTask.Tests.csproj
@@ -8,6 +8,8 @@
   <PropertyGroup>
     <CsWin32RunAsBuildTask>true</CsWin32RunAsBuildTask>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <IsAotCompatible Condition="'$(TargetFramework)' != 'net472'">true</IsAotCompatible>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2091</WarningsAsErrors>
   </PropertyGroup>
 
   <!-- For browsing, add the .cs files as None items -->

--- a/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
@@ -975,6 +975,23 @@ public class COMTests : GeneratorTestBase
         }
     }
 
+    [Fact]
+    public void CocreatableClass_CreateInstancePreservesGenericTypeFieldsForAot()
+    {
+        this.GenerateMarshaledComApi("ShellLink");
+
+        ClassDeclarationSyntax shellLinkType = Assert.IsType<ClassDeclarationSyntax>(
+            Assert.Single(this.FindGeneratedType("ShellLink")));
+        MethodDeclarationSyntax createInstance = Assert.Single(
+            shellLinkType.Members.OfType<MethodDeclarationSyntax>(),
+            method => method.Identifier.ValueText == "CreateInstance");
+        TypeParameterSyntax typeParameter = Assert.Single(createInstance.TypeParameterList!.Parameters);
+
+        Assert.Contains(
+            typeParameter.AttributeLists,
+            attributeList => IsAttributePresent(attributeList, "DynamicallyAccessedMembers"));
+    }
+
     [Theory]
     [InlineData(true, "net472")]
     [InlineData(true, "net8.0")]


### PR DESCRIPTION
﻿## Summary

- Propagate `DynamicallyAccessedMembers(PublicFields)` to generated coclass `CreateInstance<T>` helpers when automatic WinRT output marshalling is active.
- Enable AOT compatibility analysis in the build-task generation tests and promote `IL2091` to an error.
- Add generator regression coverage for the coclass type-parameter annotation.

This fixes Native AOT analysis failures in consumers that call generated helpers such as `ShellLink.CreateInstance<T>()`.

## Testing

- `Microsoft.Windows.CsWin32.Tests`: 827 passed
- `GenerationSandbox.BuildTask.Tests`: 8 passed on net9 and 8 passed on net10
- Release `build,pack` with warnings as errors: succeeded with 0 warnings