### PR TITLE
Honor configured visibility for IVTable

### DIFF
--- a/src/Microsoft.Windows.CsWin32/Generator.cs
+++ b/src/Microsoft.Windows.CsWin32/Generator.cs
@@ -970,12 +970,12 @@ public partial class Generator : IGenerator, IDisposable
             {
                 if (!this.IsTypeAlreadyFullyDeclared($"{this.Namespace}.{IVTableInterface.Identifier.ValueText}"))
                 {
-                    this.volatileCode.GenerateSpecialType("IVTable", () => this.volatileCode.AddSpecialType("IVTable", IVTableInterface));
+                    this.volatileCode.GenerateSpecialType("IVTable", () => this.volatileCode.AddSpecialType("IVTable", this.ElevateVisibility(IVTableInterface)));
                 }
 
                 if (!this.IsTypeAlreadyFullyDeclared($"{this.Namespace}.{IVTableGenericInterface.Identifier.ValueText}`2"))
                 {
-                    this.volatileCode.GenerateSpecialType("IVTable`2", () => this.volatileCode.AddSpecialType("IVTable`2", IVTableGenericInterface));
+                    this.volatileCode.GenerateSpecialType("IVTable`2", () => this.volatileCode.AddSpecialType("IVTable`2", this.ElevateVisibility(IVTableGenericInterface)));
                 }
 
                 if (!this.TryGenerate("IUnknown", default))

--- a/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
+++ b/test/CsWin32Generator.Tests/CsWin32GeneratorTests.cs
@@ -18,6 +18,22 @@ public partial class CsWin32GeneratorTests : CsWin32GeneratorTestsBase
     }
 
     [Fact]
+    public async Task IVTableRespectsPublicVisibilityFromNativeMethodsJson()
+    {
+        this.compilation = this.starterCompilations["net10.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(LanguageVersion.CSharp14);
+        this.tfm = "net10.0";
+        this.nativeMethodsJson = "NativeMethods.Public.json";
+        this.nativeMethods.Add("ITypeInfo");
+
+        await this.InvokeGeneratorAndCompileFromFact();
+
+        InterfaceDeclarationSyntax[] ivtableInterfaces = this.FindGeneratedType("IVTable").OfType<InterfaceDeclarationSyntax>().ToArray();
+        Assert.Equal(2, ivtableInterfaces.Length);
+        Assert.All(ivtableInterfaces, declaration => Assert.Contains(declaration.Modifiers, modifier => modifier.IsKind(SyntaxKind.PublicKeyword)));
+    }
+
+    [Fact]
     public async Task FlattenedAnonymousAccessorsCompileWithComSourceGenerators()
     {
         // Regression: the CLI/source-generator path defaults UseComSourceGenerators=true, which can type an

--- a/test/CsWin32Generator.Tests/TestContent/NativeMethods.Public.json
+++ b/test/CsWin32Generator.Tests/TestContent/NativeMethods.Public.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "..\\..\\..\\src\\Microsoft.Windows.CsWin32\\settings.schema.json",
+  "allowMarshaling": false,
+  "public": true
+}

--- a/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
+++ b/test/Microsoft.Windows.CsWin32.Tests/COMTests.cs
@@ -1185,6 +1185,57 @@ public class COMTests : GeneratorTestBase
                     && System.Text.RegularExpressions.Regex.IsMatch(text, $@"#pragma warning disable[^\r\n]*\b{warningId}\b"));
     }
 
+    [Theory, PairwiseData]
+    public void IVTableRespectsConfiguredVisibility(bool publicVisibility)
+    {
+        this.compilation = this.starterCompilations["net10.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(GetLanguageVersionForTfm("net10.0") ?? LanguageVersion.Latest);
+        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions with { AllowMarshaling = false, Public = publicVisibility });
+
+        Assert.True(this.generator.TryGenerate("ITypeInfo", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+
+        BaseTypeDeclarationSyntax[] ivtableInterfaces = this.FindGeneratedType("IVTable").ToArray();
+        Assert.Equal(2, ivtableInterfaces.Length);
+        SyntaxKind expectedVisibility = publicVisibility ? SyntaxKind.PublicKeyword : SyntaxKind.InternalKeyword;
+        Assert.All(ivtableInterfaces, declaration => Assert.Contains(declaration.Modifiers, modifier => modifier.IsKind(expectedVisibility)));
+        this.AssertNoDiagnostics();
+    }
+
+    [Theory, PairwiseData]
+    public void IVTableHonorsExistingTypeVisibility(bool existingTypeIsVisible)
+    {
+        this.compilation = this.starterCompilations["net10.0"];
+        this.parseOptions = this.parseOptions.WithLanguageVersion(GetLanguageVersionForTfm("net10.0") ?? LanguageVersion.Latest);
+        string visibility = existingTypeIsVisible ? "public" : "internal";
+        CSharpCompilation referencedProject = this.AddCode(
+            $$"""
+                namespace Windows.Win32
+                {
+                    {{visibility}} unsafe interface IVTable
+                    {
+                    }
+
+                    {{visibility}} unsafe interface IVTable<TComInterface, TVTable> : IVTable
+                        where TComInterface : unmanaged, IVTable<TComInterface, TVTable>
+                        where TVTable : unmanaged
+                    {
+                        static abstract void PopulateVTable(TVTable* vtable);
+                    }
+                }
+                """,
+            compilation: this.compilation.WithAssemblyName("IVTableReference"));
+        this.AssertNoDiagnostics(referencedProject, acceptable: diagnostic => diagnostic.Id == "CS1591");
+
+        this.compilation = this.compilation.AddReferences(referencedProject.ToMetadataReference());
+        this.generator = this.CreateGenerator(DefaultTestGeneratorOptions with { AllowMarshaling = false, Public = true });
+        Assert.True(this.generator.TryGenerate("ITypeInfo", CancellationToken.None));
+        this.CollectGeneratedCode(this.generator);
+
+        Assert.Equal(existingTypeIsVisible ? 0 : 2, this.FindGeneratedType("IVTable").Count());
+        this.AssertNoDiagnostics();
+    }
+
     /// <summary>
     /// Regression for the dotnet/winforms#14639 scenario behind <see href="https://github.com/microsoft/CsWin32/issues/1703">issue 1703</see>:
     /// a consumer adds a friendly-helper <c>partial</c> to a generated CCW-bearing COM struct (extremely common) and the


### PR DESCRIPTION
## Summary

- apply the standard template visibility promotion when emitting both `IVTable` interfaces
- preserve accessibility-aware existing-type checks so visible definitions are reused and inaccessible definitions are generated locally
- add direct generator coverage and an end-to-end `NativeMethods.json` regression for public visibility

## Testing

- `COMTests` (128 passed)
- focused `IVTable` tests (4 passed)
- `IVTableRespectsPublicVisibilityFromNativeMethodsJson` (1 passed)