### PR TITLE
Make generator path quoting test cross-platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
     - name: ⚙️ Install Mono
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends mono-complete
+        sudo apt-get install -y --no-install-recommends mono-complete
     - name: 🛠️ Build
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
     - name: 🧪 Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
         )
         foreach ($testProject in $testProjects) {
           dotnet test $testProject --no-build -c ${{ env.BuildConfiguration }} `
-            --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
+            --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware&WindowsOnly!=true" `
             --blame-hang-timeout 600s `
             --blame-crash `
             --logger trx `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,10 @@ jobs:
     - name: ⚙️ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
       shell: pwsh
+    - name: ⚙️ Install Mono
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends mono-runtime
     - name: 🛠️ Build
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
     - name: 🧪 Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
     - name: ⚙️ Install Mono
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends mono-runtime
+        sudo apt-get install --no-install-recommends mono-complete
     - name: 🛠️ Build
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
     - name: 🧪 Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,21 +126,26 @@ jobs:
       run: dotnet build -t:build,pack -c ${{ env.BuildConfiguration }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904
     - name: 🧪 Run tests
       run: |
-        # Only run cross-platform test projects. Windows-specific projects
-        # (GenerationSandbox.*, SpellChecker, WinRTInteropTest) use Windows TFMs
-        # and produce app hosts that cannot execute on Linux.
-        dotnet test test/CsWin32Generator.Tests --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
-          --blame-hang-timeout 600s `
-          --blame-crash `
-          --logger trx `
-          --results-directory TestResults
-        dotnet test test/Microsoft.Windows.CsWin32.Tests --no-build -c ${{ env.BuildConfiguration }} `
-          --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
-          --blame-hang-timeout 600s `
-          --blame-crash `
-          --logger trx `
-          --results-directory TestResults
+        # Keep this list aligned with the portable projects exercised by the official Linux build.
+        # Other GenerationSandbox projects, SpellChecker, and WinRTInteropTest require Windows.
+        $testProjects = @(
+          "test/CsWin32Generator.Tests"
+          "test/CsWin32Generator.BuildTasks.Tests"
+          "test/Microsoft.Windows.CsWin32.Tests"
+          "test/GenerationSandbox.Tests"
+          "test/GenerationSandbox.Unmarshalled.Tests"
+        )
+        foreach ($testProject in $testProjects) {
+          dotnet test $testProject --no-build -c ${{ env.BuildConfiguration }} `
+            --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" `
+            --blame-hang-timeout 600s `
+            --blame-crash `
+            --logger trx `
+            --results-directory TestResults
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+        }
       shell: pwsh
     - name: 📢 Upload test results
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/test/CsWin32Generator.BuildTasks.Tests/BuildTaskTests.cs
+++ b/test/CsWin32Generator.BuildTasks.Tests/BuildTaskTests.cs
@@ -220,14 +220,24 @@ public class BuildTaskTests
         // Arrange
         var task = CreateTaskWithMockBuildEngine();
         SetupRequiredParameters(task);
-        task.GeneratorToolPath = @"C:\Users\User Name\.nuget\packages\microsoft.windows.cswin32\0.3.321\build\tools\CsWin32Generator.dll";
+        string generatorToolPath = Path.Combine(
+            "Users",
+            "User Name",
+            ".nuget",
+            "packages",
+            "microsoft.windows.cswin32",
+            "0.3.321",
+            "build",
+            "tools",
+            "CsWin32Generator.dll");
+        task.GeneratorToolPath = generatorToolPath;
 
         // Act
         string commandLine = task.GetCommandLineArguments();
         this.Logger.WriteLine($"Command line: {commandLine}");
 
         // Assert
-        Assert.Contains(@"""C:\Users\User Name\.nuget\packages\microsoft.windows.cswin32\0.3.321\build\tools\CsWin32Generator.dll""", commandLine);
+        Assert.StartsWith($"\"{generatorToolPath}\"", commandLine);
     }
 
     [Fact]


### PR DESCRIPTION
﻿## Summary
- make the generator tool-path quoting test use platform-native separators
- preserve coverage that paths containing spaces are quoted
- run every portable test project in the GitHub Linux PR job, matching the official Linux build

## Validation
- `dotnet test test\CsWin32Generator.BuildTasks.Tests -c Release --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" --no-build`
- `dotnet test test\GenerationSandbox.Tests -c Release --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" --no-build`
- `dotnet test test\GenerationSandbox.Unmarshalled.Tests -c Release --filter "TestCategory!=HighMemory&TestCategory!=RequiresHardware" --no-build`

Fixes the Linux failure in official build `15191331` for version `0.3.332` and closes the PR-validation coverage gap that allowed it through.