### PR TITLE
Fix GitHub release service connection

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -53,6 +53,7 @@ extends:
       - job: github
         displayName: 📢 GitHub release
         dependsOn: nuget
+        condition: succeededOrFailed()
         pool:
           name: AzurePipelines-EO
           demands:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -53,7 +53,6 @@ extends:
       - job: github
         displayName: 📢 GitHub release
         dependsOn: nuget
-        condition: succeededOrFailed()
         pool:
           name: AzurePipelines-EO
           demands:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -79,7 +79,7 @@ extends:
         - task: GitHubRelease@1
           displayName: 📢 GitHub release (create)
           inputs:
-            gitHubConnection: AArnott
+            gitHubConnection: github.com_jevansaks
             repositoryName: $(Build.Repository.Name)
             target: $(resources.pipeline.CI.sourceCommit)
             tagSource: userSpecifiedTag


### PR DESCRIPTION
﻿## Summary
- switch the release pipeline from the stale `AArnott` GitHub connection to `github.com_jevansaks`
- restore GitHub draft release creation

## Diagnosis
The last three release runs failed in `GitHubRelease@1` while creating the release with `Error: Not Found`. The target commits existed, and the connection could read public release and commit data, but it could not create releases.

A diagnostic run using `github.com_jevansaks` successfully created the `v0.3.333` draft release. The diagnostic pipeline's overall result is failed only because NuGet correctly rejected republishing the already-existing `0.3.333` package.

Diagnostic build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=15202077
Draft release: https://github.com/microsoft/CsWin32/releases/tag/untagged-ba220eb6b8235989a129

`github.com_jevansaks` is also OAuth-based. This fixes the immediate failure, but the service connection should eventually be migrated to the Azure Pipelines GitHub App for improved reliability.